### PR TITLE
Some clean up for consideration

### DIFF
--- a/org-gtd.el
+++ b/org-gtd.el
@@ -25,9 +25,9 @@
 ;;; Commentary:
 
 ;; This package tries to replicate as closely as possible the GTD workflow.
-;; This package, and this readme, assume familiarity with GTD. There are many
-;; resources out there to learn how to use the framework. If you are new to GTD,
-;; this package may be unpleasant to use.
+;; This package, and this readme, assume familiarity with GTD.  There are many
+;; resources out there to learn how to use the framework.  If you are new to
+;; GTD, this package may be unpleasant to use.
 ;;
 ;; Assuming the keybindings below are used, here is how you could use org-gtd:
 ;; GTD uses one basic axiom: everything that comes your way goes into the inbox.
@@ -37,18 +37,18 @@
 ;; When you process the inbox, you will see each inbox item, one at a time,
 ;; with an interface letting you decide what to do with the item:
 ;;
-;; - *Quick Action* :: You've taken care of this action just now. Choose this to mark the item as DONΕ and archive it.
-;; - *Throw out* :: This is not actionable and it's not knowledge for later. Choose this to mark the item as CANCELED and archive it.
-;; - *Project* :: This is a multi-step action. I'll describe how to handle these below.
-;; - *Calendar* :: This is a single item to be done at a given date or time. You'll be presented with org-mode's date picker, then it'll refile the item. You'll find this in the agenda later.
-;; - *Delegate* :: Let someone else do this. Write the name of the person doing it, and choose a time to check up on that item.
-;; - *Single action* :: This is a one-off to be done when possible. You can add tags to help you.
-;; - *Reference* :: This is knowledge to be stored away. I'll describe how to handle these below.
+;; - *Quick Action* :: You've taken care of this action just now.  Choose this to mark the item as DONΕ and archive it.
+;; - *Throw out* :: This is not actionable and it's not knowledge for later.  Choose this to mark the item as CANCELED and archive it.
+;; - *Project* :: This is a multi-step action.  I'll describe how to handle these below.
+;; - *Calendar* :: This is a single item to be done at a given date or time.  You'll be presented with org-mode's date picker, then it'll refile the item.  You'll find this in the agenda later.
+;; - *Delegate* :: Let someone else do this.  Write the name of the person doing it, and choose a time to check up on that item.
+;; - *Single action* :: This is a one-off to be done when possible.  You can add tags to help you.
+;; - *Reference* :: This is knowledge to be stored away.  I'll describe how to handle these below.
 ;; - *Incubate* :: no action now, review later
 ;;
 ;; When processing each item you'll get a chance to add tags and other such
-;; metadata. This package will add keywords (e.g. NEXT, TODO, DONE) for you,
-;; so don't worry about them. Do the work that only you can do, and let this
+;; metadata.  This package will add keywords (e.g. NEXT, TODO, DONE) for you,
+;; so don't worry about them.  Do the work that only you can do, and let this
 ;; package handle the bookkeeping.
 ;;
 ;; A "project" is defined as an org heading with a set of children headings.
@@ -61,7 +61,7 @@
 ;; One of the ways to see what's next for you to do is to see all the next
 ;; actions ( ~C-c d n~ ).
 ;;
-;; Sometimes things break. Use ~C-c d s~ to find all projects that don't have a
+;; Sometimes things break.  Use ~C-c d s~ to find all projects that don't have a
 ;; NEXT item, which is to say, all projects that the package will not surface
 ;; and help you finish.
 ;;
