### PR TITLE
Fix issues in the duplicate item clarification workflow

### DIFF
--- a/org-gtd-wip.el
+++ b/org-gtd-wip.el
@@ -35,7 +35,7 @@
 
 ;;;; Constants
 
-(defconst org-gtd-wip--prefix "Org-GTD Clarify")
+(defconst org-gtd-wip--prefix "Org GTD Clarify")
 
 (defconst org-gtd-wip--max-filename-id-length 80
   "Maximum length for ID portion in temp filenames.


### PR DESCRIPTION
This PR addresses the following issues when clarifying duplicate items from the queue:

- The heading retains the original title instead of updating to the new one provided by the user
- The queue is removed from display after `org-gtd-clarify-setup-windows` due to `delete-other-windows`
- The duplicate items share the same ID as the original, which can cause conflicts when referenced by projects
- The buffer name does not use `org-gtd-id-get-create`, which can cause confusion
- During clarification, the current item is popped from the queue, and only the remaining items can be saved if the user cancels the clarification
- The WIP buffer prefix `Org-GTD Clarify` is inconsistent with other temporary buffers that use `Org GTD ...`

Note that the logic of `org-gtd-clarify-item` can be reused if we persist the item to `inbox.org` immediately after popping it from the queue. This allows the generation of an Org GTD ID, consistent with the standard clarification process where the Org GTD ID remains in the inbox unless organized. This also prevents the data loss when canceling the clarification.