### PR TITLE
fix org-agenda-custom-commands in example

### DIFF
--- a/README.org
+++ b/README.org
@@ -124,7 +124,7 @@ For your convenience, here's a commented elisp code block, assuming you are usin
     ;; otherwise push the directory to the existing list
     (org-agenda-files `(,org-gtd-directory))
     ;; a useful view to see what can be accomplished today
-    (org-agenda-custom-commands '(("g" "Scheduled today and all NEXT items" ((agenda "" ((org-agenda-span 1))) (todo "NEXT"))))))
+    (setq org-agenda-custom-commands '(("g" "Scheduled today and all NEXT items" ((agenda "" ((org-agenda-span 1))) (todo "NEXT"))))))
 
     (use-package org-capture
       :ensure nil


### PR DESCRIPTION
it fixes
```
Error (use-package): org-agenda/:config: Symbol’s function definition is void: org-agenda-custom-commands
```