### PR TITLE
Added variable to configure width of project in agenda view

### DIFF
--- a/org-gtd-agenda.el
+++ b/org-gtd-agenda.el
@@ -100,6 +100,9 @@ This assumes all GTD files are also agenda files."
 
 (defun org-gtd-agenda--prefix-format ()
   "Format prefix for items in agenda buffer."
+  (defun truncate (st)
+    (truncate-string-to-width (string-trim st) org-gtd-agenda-width-project-name nil ?\s  "…")
+    )
   (let* ((elt (org-element-at-point))
          (level (org-element-property :level elt))
          (category (org-entry-get (point) "CATEGORY" t))
@@ -107,7 +110,7 @@ This assumes all GTD files are also agenda files."
                         :raw-value
                         (org-element-property :parent elt)))
          (tally-cookie-regexp "\[[[:digit:]]+/[[:digit:]]+\][[:space:]]*"))
-    (truncate-string-to-width
+    (truncate
      ;; if level 3, use the parent
      ;; otherwise if it has category, use category
      ;; else "no project" so we avoid failing
@@ -115,9 +118,7 @@ This assumes all GTD files are also agenda files."
       ((eq level 3) (replace-regexp-in-string tally-cookie-regexp "" parent-title))
       (category     category)
       (t  "no project")
-      )
-     org-gtd-agenda-width-project-name nil ?\s  "…"
-     )))
+      ))))
 
 ;;;; Footer
 

