### PR TITLE
Remove interactive form from private functions

### DIFF
--- a/org-gtd-process.el
+++ b/org-gtd-process.el
@@ -56,7 +56,6 @@
 
 (defun org-gtd-process--stop ()
   "Stop processing the inbox."
-  (interactive)
   (whitespace-cleanup))
 
 ;;;; Footer

--- a/org-gtd-single-action.el
+++ b/org-gtd-single-action.el
@@ -74,7 +74,6 @@ TOPIC is what you want to see in the agenda view."
 
 (defun org-gtd-single-action--apply ()
   "Item at point is a one-off action, ready to be executed."
-  (interactive)
   (org-todo org-gtd-next)
   (setq-local org-gtd--organize-type 'single-action)
   (org-gtd-organize-apply-hooks)


### PR DESCRIPTION
Private functions should not be interactive. Unless these `defun`s should in fact be commands instead?