@@ -171,7 +171,7 @@ This is the inbox. Everything goes in here when you capture it.
 
 (defconst org-gtd-incubate-template
   "#+begin_comment
-Here go the things you want to think about someday. Review this file as often
+Here go the things you want to think about someday.  Review this file as often
 as you feel the need: every two months? Every six months? Every year?
 It's suggested that you categorize the items in here somehow, such as:
 \"to read\", \"to buy\", \"to eat\", etc - whatever works best for your mind!
@@ -284,7 +284,7 @@ It's suggested that you categorize the items in here somehow, such as:
   (org-refile nil nil (org-gtd--refile-target org-gtd-incubate)))
 
 (defun org-gtd--archive ()
-  "Process element - completely user-defined action. Store this as a reference.
+  "Process element - completely user-defined action.  Store this as a reference.
 
 Do not remove the item from the inbox, it will be archived."
   (org-gtd--edit-item)
@@ -347,7 +347,7 @@ Do not remove the item from the inbox, it will be archived."
 (defun org-gtd--refile-target (heading-regexp)
   "Refile to one of the `org-gtd' refile locations.
 
-HEADING-REGEXP is a regular expression. See `org-refile'."
+HEADING-REGEXP is a regular expression.  See `org-refile'."
   (let* ((user-refile-targets org-refile-targets)
          (org-refile-targets (org-gtd--refile-targets))
          (results   (cl-find-if

--- a/org-gtd.el
+++ b/org-gtd.el
@@ -53,7 +53,7 @@
 ;;
 ;; A "project" is defined as an org heading with a set of children headings.
 ;;
-;; When you are processing the inbox and creating a project, emacs enters a
+;; When you are processing the inbox and creating a project, Emacs enters a
 ;; recursive edit mode to let you define and refine the project.
 ;; When finished, press ~C-c C-c~ to exit the recursive edit and go back to
 ;; processing the inbox.
@@ -89,7 +89,7 @@
 ;;                                  entry (file ,(org-gtd--path org-gtd-inbox-file-basename))
 ;;                                  "* %?\n%U\n\n  %i"
 ;;                                  :kill-buffer t)
-;;                                 ("l" "GTD item with link to where you are in emacs now"
+;;                                 ("l" "GTD item with link to where you are in Emacs now"
 ;;                                  entry (file ,(org-gtd--path org-gtd-inbox-file-basename))
 ;;                                  "* %?\n%U\n\n  %i\n  %a"
 ;;                                  :kill-buffer t)))

--- a/org-gtd.el
+++ b/org-gtd.el
@@ -4,23 +4,23 @@
 
 ;; Author: Aldric Giacomoni <trevoke@gmail.com>
 ;; Version: 0.2
-;; URL: https://github.com/trevoke/org-gtd
+;; Homepage: https://github.com/Trevoke/org-gtd.el
 ;; Package-Requires: ((emacs "26.1") (org-edna "1.0.2") (f "0.20.0") (org "9.3.1") (org-agenda-property "1.3.1"))
 
-;; This file is NOT part of GNU Emacs.
+;; This file is not part of GNU Emacs.
 
-;; GNU Emacs is free software: you can redistribute it and/or modify
+;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation, either version 3 of the License, or
-;; (at your option) any later version.
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
 
-;; GNU Emacs is distributed in the hope that it will be useful,
+;; This file is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
 
 ;; You should have received a copy of the GNU General Public License
-;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 

--- a/org-gtd.el
+++ b/org-gtd.el
@@ -174,7 +174,7 @@ This is the inbox. Everything goes in here when you capture it.
 Here go the things you want to think about someday.  Review this file as often
 as you feel the need: every two months? Every six months? Every year?
 It's suggested that you categorize the items in here somehow, such as:
-\"to read\", \"to buy\", \"to eat\", etc - whatever works best for your mind!
+\"to read\", \"to buy\", \"to eat\", etc. - whatever works best for your mind!
 #+end_comment
 ")
 
@@ -191,7 +191,7 @@ It's suggested that you categorize the items in here somehow, such as:
   :type 'directory)
 
 (defun org-gtd-capture ()
-  "Wrap `org-capture' to make sure the gtd inbox exists."
+  "Wrap `org-capture' to make sure the GTD inbox exists."
   (interactive)
   (kill-buffer (org-gtd--inbox-file))
   (org-capture))
@@ -386,7 +386,7 @@ HEADING-REGEXP is a regular expression.  See `org-refile'."
   "Return buffer position for start of org ELEMENT."
   (org-element-property :begin element))
 
-;;; file management
+;;; File management
 
 (defun org-gtd--path (file)
   "Return the full path to FILE.org assuming it is in the GTD framework."
@@ -395,7 +395,7 @@ HEADING-REGEXP is a regular expression.  See `org-refile'."
 (defun org-gtd--gtd-file (gtd-type)
   "Return a buffer for GTD-TYPE.org.
 
-create the file and template first if it doesn't already exist."
+Create the file and template first if it doesn't already exist."
   (let* ((file-path (org-gtd--path gtd-type))
          (file-buffer (find-file-noselect file-path)))
     (or (f-file-p file-path)


### PR DESCRIPTION
Feel free to cherry pick the commits you are happy to accept. If you accept all these changes I can squash them into a single commit.

I would have made further changes to remove overly long lines but I wanted to first check with you what your preference is and know what you typically set `fill-column` to - maybe define it via `.dir-locals.el`. Most of these overly long lines are within the commentary section which seems to repeat the information provided in the README. Is that intentional?

In any case, happy to have found this package. I hope it can become the standard GTD implementation in Org mode.