--- a/org-gtd-agenda.el
+++ b/org-gtd-agenda.el
@@ -32,6 +32,10 @@
 (require 'org-gtd-core)
 (require 'org-gtd-backward-compatibility)
 
+(defvar org-gtd-agenda-width-project-name 12
+  "width of the project name in the agenda view. Name will be truncated to this length"
+  )
+
 ;;;; Commands
 
 ;;;###autoload
@@ -40,7 +44,9 @@
   (interactive)
   (org-gtd-core-prepare-agenda-buffers)
   (with-org-gtd-context
-      (let ((org-agenda-custom-commands
+      (let* ((project-format-prefix  (format " %%i %%-%d"
+                                            org-gtd-agenda-width-project-name) )
+             (org-agenda-custom-commands
              `(("g" "Scheduled today and all NEXT items"
                 ((agenda ""
                          ((org-agenda-span 1)
@@ -49,12 +55,12 @@
                  (todo org-gtd-next
                        ((org-agenda-overriding-header "All actions ready to be executed.")
                         (org-agenda-prefix-format
-                         '((todo . " %i %-12:(org-gtd-agenda--prefix-format)")))))
+                         '((todo . ,(eval (concat project-format-prefix ":(org-gtd-agenda--prefix-format) ")))))))
                  (todo org-gtd-wait
                        ((org-agenda-todo-ignore-with-date t)
                         (org-agenda-overriding-header "Delegated/Blocked items")
                         (org-agenda-prefix-format
-                         '((todo . " %i %-12 (org-gtd-agenda--prefix-format)"))))))))))
+                         '((todo . ,(eval (concat project-format-prefix " (org-gtd-agenda--prefix-format) "))))))))))))
         (org-agenda nil "g")
         (goto-char (point-min)))))
 
@@ -101,16 +107,17 @@ This assumes all GTD files are also agenda files."
                         :raw-value
                         (org-element-property :parent elt)))
          (tally-cookie-regexp "\[[[:digit:]]+/[[:digit:]]+\][[:space:]]*"))
-
-    (cond
-     ((eq level 3)
-      (concat
-       (substring (string-pad
-                   (replace-regexp-in-string tally-cookie-regexp "" parent-title)
-                   11)
-                  0 10)
-       "…"))
-     (category (concat (substring (string-pad category 11) 0 10) "…")))))
+    (truncate-string-to-width
+     ;; if level 3, use the parent
+     ;; otherwise if it has category, use category
+     ;; else "no project" so we avoid failing
+     (cond
+      ((eq level 3) (replace-regexp-in-string tally-cookie-regexp "" parent-title))
+      (category     category)
+      (t  "no project")
+      )
+     org-gtd-agenda-width-project-name nil ?\s  "…"
+     )))
 
 ;;;; Footer
 

--- a/test/agenda-width-project-name.el
+++ b/test/agenda-width-project-name.el
@@ -1,0 +1,113 @@
+(load "test/helpers/setup.el")
+(require 'org-gtd)
+(require 'buttercup)
+
+;; the the implementation of org-gtd-agenda-width-project-name
+
+(describe
+    "Engage view"
+
+  :var ((inhibit-message t))
+
+  (before-each (ogt--configure-emacs)
+               (setq org-gtd-agenda-width-project-name 17))
+  (after-each (ogt--close-and-delete-files)
+              (setq org-gtd-agenda-width-project-name 12))
+
+  (it "can have a specific agenda width"
+    (ogt-capture-and-process-project "My long project name which needs shortening") ;; see test/helpers/processing.el
+    (org-gtd-engage)
+    (expect (message (ogt--buffer-string org-agenda-buffer))
+            :to-match
+            "My long project …")
+    ))
+
+(describe
+    "Engage view"
+
+  :var ((inhibit-message t))
+  
+  (before-each (ogt--configure-emacs)
+               (setq org-gtd-agenda-width-project-name 5))
+  (after-each (ogt--close-and-delete-files)
+              (setq org-gtd-agenda-width-project-name 12))
+  
+  (it "can have a specific agenda width"
+    (ogt-capture-and-process-project "P234567890")
+    (org-gtd-engage)
+    (expect (message (ogt--buffer-string org-agenda-buffer))
+            :to-match
+            "P234…")
+    ))
+
+(describe
+    "Engage view"
+
+  :var ((inhibit-message t))
+  
+  (before-each (ogt--configure-emacs)
+               (setq org-gtd-agenda-width-project-name 1))
+  (after-each (ogt--close-and-delete-files)
+              (setq org-gtd-agenda-width-project-name 12))
+  
+  (it "can have a specific agenda width"
+    (ogt-capture-and-process-project "P234567890")
+    (org-gtd-engage)
+    (expect (message (ogt--buffer-string org-agenda-buffer))
+            :to-match
+            "…")
+    ))
+
+(describe
+    "Engage view"
+
+  :var ((inhibit-message t))
+  
+  (before-each (ogt--configure-emacs)
+               (setq org-gtd-agenda-width-project-name 10))
+  (after-each (ogt--close-and-delete-files)
+              (setq org-gtd-agenda-width-project-name 12))
+  
+  (it "can have a specific agenda width"
+    (ogt-capture-and-process-project "P234567890")
+    (org-gtd-engage)
+    (expect (message (ogt--buffer-string org-agenda-buffer))
+            :to-match
+            "P234567890")
+    ))
+
+(describe
+    "Engage view"
+
+  :var ((inhibit-message t))
+  
+  (before-each (ogt--configure-emacs)
+               (setq org-gtd-agenda-width-project-name 12))
+  (after-each (ogt--close-and-delete-files)
+              (setq org-gtd-agenda-width-project-name 12))
+  
+  (it "can have a specific agenda width"
+    (ogt-capture-and-process-project "P234567890")
+    (org-gtd-engage)
+    (expect (message (ogt--buffer-string org-agenda-buffer))
+            :to-match
+            "P234567890  ")
+    ))
+
+(describe
+    "Engage view"
+
+  :var ((inhibit-message t))
+  
+  (before-each (ogt--configure-emacs)
+               (setq org-gtd-agenda-width-project-name 50))
+  (after-each (ogt--close-and-delete-files)
+              (setq org-gtd-agenda-width-project-name 12))
+  
+  (it "can have a specific agenda width"
+    (ogt-capture-and-process-project "P234567890")
+    (org-gtd-engage)
+    (expect (message (ogt--buffer-string org-agenda-buffer))
+            :to-match
+            "P234567890                                        ")
+    ))

--- a/test/agenda-width-project-name.el
+++ b/test/agenda-width-project-name.el
@@ -17,7 +17,7 @@
   (it "can have a specific agenda width"
     (ogt-capture-and-process-project "My long project name which needs shortening") ;; see test/helpers/processing.el
     (org-gtd-engage)
-    (expect (message (ogt--buffer-string org-agenda-buffer))
+    (expect (ogt--buffer-string org-agenda-buffer)
             :to-match
             "My long project …")
     ))
@@ -35,7 +35,7 @@
   (it "can have a specific agenda width"
     (ogt-capture-and-process-project "P234567890")
     (org-gtd-engage)
-    (expect (message (ogt--buffer-string org-agenda-buffer))
+    (expect (ogt--buffer-string org-agenda-buffer)
             :to-match
             "P234…")
     ))
@@ -53,7 +53,7 @@
   (it "can have a specific agenda width"
     (ogt-capture-and-process-project "P234567890")
     (org-gtd-engage)
-    (expect (message (ogt--buffer-string org-agenda-buffer))
+    (expect (ogt--buffer-string org-agenda-buffer)
             :to-match
             "…")
     ))
@@ -71,7 +71,7 @@
   (it "can have a specific agenda width"
     (ogt-capture-and-process-project "P234567890")
     (org-gtd-engage)
-    (expect (message (ogt--buffer-string org-agenda-buffer))
+    (expect (ogt--buffer-string org-agenda-buffer)
             :to-match
             "P234567890")
     ))
@@ -89,7 +89,7 @@
   (it "can have a specific agenda width"
     (ogt-capture-and-process-project "P234567890")
     (org-gtd-engage)
-    (expect (message (ogt--buffer-string org-agenda-buffer))
+    (expect (ogt--buffer-string org-agenda-buffer)
             :to-match
             "P234567890  ")
     ))
@@ -107,7 +107,7 @@
   (it "can have a specific agenda width"
     (ogt-capture-and-process-project "P234567890")
     (org-gtd-engage)
-    (expect (message (ogt--buffer-string org-agenda-buffer))
+    (expect (ogt--buffer-string org-agenda-buffer)
             :to-match
             "P234567890                                        ")
     ))


### PR DESCRIPTION
Added org-gtd-agenda-width-project-name to remove the hardcoded width of the project in the agenda view.

This will allow the user to define the width to any reasonable value.