### PR TITLE
local defuns are not local.

### DIFF
--- a/org-gtd-agenda.el
+++ b/org-gtd-agenda.el
@@ -108,11 +108,13 @@ This assumes all GTD files are also agenda files."
 
 ;;;;; Private
 
+(defun org-gtd--truncate-project-to-width (st)
+  "Truncates the string to the width indicated by org-gtd-engage-prefix-width."
+  (truncate-string-to-width (string-trim st) org-gtd-engage-prefix-width nil ?\s  "…")
+  )
+
 (defun org-gtd-agenda--prefix-format ()
   "Format prefix for items in agenda buffer."
-  (defun truncate (st)
-    (truncate-string-to-width (string-trim st) org-gtd-engage-prefix-width nil ?\s  "…")
-    )
   (let* ((elt (org-element-at-point))
          (level (org-element-property :level elt))
          (category (org-entry-get (point) "CATEGORY" t))
@@ -120,7 +122,7 @@ This assumes all GTD files are also agenda files."
                         :raw-value
                         (org-element-property :parent elt)))
          (tally-cookie-regexp "\[[[:digit:]]+/[[:digit:]]+\][[:space:]]*"))
-    (truncate
+    (org-gtd--truncate-project-to-width
      ;; if level 3, use the parent
      ;; otherwise if it has category, use category
      ;; else "no project" so we avoid failing


### PR DESCRIPTION
I was under the assumption that a local defun is part of the closure of the enclosing defun. I was wrong. local defuns are global bindings. Thus the old code was replacing emacs's truncate with the local truncate.

This patch renames the function and makes it global, in case it is every needed.