### PR TITLE
docs: fix for getting started workflow

### DIFF
--- a/doc/getting-started-existing-org-workflow.org
+++ b/doc/getting-started-existing-org-workflow.org
@@ -59,7 +59,7 @@ This goes to org-gtd's inbox (separate from your existing files).
 M-x org-gtd-process-inbox RET
 #+end_example
 
-The item appears. Press ~C-c c~ to organize, then ~s~ for single action.
+The item appears. Press ~M-x org-gtd-organize~ to organize, then ~s~ for single action.
 
 ** Step 4: See It in the GTD View
 


### PR DESCRIPTION
In the "Adding org-gtd to Your Existing Org-Mode Workflow", C-c c isn't bound to org-gtd-organize, so spell out the command instead of referring to the key binding.