### PR TITLE
Add missing requires

### DIFF
--- a/org-gtd-core.el
+++ b/org-gtd-core.el
@@ -171,9 +171,7 @@ See `org-todo-keywords' for definition."
   "Wrap BODY... in this macro to inherit the org-gtd settings for your logic."
   (declare (debug t) (indent 2))
   `(progn
-     (require 'org-gtd-archive)
-     (require 'org-gtd-projects)
-     (require 'org-gtd-delegate)
+     (require 'org-gtd)
      (let* ((org-use-property-inheritance "ORG_GTD")
             (org-todo-keywords `((sequence ,(string-join `(,org-gtd-next ,org-gtd-next-suffix))
                                            ,(string-join `(,org-gtd-todo ,org-gtd-todo-suffix))

--- a/org-gtd-core.el
+++ b/org-gtd-core.el
@@ -160,11 +160,6 @@ See `org-todo-keywords' for definition."
 
 ;;;; Variables
 
-(defvar org-gtd-archive-location)
-(defvar org-gtd-delegate-property)
-(defvar org-gtd-project-headings)
-(defvar org-gtd-stuck-projects)
-
 (defvar-local org-gtd--loading-p nil
   "`Org-gtd' sets this variable after it has changed the state in this buffer.")
 
@@ -174,28 +169,32 @@ See `org-todo-keywords' for definition."
 (defmacro with-org-gtd-context (&rest body)
   "Wrap BODY... in this macro to inherit the org-gtd settings for your logic."
   (declare (debug t) (indent 2))
-  `(let* ((org-use-property-inheritance "ORG_GTD")
-          (org-todo-keywords `((sequence ,(string-join `(,org-gtd-next ,org-gtd-next-suffix))
-                                         ,(string-join `(,org-gtd-todo ,org-gtd-todo-suffix))
-                                         ,(string-join `(,org-gtd-wait ,org-gtd-wait-suffix))
-                                         "|"
-                                         ,(string-join `(,org-gtd-done ,org-gtd-done-suffix))
-                                         ,(string-join `(,org-gtd-canceled ,org-gtd-canceled-suffix)))))
-          ;; (org-log-done 'time)
-          ;; (org-log-done-with-time t)
-          ;; (org-log-refile 'time)
-          (org-archive-location (funcall org-gtd-archive-location))
-          ;(org-refile-use-outline-path nil)
-          (org-stuck-projects org-gtd-stuck-projects)
-          (org-odd-levels-only nil)
-          (org-agenda-files (org-gtd-core--agenda-files))
-          (org-agenda-property-list `(,org-gtd-delegate-property)))
-     (unwind-protect
+  `(progn
+     (require 'org-gtd-archive)
+     (require 'org-gtd-projects)
+     (require 'org-gtd-delegate)
+     (let* ((org-use-property-inheritance "ORG_GTD")
+            (org-todo-keywords `((sequence ,(string-join `(,org-gtd-next ,org-gtd-next-suffix))
+                                           ,(string-join `(,org-gtd-todo ,org-gtd-todo-suffix))
+                                           ,(string-join `(,org-gtd-wait ,org-gtd-wait-suffix))
+                                           "|"
+                                           ,(string-join `(,org-gtd-done ,org-gtd-done-suffix))
+                                           ,(string-join `(,org-gtd-canceled ,org-gtd-canceled-suffix)))))
+            ;; (org-log-done 'time)
+            ;; (org-log-done-with-time t)
+            ;; (org-log-refile 'time)
+            (org-archive-location (funcall org-gtd-archive-location))
+                                        ;(org-refile-use-outline-path nil)
+            (org-stuck-projects org-gtd-stuck-projects)
+            (org-odd-levels-only nil)
+            (org-agenda-files (org-gtd-core--agenda-files))
+            (org-agenda-property-list `(,org-gtd-delegate-property)))
+       (unwind-protect
+           (progn
+             (advice-add 'org-agenda-files :filter-return #'org-gtd-core--uniq)
+             ,@body)
          (progn
-           (advice-add 'org-agenda-files :filter-return #'org-gtd-core--uniq)
-           ,@body)
-       (progn
-         (advice-remove 'org-agenda-files #'org-gtd-core--uniq)))))
+           (advice-remove 'org-agenda-files #'org-gtd-core--uniq))))))
 
 ;;;; Functions
 

--- a/org-gtd-core.el
+++ b/org-gtd-core.el
@@ -27,6 +27,7 @@
 
 ;;;; Requirements
 
+(require 'f)
 (require 'org-agenda-property)
 
 (require 'org-gtd-backward-compatibility)

--- a/test/autoload-test.el
+++ b/test/autoload-test.el
@@ -1,0 +1,65 @@
+(load "test/helpers/setup.el")
+(require 'buttercup)
+(describe
+    "autoloaded entry point"
+
+  (it "org-gtd-archive-completed-items"
+    (expect
+     (ogt--recursive-eldev-test
+      "autoload-tests/org-gtd-archive-completed-items-test.el")
+     :to-equal 0))
+
+  (it "org-gtd-capture"
+    (expect
+     (ogt--recursive-eldev-test
+      "autoload-tests/org-gtd-capture-test.el")
+     :to-equal 0))
+
+  (it "org-gtd-clarify-item"
+    (expect
+     (ogt--recursive-eldev-test
+      "autoload-tests/org-gtd-clarify-item-test.el")
+     :to-equal 0))
+
+  (it "org-gtd-clarify-mode"
+    (expect
+     (ogt--recursive-eldev-test
+      "autoload-tests/org-gtd-clarify-mode-test.el")
+     :to-equal 0))
+
+  (it "org-gtd-engage"
+    (expect
+     (ogt--recursive-eldev-test "autoload-tests/org-gtd-engage-test.el")
+     :to-equal 0))
+
+  (it "org-gtd-inbox-path"
+    (expect
+     (ogt--recursive-eldev-test
+      "autoload-tests/org-gtd-inbox-path-test.el")
+     :to-equal 0))
+
+  (it "org-gtd-mode"
+    (expect
+     (ogt--recursive-eldev-test
+      "autoload-tests/org-gtd-mode-test.el")
+     :to-equal 0))
+
+  (it "org-gtd-process-inbox"
+    (expect
+     (ogt--recursive-eldev-test
+      "autoload-tests/org-gtd-process-inbox-test.el")
+     :to-equal 0))
+
+  (it "org-gtd-review-stuck-projects"
+    (expect
+     (ogt--recursive-eldev-test
+      "autoload-tests/org-gtd-review-stuck-projects-test.el")
+     :to-equal 0))
+
+  (it "org-gtd-show-all-next"
+    (expect
+     (ogt--recursive-eldev-test
+      "autoload-tests/org-gtd-show-all-next-test.el")
+     :to-equal 0))
+
+  )

--- a/test/autoload-tests/org-gtd-archive-completed-items-test.el
+++ b/test/autoload-tests/org-gtd-archive-completed-items-test.el
@@ -1,0 +1,12 @@
+(require 'buttercup)
+(setq org-gtd-update-ack "3.0.0")
+(load "org-gtd-autoloads")
+(load "test/helpers/autoload-setup.el")
+
+(describe
+ "autoload management (recursive)"
+ (before-each (ogt--prepare-gtd-directory))
+ (after-each (ogt--clear-gtd-directory))
+
+ (it "org-gtd-archive-completed-items"
+     (org-gtd-archive-completed-items)))

--- a/test/autoload-tests/org-gtd-capture-test.el
+++ b/test/autoload-tests/org-gtd-capture-test.el
@@ -1,0 +1,12 @@
+(require 'buttercup)
+(setq org-gtd-update-ack "3.0.0")
+(load "org-gtd-autoloads")
+(load "test/helpers/autoload-setup.el")
+
+(describe
+ "autoload management (recursive)"
+ (before-each (ogt--prepare-gtd-directory))
+ (after-each (ogt--clear-gtd-directory))
+
+ (it "org-gtd-capture"
+     (org-gtd-capture nil "i")))

--- a/test/autoload-tests/org-gtd-clarify-item-test.el
+++ b/test/autoload-tests/org-gtd-clarify-item-test.el
@@ -1,0 +1,15 @@
+(require 'buttercup)
+(setq org-gtd-update-ack "3.0.0")
+(load "org-gtd-autoloads")
+(load "test/helpers/utils.el")
+(load "test/helpers/autoload-setup.el")
+
+(describe
+ "autoload management (recursive)"
+ (before-each (ogt--prepare-gtd-directory))
+ (after-each (ogt--clear-gtd-directory))
+
+ (it "org-gtd-clarify-item"
+     (ogt--with-temp-org-buffer
+      "* This is the heading to clarify"
+      (org-gtd-clarify-item))))

--- a/test/autoload-tests/org-gtd-clarify-mode-test.el
+++ b/test/autoload-tests/org-gtd-clarify-mode-test.el
@@ -1,0 +1,9 @@
+(require 'buttercup)
+(setq org-gtd-update-ack "3.0.0")
+(load "org-gtd-autoloads")
+
+(describe
+ "autoload management (recursive)"
+
+ (it "org-gtd-clarify-mode"
+     (org-gtd-clarify-mode)))

--- a/test/autoload-tests/org-gtd-engage-test.el
+++ b/test/autoload-tests/org-gtd-engage-test.el
@@ -1,0 +1,12 @@
+(require 'buttercup)
+(setq org-gtd-update-ack "3.0.0")
+(load "org-gtd-autoloads")
+(load "test/helpers/autoload-setup.el")
+
+(describe
+ "autoload management (recursive)"
+ (before-each (ogt--prepare-gtd-directory))
+ (after-each (ogt--clear-gtd-directory))
+
+ (it "org-gtd-engage"
+     (org-gtd-engage)))

--- a/test/autoload-tests/org-gtd-inbox-path-test.el
+++ b/test/autoload-tests/org-gtd-inbox-path-test.el
@@ -1,0 +1,13 @@
+(require 'buttercup)
+(setq org-gtd-update-ack "3.0.0")
+(load "org-gtd-autoloads")
+
+(load "test/helpers/autoload-setup.el")
+
+(describe
+ "autoload management (recursive)"
+ (before-each (ogt--prepare-gtd-directory))
+ (after-each (ogt--clear-gtd-directory))
+
+ (it "org-gtd-inbox-path"
+     (org-gtd-inbox-path)))

--- a/test/autoload-tests/org-gtd-mode-test.el
+++ b/test/autoload-tests/org-gtd-mode-test.el
@@ -1,0 +1,8 @@
+(require 'buttercup)
+(setq org-gtd-update-ack "3.0.0")
+(load "org-gtd-autoloads")
+
+(describe
+ "autoload management (recursive)"
+ (it "org-gtd-mode"
+     (org-gtd-mode)))

--- a/test/autoload-tests/org-gtd-process-inbox-test.el
+++ b/test/autoload-tests/org-gtd-process-inbox-test.el
@@ -1,0 +1,12 @@
+(require 'buttercup)
+(setq org-gtd-update-ack "3.0.0")
+(load "org-gtd-autoloads")
+(load "test/helpers/autoload-setup.el")
+
+(describe
+ "autoload management (recursive)"
+ (before-each (ogt--prepare-gtd-directory))
+ (after-each (ogt--clear-gtd-directory))
+
+ (it "org-gtd-process-inbox"
+     (org-gtd-process-inbox)))

--- a/test/autoload-tests/org-gtd-review-stuck-projects-test.el
+++ b/test/autoload-tests/org-gtd-review-stuck-projects-test.el
@@ -1,0 +1,14 @@
+(require 'buttercup)
+(setq org-gtd-update-ack "3.0.0")
+(load "org-gtd-autoloads")
+(load "test/helpers/autoload-setup.el")
+
+(describe
+ "autoload management (recursive)"
+ (before-each (ogt--prepare-gtd-directory))
+ (after-each (ogt--clear-gtd-directory))
+
+ (it "org-gtd-review-stuck-projects"
+     (org-gtd-review-stuck-projects)))
+
+

--- a/test/autoload-tests/org-gtd-show-all-next-test.el
+++ b/test/autoload-tests/org-gtd-show-all-next-test.el
@@ -1,0 +1,12 @@
+(require 'buttercup)
+(setq org-gtd-update-ack "3.0.0")
+(load "org-gtd-autoloads")
+(load "test/helpers/autoload-setup.el")
+
+(describe
+ "autoload management (recursive)"
+ (before-each (ogt--prepare-gtd-directory))
+ (after-each (ogt--clear-gtd-directory))
+
+ (it "org-gtd-show-all-next"
+     (org-gtd-show-all-next)))

--- a/test/helpers/autoload-setup.el
+++ b/test/helpers/autoload-setup.el
@@ -1,0 +1,22 @@
+;; NEVER put loads or requires in here.  That's the point of this helper: to
+;; help test things in an environment where things aren't loaded.
+
+(defun ogt--prepare-gtd-directory ()
+  "Run before autoload test that needs the gtd directory to exist."
+  (setq org-gtd-directory (make-temp-file "org-gtd" t)))
+
+(defmacro ogt--with-temp-org-buffer (contents &rest body)
+  "Like `with-temp-buffer', but in Org mode.
+
+CONTENTS is inserted and point is set to the buffer's beginning
+before running BODY."
+  (declare (debug t))
+  `(with-temp-buffer
+     (org-mode)
+     (insert ,contents)
+     (goto-char 1)
+     ,@body))
+
+(defun ogt--clear-gtd-directory ()
+  "Clean up after `ogt--prepare-gtd-directory'."
+  (delete-directory org-gtd-directory t))

--- a/test/helpers/setup.el
+++ b/test/helpers/setup.el
@@ -46,3 +46,17 @@
     (with-current-buffer buffer
       (revert-buffer t t)))
   (kill-buffer buffer))
+
+(defun ogt--recursive-eldev-test (file)
+  (unless (file-readable-p (file-name-concat "test" file))
+    (error "Cannot find or read file %s" file))
+  (with-temp-buffer
+    (prog1 (call-process
+            eldev-shell-command
+            nil
+            t
+            nil
+            "test"
+            "-f"
+            file)
+      (princ (buffer-substring 1 (point-max))))))


### PR DESCRIPTION
This PR fixes the problem where you get `Symbol’s value as variable is void: org-gtd-archive-location` or similar such-and-such-is-undefined errors if you don't do an explicit `(require 'org-gtd)`, making autoloads useless.


# Steps to reproduce

Short version: do `M-x org-gtd-engage` when org-gtd is installed and activated but not loaded.

Long version: assuming Emacs 29.1, make a fresh directory containing an `init.el` file with the following contents and nothing else.

    (require 'package)
    (setq package-archives
          '(("gnu" . "http://elpa.gnu.org/packages/")
            ("melpa" . "http://melpa.org/packages/")))
    
    (require 'use-package)
    (use-package org-gtd
      :ensure t
      :defer t ; Note this is implied by :bind, which is almost always used.
      :init
      (setq org-gtd-update-ack "3.0.0")
      :config
      (org-gtd-mode 1))

1.  Invoke `emacs --init-directory=<that directory>`, wait for it to download and install org-gtd.
2.  Restart emacs with the same arguments.  (Restart is necessary because byte-compilation of org-gtd apparently causes bits of it to be loaded.)
3.  Do `M-x org-gtd-engage`.

Result:
`org-gtd-engage: Symbol’s value as variable is void: org-gtd-archive-location`


# Cause

1.  Emacs calls `package-activate-all` at startup, which loads `org-gtd-autoloads.el`, which sets `org-gtd-engage` to be loaded from `org-gtd-agenda.el`.
2.  `org-gtd-engage` uses `with-org-gtd-context`, but `org-gtd-agenda.el` doesn't load all the packages this macro requires, in particular `org-gtd-archive.el`.

Similar problems abound for other autoloaded functions.  The root of the problem is that `with-org-gtd-context` tightly couples `org-gtd-agenda.el`, `org-gtd-projects.el`, `org-gtd-delegate`, and `org-gtd-core.el`, but these modules are not (cannot be) set up to require each other for fear of recursive `require`.


# Fix

I fixed it by adding `require` for `org-gtd-agenda` et al. from the code generated by `with-org-gtd-context`.

I also added a missing `(require 'f)` in `org-gtd-core.el` while I was at it.  You can tickle this bug by removing `org-gtd-core.elc` before doing `org-gtd-engage`, which complains that `-flatten` is undefined.

