### PR TITLE
restore `inbox-current-tags-alist` from inbox buffer to WIP clarifying buffer

### DIFF
--- a/org-gtd-clarify.el
+++ b/org-gtd-clarify.el
@@ -104,13 +104,16 @@ which turns out to be a project."
   (declare (modes org-mode)) ;; for 27.2 compatibility
   (interactive)
   (let ((processing-buffer (org-gtd-clarify--get-buffer))
-        (window-config (current-window-configuration))
-        (source-heading-marker (point-marker)))
+        (window-config (current-window-configuration))        
+        (source-heading-marker (point-marker))
+        (inbox-current-tags-alist org-current-tag-alist)
+        )
     (org-gtd-clarify--maybe-initialize-buffer-contents processing-buffer)
     (with-current-buffer processing-buffer
       (setq-local org-gtd-clarify--window-config window-config
                   org-gtd-clarify--source-heading-marker source-heading-marker
-                  org-gtd-clarify--clarify-id (org-id-get)))
+                  org-gtd-clarify--clarify-id (org-id-get)
+                  org-current-tag-alist inbox-current-tags-alist))
     (org-gtd-clarify-setup-windows processing-buffer)))
 
 (defun org-gtd-clarify--maybe-initialize-buffer-contents (buffer)


### PR DESCRIPTION
When using `org-gtd-process-inbox`, Org-GTD creates a new buffer for each item but does not bring the heading metadata from `inbox.org`. This causes org-mode to be unable to find tags from the current buffer. This PR resolved #145  in my situation.