### PR TITLE
Update several defcustom expressions

### DIFF
--- a/org-gtd-archive.el
+++ b/org-gtd-archive.el
@@ -37,8 +37,8 @@
 
 (defgroup org-gtd-archive nil
   "How to archive completed / canceled items."
-  :package-version '(org-gtd . "3.0.0")
-  :group 'org-gtd)
+  :group 'org-gtd
+  :package-version '(org-gtd . "3.0.0"))
 
 (defcustom org-gtd-archive-location #'org-gtd-archive-location-func
   "Function to generate archive location for org gtd.
@@ -54,8 +54,8 @@ This function has an arity of zero.  By default this generates a file
 called gtd_archive_<currentyear> in `org-gtd-directory' and puts the entries
 into a datetree."
   :group 'org-gtd-archive
-  :type 'sexp
-  :package-version '(org-gtd . "2.0.0"))
+  :package-version '(org-gtd . "2.0.0")
+  :type 'sexp)
 
 ;;;; Constants
 
@@ -126,11 +126,9 @@ Done here is any done `org-todo-keyword'.  For org-gtd this means `org-gtd-done'
 or `org-gtd-canceled'."
   (org-map-entries
    (lambda ()
-
      (when (org-gtd--all-subheadings-in-done-type-p)
        (setq org-map-continue-from
              (org-element-property :begin (org-element-at-point)))
-
        (org-archive-subtree-default)))
    "+LEVEL=2&+ORG_GTD=\"Projects\""
    'agenda))

--- a/org-gtd-areas-of-focus.el
+++ b/org-gtd-areas-of-focus.el
@@ -38,9 +38,9 @@
 
 (defcustom org-gtd-areas-of-focus '("Home" "Health" "Family" "Career")
   "The current major areas in your life where you don't want to drop balls."
-  :type 'list
   :group 'org-gtd-horizons
-  :package-version '(org-gtd . "3.0.0"))
+  :package-version '(org-gtd . "3.0.0")
+  :type 'list)
 
 ;;;; Commands
 
@@ -74,6 +74,8 @@
         (org-gtd-area-of-focus-set-on-item-at-point)))))
 
 ;;;; Functions
+
+;;;;; Public
 
 (defalias 'org-gtd-set-area-of-focus 'org-gtd-areas-of-focus--set)
 

--- a/org-gtd-backward-compatibility.el
+++ b/org-gtd-backward-compatibility.el
@@ -30,6 +30,16 @@
 
 ;;;; Functions
 
+;;;;; Public
+
+;; this was added in emacs 28.1
+(unless (fboundp 'ensure-list)
+  (defalias 'ensure-list 'org-gtd--ensure-list))
+
+;; this was added in emacs 28.1
+(unless (fboundp 'string-pad)
+  (defalias 'string-pad 'org-gtd--string-pad))
+
 ;;;;; Private
 
 (defun org-gtd--ensure-list (object)
@@ -39,10 +49,6 @@ not a list, return a one-element list containing OBJECT."
   (if (listp object)
       object
     (list object)))
-
-;; this was added in emacs 28.1
-(unless (fboundp 'ensure-list)
-  (defalias 'ensure-list 'org-gtd--ensure-list))
 
 (defun org-gtd--string-pad (string length &optional padding start)
   "Pad STRING to LENGTH using PADDING.
@@ -61,10 +67,6 @@ the string."
     (cond ((<= pad-length 0) string)
           (start (concat (make-string pad-length (or padding ?\s)) string))
           (t (concat string (make-string pad-length (or padding ?\s)))))))
-
-;; this was added in emacs 28.1
-(unless (fboundp 'string-pad)
-  (defalias 'string-pad 'org-gtd--string-pad))
 
 ;;;; Footer
 

--- a/org-gtd-calendar.el
+++ b/org-gtd-calendar.el
@@ -40,11 +40,7 @@
   "Function called when item at point is a task that must happen on a given day.
 
 Keep this clean and don't load your calendar with things that aren't
-actually appointments or deadlines."
-  ;; :group 'org-gtd-organize
-  ;; :type 'function
-  ;; :package-version '(org-gtd . "3.0.0")
-  )
+actually appointments or deadlines.")
 
 (defconst org-gtd-calendar-template
   (format "* Calendar
@@ -53,9 +49,7 @@ actually appointments or deadlines."
 :END:
 " org-gtd-calendar))
 
-;;;; Functions
-
-;;;;; Public
+;;;; Commands
 
 (defun org-gtd-calendar (&optional appointment-date)
   "Decorate and refile item at point as a calendar item.
@@ -66,6 +60,10 @@ non-interactively."
   (org-gtd-organize--call
    (apply-partially org-gtd-calendar-func
                     appointment-date)))
+
+;;;; Functions
+
+;;;;; Public
 
 (defun org-gtd-calendar-create (topic appointment-date)
   "Automatically create a calendar task in the GTD flow.

--- a/org-gtd-capture.el
+++ b/org-gtd-capture.el
@@ -34,8 +34,8 @@
 
 (defgroup org-gtd-capture nil
   "Manage the functions for organizing the GTD actions."
-  :package-version '(org-gtd . "3.0.0")
-  :group 'org-gtd)
+  :group 'org-gtd
+  :package-version '(org-gtd . "3.0.0"))
 
 (defcustom org-gtd-capture-templates
   `(("i" "Inbox"
@@ -52,8 +52,8 @@ See `org-capture-templates' for the format of each capture template.
 Make the sure the template string starts with a single asterisk to denote a
 top level heading, or the behavior of org-gtd will be undefined."
   :group 'org-gtd-capture
-  :type 'sexp
-  :package-version '(org-gtd . "2.0.0"))
+  :package-version '(org-gtd . "2.0.0")
+  :type 'sexp)
 
 ;;;; Constants
 

--- a/org-gtd-clarify.el
+++ b/org-gtd-clarify.el
@@ -36,8 +36,8 @@
 
 (defgroup org-gtd-clarify nil
   "Customize the behavior when clarifying an item."
-  :package-version '(org-gtd . "3.0")
-  :group 'org-gtd)
+  :group 'org-gtd
+  :package-version '(org-gtd . "3.0"))
 
 (defcustom org-gtd-clarify-project-templates nil
   "This is an alist of (\"template title\" . \"template\").
@@ -53,9 +53,9 @@ which turns out to be a project."
 The values can be: nil, top, right, left, bottom.
 
 The file shown can be configured in `org-gtd-horizons-file'."
+  :group 'org-gtd-clarify
   :options '('right 'top 'left 'bottom 'nil)
   :package-version '(org-gtd . "3.0")
-  :group 'org-gtd-clarify
   :type 'symbol)
 
 ;;;; Constants
@@ -112,6 +112,16 @@ The file shown can be configured in `org-gtd-horizons-file'."
 
 ;;;; Commands
 
+(defun org-gtd-clarify-agenda-item ()
+  "Process item at point on agenda view."
+  (declare (modes org-agenda-mode)) ;; for 27.2 compatibility
+  (interactive nil)
+  (org-agenda-check-type t 'agenda 'todo 'tags 'search)
+  (org-agenda-check-no-diary)
+  (let ((heading-marker (or (org-get-at-bol 'org-marker)
+                            (org-agenda-error))))
+    (org-gtd-clarify-item-at-marker heading-marker)))
+
 ;;;###autoload
 (defun org-gtd-clarify-item ()
   "Process item at point through org-gtd."
@@ -149,16 +159,6 @@ The file shown can be configured in `org-gtd-horizons-file'."
 ;;;; Functions
 
 ;;;;; Public
-
-(defun org-gtd-clarify-agenda-item ()
-  "Process item at point on agenda view."
-  (declare (modes org-agenda-mode)) ;; for 27.2 compatibility
-  (interactive nil)
-  (org-agenda-check-type t 'agenda 'todo 'tags 'search)
-  (org-agenda-check-no-diary)
-  (let ((heading-marker (or (org-get-at-bol 'org-marker)
-                            (org-agenda-error))))
-    (org-gtd-clarify-item-at-marker heading-marker)))
 
 (defun org-gtd-clarify-inbox-item ()
   "Process item at point through org-gtd.

--- a/org-gtd-core.el
+++ b/org-gtd-core.el
@@ -35,9 +35,9 @@
 
 (defgroup org-gtd nil
   "Customize the org-gtd package."
+  :group 'org
   :link '(url-link "https://github.com/Trevoke/org-gtd.el")
-  :package-version '(org-gtd . "0.1")
-  :group 'org)
+  :package-version '(org-gtd . "0.1"))
 
 (defcustom org-gtd-canceled "CNCL"
   "The `org-mode' keyword for a canceled task.

--- a/org-gtd-delegate.el
+++ b/org-gtd-delegate.el
@@ -51,11 +51,7 @@ Needs to return a string that will be used as the persons name."
 (defconst org-gtd-delegate-property "DELEGATED_TO")
 
 (defconst org-gtd-delegate-func #'org-gtd-delegate--apply
-  "Function called when organizing item at at point as delegated."
-  ;; :group 'org-gtd-organize
-  ;; :type 'function
-  ;; :package-version '(org-gtd . "3.0.0")
-  )
+  "Function called when organizing item at at point as delegated.")
 
 ;;;; Commands
 

--- a/org-gtd-habit.el
+++ b/org-gtd-habit.el
@@ -38,11 +38,7 @@
 (defconst org-gtd-habit "Habits")
 
 (defconst org-gtd-habit-func #'org-gtd-habit--apply
-  "Function called when organizing item as a habit."
-  ;; :group 'org-gtd-organize
-  ;; :type 'function
-  ;; :package-version '(org-gtd . "3.0.0")
-  )
+  "Function called when organizing item as a habit.")
 
 (defconst org-gtd-habit-template
   (format "* Habits

--- a/org-gtd-horizons.el
+++ b/org-gtd-horizons.el
@@ -34,8 +34,8 @@
 
 (defgroup org-gtd-horizons nil
   "Variables handling GTD horizons-related logic."
-  :package-version '(org-gtd . "3.0.0")
-  :group 'org-gtd)
+  :group 'org-gtd
+  :package-version '(org-gtd . "3.0.0"))
 
 (defcustom org-gtd-horizons-file "horizons.org"
   "File holding your GTD horizons.

--- a/org-gtd-incubate.el
+++ b/org-gtd-incubate.el
@@ -37,11 +37,7 @@
 (defconst org-gtd-incubate "Incubated")
 
 (defconst org-gtd-incubate-func #'org-gtd-incubate--apply
-  "Function called when organizing item as incubated."
-  ;; :group 'org-gtd-organize
-  ;; :type 'function
-  ;; :package-version '(org-gtd . "3.0.0")
-  )
+  "Function called when organizing item as incubated.")
 
 (defconst org-gtd-incubate-template
   (format "* Incubate

--- a/org-gtd-knowledge.el
+++ b/org-gtd-knowledge.el
@@ -41,11 +41,7 @@ Note that this function is used inside loops,for instance to process the inbox,
 so if you have manual steps you need to take when storing a heading
 as knowledge, take them before calling this function
 \(for instance, during inbox processing, take the manual steps during the
-clarify step, before you call `org-gtd-organize')."
-  ;; :group 'org-gtd-organize
-  ;; :type 'function
-  ;; :package-version '(org-gtd . "3.0.0")
-  )
+clarify step, before you call `org-gtd-organize').")
 
 ;;;; Commands
 

--- a/org-gtd-organize.el
+++ b/org-gtd-organize.el
@@ -48,8 +48,8 @@
 
 (defgroup org-gtd-organize nil
   "Manage the functions for organizing the GTD actions."
-  :package-version '(org-gtd . "3.0.0")
-  :group 'org-gtd)
+  :group 'org-gtd
+  :package-version '(org-gtd . "3.0.0"))
 
 (defcustom org-gtd-organize-hooks '(org-set-tags-command)
   "Enhancements to add to each item as they get processed from the inbox.
@@ -62,9 +62,9 @@ the items once they have been processed and add them to that list.
 Once you have your ground items managed, you might like to set the variable
 `org-gtd-areas-of-focus' and add `org-gtd-set-area-of-focus' to these hooks."
   :group 'org-gtd-organize
+  :options '(org-set-tags-command org-set-effort org-priority)
   :package-version '(org-gtd . "1.0.4")
-  :type 'hook
-  :options '(org-set-tags-command org-set-effort org-priority))
+  :type 'hook)
 
 ;;;; Constants
 

--- a/org-gtd-projects.el
+++ b/org-gtd-projects.el
@@ -40,18 +40,10 @@
 ;;;; Constants
 
 (defconst org-gtd-add-to-project-func #'org-gtd-project-extend--apply
-  "Function called when organizing item at point as a new task in a project."
-  ;; :group 'org-gtd-organize
-  ;; :type 'function
-  ;; :package-version '(org-gtd . "3.0.0")
-  )
+  "Function called when organizing item at point as a new task in a project.")
 
 (defconst org-gtd-project-func #'org-gtd-project-new--apply
-  "Function called when organizing item at point as a project."
-  ;; :group 'org-gtd-organize
-  ;; :type 'function
-  ;; :package-version '(org-gtd . "3.0.0")
-  )
+  "Function called when organizing item at point as a project.")
 
 (defconst org-gtd-project-headings
   "+LEVEL=2&+ORG_GTD=\"Projects\""

--- a/org-gtd-quick-action.el
+++ b/org-gtd-quick-action.el
@@ -35,11 +35,7 @@
 ;;;; Constants
 
 (defconst org-gtd-quick-action-func #'org-gtd-quick-action--apply
-  "Function called when organizing item at point as quick action."
-  ;; :group 'org-gtd-organize
-  ;; :type 'function
-  ;; :package-version '(org-gtd . "3.0.0")
-  )
+  "Function called when organizing item at point as quick action.")
 
 ;;;; Commands
 

--- a/org-gtd-refile.el
+++ b/org-gtd-refile.el
@@ -46,8 +46,8 @@ to create new refile targets.
 Defaults to true to carry over pre-2.0 behavior.  You will need to change this
 setting as part of following the instructions to add your own refile targets."
   :group 'org-gtd-organize
-  :type 'boolean
-  :package-version '(org-gtd . "2.0.0"))
+  :package-version '(org-gtd . "2.0.0")
+  :type 'boolean)
 
 ;;;; Macros
 

--- a/org-gtd-single-action.el
+++ b/org-gtd-single-action.el
@@ -44,11 +44,7 @@
 " org-gtd-action))
 
 (defconst org-gtd-single-action-func #'org-gtd-single-action--apply
-  "Function called when organizing item at point as a single next action."
-  ;; :group 'org-gtd-organize
-  ;; :type 'function
-  ;; :package-version '(org-gtd . "3.0.0")
-  )
+  "Function called when organizing item at point as a single next action.")
 
 ;;;; Commands
 

--- a/org-gtd-trash.el
+++ b/org-gtd-trash.el
@@ -34,11 +34,7 @@
 ;;;; Constants
 
 (defconst org-gtd-trash-func #'org-gtd-trash--apply
-  "Function called when organizing item at point as trash."
-  ;; :group 'org-gtd-organize
-  ;; :type 'function
-  ;; :package-version '(org-gtd . "3.0.0")
-  )
+  "Function called when organizing item at point as trash.")
 
 ;;;; Commands
 


### PR DESCRIPTION
- Apply consistent lexicographical ordering of optional arguments
- Remove obsolete commented defcustom arguments and values

In addition, move some other top-level expressions to the appropriate outline section missed in commits merged with commit be1c513.