### PR TITLE
feat: add org-gtd-review-missed-items

### DIFF
--- a/doc/org-gtd.org
+++ b/doc/org-gtd.org
@@ -797,6 +797,7 @@ Sometimes things break. The following functions will help you find these items:
 - ~org-gtd-review-stuck-delegated-items~
 - ~org-gtd-review-stuck-single-action-items~
 - ~org-gtd-review-stuck-projects~
+- ~org-gtd-review-missed-items~
 
 ** Projects without a NEXT item
 

--- a/doc/org-gtd.texi
+++ b/doc/org-gtd.texi
@@ -1328,6 +1328,8 @@ Sometimes things break. The following functions will help you find these items:
 @code{org-gtd-review-stuck-single-action-items}
 @item
 @code{org-gtd-review-stuck-projects}
+@item
+@code{org-gtd-review-missed-items}
 @end itemize
 
 @node Projects without a NEXT item

--- a/org-gtd-review.el
+++ b/org-gtd-review.el
@@ -105,7 +105,7 @@ mostly of value for testing purposes."
         (org-agenda nil "g"))))
 
 (defun org-gtd-review-stuck-delegated-items ()
-  "Agenda view with all invalid Calendar actions."
+  "Agenda view with all invalid delegated actions."
   (interactive)
   (with-org-gtd-context
       (let ((org-agenda-custom-commands
@@ -119,7 +119,7 @@ mostly of value for testing purposes."
         (org-agenda nil "g"))))
 
 (defun org-gtd-review-stuck-habit-items ()
-  "Agenda view with all invalid Calendar actions."
+  "Agenda view with all invalid habit actions."
   (interactive)
   (with-org-gtd-context
       (let ((org-agenda-custom-commands
@@ -131,7 +131,7 @@ mostly of value for testing purposes."
         (org-agenda nil "g"))))
 
 (defun org-gtd-review-stuck-incubated-items ()
-  "Agenda view with all invalid Calendar actions."
+  "Agenda view with all invalid incubated actions."
   (interactive)
   (with-org-gtd-context
       (let ((org-agenda-custom-commands
@@ -140,6 +140,23 @@ mostly of value for testing purposes."
                        ((org-agenda-skip-function
                          'org-gtd-skip-unless-timestamp-empty-or-invalid)
                         (org-agenda-skip-additional-timestamps-same-entry t))))))))
+        (org-agenda nil "g"))))
+
+(defun org-gtd-review-missed-items ()
+  "Agenda view with all incubated or delegated actions whose date is in the past."
+  (interactive)
+  (with-org-gtd-context
+      (let ((org-agenda-custom-commands
+             '(("g" "foobar"
+                ((tags "ORG_GTD=\"Incubated\"+ITEM<>\"Incubate\"|"
+                       ((org-agenda-skip-function
+                         'org-gtd-skip-unless-timestamp-in-the-past)
+                        (org-agenda-skip-additional-timestamp-same-entry t)))
+                 (tags (format "+TODO=\"%s\"" org-gtd-wait)
+                       ((org-agenda-skip-function
+                         'org-gtd-skip-unless-timestamp-in-the-past)
+                        (org-agenda-skip-additional-timestamps-same-entry t)))
+                 )))))
         (org-agenda nil "g"))))
 
 ;;;###autoload

--- a/org-gtd.info
+++ b/org-gtd.info
@@ -1465,6 +1465,7 @@ these items:
    • ‘org-gtd-review-stuck-delegated-items’
    • ‘org-gtd-review-stuck-single-action-items’
    • ‘org-gtd-review-stuck-projects’
+   • ‘org-gtd-review-missed-items’
 
 
 File: org-gtd.info,  Node: Projects without a NEXT item,  Next: I can't create a project when clarifying an inbox item!,  Prev: Finding lost tasks,  Up: Troubleshooting


### PR DESCRIPTION
Potential solution for https://github.com/Trevoke/org-gtd.el/issues/186

I have the same problem for missed incubated actions and missed delegated actions.
This agenda view shows both of them.

