### PR TITLE
Simplify capture template management

### DIFF
--- a/org-gtd-capture.el
+++ b/org-gtd-capture.el
@@ -37,7 +37,6 @@ Wraps the function `org-capture' to ensure the inbox exists.
 For GOTO and KEYS, see `org-capture' documentation for the variables of the same name."
   (interactive)
   (with-org-gtd-context
-      (org-gtd--ensure-inbox)
       (org-capture goto keys)))
 
 (provide 'org-gtd-capture)

--- a/org-gtd-capture.el
+++ b/org-gtd-capture.el
@@ -37,7 +37,7 @@ Wraps the function `org-capture' to ensure the inbox exists.
 For GOTO and KEYS, see `org-capture' documentation for the variables of the same name."
   (interactive)
   (with-org-gtd-context
-      (org-gtd--inbox-file)
+      (org-gtd--ensure-inbox)
       (org-capture goto keys)))
 
 (provide 'org-gtd-capture)

--- a/org-gtd-core.el
+++ b/org-gtd-core.el
@@ -60,10 +60,7 @@ This is a list of four items, the same type as in `org-stuck-projects'.")
   (declare (debug t) (indent 2))
   `(let* ((org-use-property-inheritance "ORG_GTD")
           (org-archive-location (funcall org-gtd-archive-location))
-          (org-capture-templates (seq-concatenate
-                                  'list
-                                  (org-gtd--capture-templates)
-                                  org-capture-templates))
+          (org-capture-templates org-gtd-capture-templates)
           (org-refile-use-outline-path nil)
           (org-stuck-projects org-gtd-stuck-projects)
           (org-odd-levels-only nil)
@@ -72,27 +69,6 @@ This is a list of four items, the same type as in `org-stuck-projects'.")
           (org-agenda-custom-commands org-gtd-agenda-custom-commands))
      (unwind-protect
          (progn ,@body))))
-
-;; move this here to make a clear load path to make straight.el happy
-;; it was originally in org-gtd-capture.el
-(defun org-gtd--capture-templates ()
-  "Private function.
-
-Return valid `org-capture' templates based on `org-gtd-capture-templates'."
-  (mapcar #'org-gtd--gen-capture-templates
-          org-gtd-capture-templates))
-
-;; move this here to make a clear load path to make straight.el happy
-;; it was originally in org-gtd-capture.el
-(defun org-gtd--gen-capture-templates (template)
-  "Private function.
-
-Given an `org-capture-template' TEMPLATE string, generate a valid
-`org-gtd-capture' item."
-  (cl-destructuring-bind (key description template-string) template
-    `(,key ,description entry
-           (file (lambda () (org-gtd-inbox-path)))
-                 ,template-string :kill-buffer t)))
 
 (provide 'org-gtd-core)
 ;;; org-gtd-core.el ends here

--- a/org-gtd-customize.el
+++ b/org-gtd-customize.el
@@ -76,14 +76,17 @@ into a datetree."
   :package-version '(org-gtd . "2.0.0"))
 
 (defcustom org-gtd-capture-templates
-  '(("i" "Inbox" "* %?\n%U\n\n  %i")
-    ("l" "Inbox with link" "* %?\n%U\n\n  %i\n  %a"))
+  '(("i" "Inbox"
+        entry (file #'org-gtd-inbox-path)
+        "* %?\n%U\n\n  %i"
+        :kill-buffer t)
+    ("l" "Inbox with link"
+        entry (file #'org-gtd-inbox-path)
+        "* %?\n%U\n\n  %i\n  %a"
+        :kill-buffer t))
   "Capture templates to be used when adding something to the inbox.
 
-This is a list of lists.  Each list is composed of three elements:
-
-\(KEYS DESCRIPTION TEMPLATE)
-see `org-capture-templates' for the definition of each of those items.
+See `org-capture-templates' for the format of each capture template.
 Make the sure the template string starts with a single asterisk to denote a
 top level heading, or the behavior of org-gtd will be undefined."
   :group 'org-gtd

--- a/org-gtd-customize.el
+++ b/org-gtd-customize.el
@@ -76,12 +76,12 @@ into a datetree."
   :package-version '(org-gtd . "2.0.0"))
 
 (defcustom org-gtd-capture-templates
-  '(("i" "Inbox"
-        entry (file #'org-gtd-inbox-path)
+  `(("i" "Inbox"
+        entry  (file ,#'org-gtd-inbox-path)
         "* %?\n%U\n\n  %i"
         :kill-buffer t)
     ("l" "Inbox with link"
-        entry (file #'org-gtd-inbox-path)
+        entry (file ,#'org-gtd-inbox-path)
         "* %?\n%U\n\n  %i\n  %a"
         :kill-buffer t))
   "Capture templates to be used when adding something to the inbox.

--- a/org-gtd-files.el
+++ b/org-gtd-files.el
@@ -25,6 +25,7 @@
 ;;; Code:
 
 (require 'f)
+(require 'org-gtd-core)
 
 (defconst org-gtd-inbox-template
   "#+STARTUP: overview hidestars logrefile indent logdone

--- a/org-gtd-files.el
+++ b/org-gtd-files.el
@@ -50,25 +50,30 @@ This is the inbox. Everything goes in here when you capture it.
 
 (defun org-gtd--inbox-file ()
   "Create or return the buffer to the GTD inbox file."
-  (let ((file-path (org-gtd--path org-gtd-inbox)))
-    (if (f-file-p file-path)
-        (find-file-noselect file-path)
-      (with-current-buffer (find-file-noselect file-path)
-        (insert org-gtd-inbox-template)
-        (org-mode-restart)
-        (basic-save-buffer)
-        (current-buffer)))))
+  (find-file-noselect (org-gtd--ensure-inbox)))
+
+(defun org-gtd--ensure-inbox ()
+  "Ensure GTD inbox file exists, and return its full path."
+  (org-gtd--ensure-path (org-gtd--path org-gtd-inbox)
+                        org-gtd-inbox-template))
 
 (defun org-gtd--default-file ()
   "Create or return the buffer to the default GTD file."
-  (let ((file-path (org-gtd--path org-gtd-default-file-name)))
-    (if (f-file-p file-path)
-        (find-file-noselect file-path)
-      (with-current-buffer (find-file-noselect file-path)
-        (insert org-gtd-file-header)
-        (org-mode-restart)
-        (basic-save-buffer)
-        (current-buffer)))))
+  (find-file-noselect (org-gtd--ensure-default)))
+
+(defun org-gtd--ensure-default ()
+  "Ensure default GTD file exists, and return its path."
+  (org-gtd--ensure-path (org-gtd--path org-gtd-default-file-name)
+                        org-gtd-file-header))
+
+(defun org-gtd--ensure-path (path initial-contents)
+  "Return PATH, creating the file with INITIAL-CONTENTS if necessary."
+  (unless (f-exists-p path)
+    (with-current-buffer (find-file-noselect path)
+      (insert initial-contents)
+      (org-mode-restart)
+      (basic-save-buffer)))
+  path)
 
 (defun org-gtd--path (file)
   "Return the full path to FILE.org.

--- a/org-gtd-files.el
+++ b/org-gtd-files.el
@@ -44,9 +44,8 @@ This is the inbox. Everything goes in here when you capture it.
 (defconst org-gtd-default-file-name "org-gtd-tasks")
 
 ;;;###autoload
-(defun org-gtd-inbox-path ()
-  "Return the full path to the inbox file."
-  (org-gtd--path org-gtd-inbox))
+(defalias 'org-gtd-inbox-path 'org-gtd--ensure-inbox
+    "Return the full path to the inbox file.")
 
 (defun org-gtd--inbox-file ()
   "Create or return the buffer to the GTD inbox file."

--- a/org-gtd-files.el
+++ b/org-gtd-files.el
@@ -45,35 +45,29 @@ This is the inbox. Everything goes in here when you capture it.
 (defconst org-gtd-default-file-name "org-gtd-tasks")
 
 ;;;###autoload
-(defalias 'org-gtd-inbox-path 'org-gtd--ensure-inbox
-    "Return the full path to the inbox file.")
+(defun org-gtd-inbox-path ()
+  "Return the full path to the inbox file."
+  (let ((path (org-gtd--path org-gtd-inbox)))
+    (org-gtd--ensure-file-exists path org-gtd-inbox-template)
+    path))
 
 (defun org-gtd--inbox-file ()
   "Create or return the buffer to the GTD inbox file."
-  (find-file-noselect (org-gtd--ensure-inbox)))
-
-(defun org-gtd--ensure-inbox ()
-  "Ensure GTD inbox file exists, and return its full path."
-  (org-gtd--ensure-path (org-gtd--path org-gtd-inbox)
-                        org-gtd-inbox-template))
+  (find-file-noselect (org-gtd-inbox-path)))
 
 (defun org-gtd--default-file ()
   "Create or return the buffer to the default GTD file."
-  (find-file-noselect (org-gtd--ensure-default)))
+  (let ((path (org-gtd--path org-gtd-default-file-name)))
+    (org-gtd--ensure-file-exists path org-gtd-file-header)
+    (find-file-noselect path)))
 
-(defun org-gtd--ensure-default ()
-  "Ensure default GTD file exists, and return its path."
-  (org-gtd--ensure-path (org-gtd--path org-gtd-default-file-name)
-                        org-gtd-file-header))
-
-(defun org-gtd--ensure-path (path initial-contents)
-  "Return PATH, creating the file with INITIAL-CONTENTS if necessary."
+(defun org-gtd--ensure-file-exists (path initial-contents)
+  "Create the file at PATH with INITIAL-CONTENTS if it does not exist."
   (unless (f-exists-p path)
     (with-current-buffer (find-file-noselect path)
       (insert initial-contents)
       (org-mode-restart)
-      (basic-save-buffer)))
-  path)
+      (basic-save-buffer))))
 
 (defun org-gtd--path (file)
   "Return the full path to FILE.org.

--- a/org-gtd-inbox-processing.el
+++ b/org-gtd-inbox-processing.el
@@ -85,7 +85,7 @@ undefined state."
   "Process the GTD inbox."
   (interactive)
   (set-buffer (org-gtd--inbox-file))
-  (display-buffer-same-window (org-gtd--inbox-file) '())
+  (display-buffer-same-window (current-buffer) '())
   (delete-other-windows)
 
   (org-gtd-process-mode)


### PR DESCRIPTION
A couple requests for improvement (more like 1.5 really):

I wanted to edit the default capture templates to replace the timestamp with a property, using the `:before-finalize` field of `org-capture-templates`. However, the current implementation is that `org-gtd-capture-templates` is really a list of capture-template templates, that are converted to actual capture templates by the `org-gtd--capture-templates` function.

An alternative would be to have `org-gtd-capture-templates` be proper capture templates, but provide a helper function to use as the target specifier. This would allow users to use all features there (template files, the options plist…)

I'm also not convinced about org-gtd concatenating the global capture templates to its own list; I'd rather do that myself when I setup `org-gtd-capture-templates`.