### PR TITLE
Fix processing with empty inbox

### DIFF
--- a/org-gtd-process.el
+++ b/org-gtd-process.el
@@ -45,7 +45,7 @@
     (when (org-before-first-heading-p)
       (org-next-visible-heading 1))
     (if (not (org-at-heading-p))
-        (user-error "No items to process" (org-gtd-process--stop))
+        (message "No items to process" (org-gtd-process--stop))
       (org-N-empty-lines-before-current 1)
       (org-gtd-clarify-inbox-item))))
 

--- a/org-gtd-process.el
+++ b/org-gtd-process.el
@@ -46,8 +46,9 @@
           (goto-char (point-min))
           (when (org-before-first-heading-p)
             (outline-next-visible-heading 1))
-          (org-N-empty-lines-before-current 1)
-          (org-gtd-clarify-inbox-item))
+          (when (org-at-heading-p)
+            (org-N-empty-lines-before-current 1)
+            (org-gtd-clarify-inbox-item)))
       (user-error (org-gtd-process--stop)))))
 
 ;;;; Functions

--- a/org-gtd-process.el
+++ b/org-gtd-process.el
@@ -41,15 +41,13 @@
   (interactive)
   (let ((buffer (find-file-noselect (org-gtd-inbox-path))))
     (set-buffer buffer)
-    (condition-case _err
-        (progn
-          (goto-char (point-min))
-          (when (org-before-first-heading-p)
-            (outline-next-visible-heading 1))
-          (when (org-at-heading-p)
-            (org-N-empty-lines-before-current 1)
-            (org-gtd-clarify-inbox-item)))
-      (user-error (org-gtd-process--stop)))))
+    (goto-char (point-min))
+    (when (org-before-first-heading-p)
+      (org-next-visible-heading 1))
+    (if (not (org-at-heading-p))
+        (user-error "No more items to process" (org-gtd-process--stop))
+      (org-N-empty-lines-before-current 1)
+      (org-gtd-clarify-inbox-item))))
 
 ;;;; Functions
 

--- a/org-gtd-process.el
+++ b/org-gtd-process.el
@@ -45,7 +45,7 @@
     (when (org-before-first-heading-p)
       (org-next-visible-heading 1))
     (if (not (org-at-heading-p))
-        (user-error "No more items to process" (org-gtd-process--stop))
+        (user-error "No items to process" (org-gtd-process--stop))
       (org-N-empty-lines-before-current 1)
       (org-gtd-clarify-inbox-item))))
 


### PR DESCRIPTION
Currently, when calling `org-gtd-process-inbox` with an empty inbox (i.e. one without headings), a PROPERTIES drawer is incorrectly added to the top of the inbox file, because `org-gtd-id-get-create` will eventually be called no matter what. This PR fix that by simply checking if there is an org heading before starting to process the item.