### PR TITLE
Checklists and guided Weekly Review (CHK-01/REF-02)

### DIFF
--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -20,6 +20,19 @@ Parse the ARGUMENTS line and pass it through:
 | (none) / `all` | Full suite |
 | `test/unit/foo-test.el` | Single file |
 | `unit` / `integration` / `acceptance` | Category |
+| `--seed=N` | Pin e-unit's shuffle order (reproduce a flake); combine with any target |
+
+### Reproducing order-dependent flakes
+
+The suite shuffles file/test order each run; the summary always prints the
+seed used. If a run fails, re-run with that exact seed to reproduce:
+
+```bash
+.claude/skills/test/run-tests.sh --seed=1783402152928884
+```
+
+`--seed=N` can be combined with a file or category, e.g.
+`run-tests.sh --seed=42 test/unit/accessors-test.el`.
 
 ### Resolving test names
 
@@ -31,7 +44,7 @@ If the argument contains `/` but no `.el` (looks like a test name, e.g. `stuck-s
 
 The script returns one of:
 
-**Success:** `PASS: 1195 tests in 18.4s`
+**Success:** `PASS: 1195 tests in 18.4s` followed by `Seed: <N>`
 
 **Failure:** Summary line + full failure/error details (test name, expected/actual, file:line)
 

--- a/.claude/skills/test/run-tests.sh
+++ b/.claude/skills/test/run-tests.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 # Run eldev etest and output only a clean summary.
 # Usage:
-#   run-tests.sh                    # all tests
-#   run-tests.sh test/unit/foo.el   # single file
-#   run-tests.sh unit               # category (unit/integration/acceptance)
+#   run-tests.sh                       # all tests
+#   run-tests.sh test/unit/foo.el      # single file
+#   run-tests.sh unit                  # category (unit/integration/acceptance)
+#   run-tests.sh --seed=N              # all tests, pinned ordering (reproduce a flake)
+#   run-tests.sh --seed=N test/unit/foo.el
+#
+# The seed controls e-unit's file/test shuffle order.  The summary always
+# reports the seed that was used, so any failure can be reproduced by passing
+# the same --seed=N back in.
 set -euo pipefail
 
 PROJECT_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
@@ -12,15 +18,28 @@ cd "$PROJECT_DIR"
 # Build the eldev command
 CMD=(~/bin/eldev etest -r dot)
 
-case "${1:-all}" in
+# Collect an optional --seed=N (order-independent) and a single target argument.
+TARGET=""
+for arg in "$@"; do
+  case "$arg" in
+    --seed=*)
+      CMD+=("$arg")
+      ;;
+    *)
+      TARGET="$arg"
+      ;;
+  esac
+done
+
+case "${TARGET:-all}" in
   all)
     ;; # no extra args
   unit|integration|acceptance)
-    CMD+=("test/$1/")
+    CMD+=("test/$TARGET/")
     ;;
   *)
     # Treat as file path
-    CMD+=("$1")
+    CMD+=("$TARGET")
     ;;
 esac
 
@@ -47,9 +66,11 @@ TIME=$(echo "$DURATION" | grep -oP '[\d.]+s' || echo "?s")
 
 if [ "$FAILED" = "0" ] && [ "$ERRORS" = "0" ]; then
   echo "PASS: $TOTAL tests in $TIME"
+  [ -n "$SEED" ] && echo "Seed: $SEED"
+  exit 0
 else
   echo "FAIL: $SUMMARY ($TIME)"
-  [ -n "$SEED" ] && echo "Seed: $SEED"
+  [ -n "$SEED" ] && echo "Seed: $SEED (reproduce with: run-tests.sh --seed=$SEED)"
   echo ""
   # Extract failure and error blocks — everything from "Failures:" or "Errors:" to "Finished in"
   # Strip file-save noise from the detail blocks

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -41,6 +41,27 @@ The registry module and command have been renamed from
 compatibility via ~define-obsolete-function-alias~, ~defvaralias~, and a
 dual ~(provide 'org-gtd-single-action)~.
 
+*** Checklists
+New =checklists.org= file of reusable checklist templates in
+~org-gtd-directory~, seeded on first touch with Weekly Review starter
+lists. Each top-level heading is a template; ~org-gtd-checklist-insert~
+stamps a fresh copy at point, and ~org-gtd-checklist-visit~ opens the
+file for editing. Checkboxes now reset automatically — subtree-wide,
+statistics cookies included — when a repeating heading re-arms.
+
+*** Guided review sessions
+~org-gtd-review~ runs guided, pausable, customizable review sessions;
+a Weekly Review profile ships as the default value of
+~org-gtd-review-profiles~. Sessions checkpoint to disk at every step,
+so pausing, killing the buffer, or crashing loses nothing.
+~org-gtd-review-schedule~ creates a recurring habit reminder, and
+~org-gtd-init-system~ is an idempotent first-run concierge that
+creates the GTD files and offers to schedule the review.
+
+*** Command center: =w= and =l=
+The Reflect column gains =w= (guided Weekly Review) and =l= (visit the
+checklists file).
+
 ** Changed
 *** Disposition runner now sets TODO state before archiving
 The =done-and-archive= and =cancel-and-archive= dispositions explicitly

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -55,7 +55,7 @@ a Weekly Review profile ships as the default value of
 ~org-gtd-review-profiles~. Sessions checkpoint to disk at every step,
 so pausing, killing the buffer, or crashing loses nothing.
 ~org-gtd-review-schedule~ creates a recurring habit reminder, and
-~org-gtd-init-system~ is an idempotent first-run concierge that
+~org-gtd-init-system~ is an idempotent first-run setup command that
 creates the GTD files and offers to schedule the review.
 
 *** Command center: =w= and =l=

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -42,10 +42,10 @@ compatibility via ~define-obsolete-function-alias~, ~defvaralias~, and a
 dual ~(provide 'org-gtd-single-action)~.
 
 *** Checklists
-New =checklists.org= file of reusable checklist templates in
+New =checklist-templates.org= file of reusable checklist templates in
 ~org-gtd-directory~, seeded on first touch with Weekly Review starter
-lists. Each top-level heading is a template; ~org-gtd-checklist-insert~
-stamps a fresh copy at point, and ~org-gtd-checklist-visit~ opens the
+lists. Each top-level heading is a template; ~org-gtd-checklist-template-insert~
+stamps a fresh copy at point, and ~org-gtd-checklist-template-visit~ opens the
 file for editing. Checkboxes now reset automatically — subtree-wide,
 statistics cookies included — when a repeating heading re-arms.
 
@@ -60,7 +60,7 @@ creates the GTD files and offers to schedule the review.
 
 *** Command center: =w= and =l=
 The Reflect column gains =w= (guided Weekly Review) and =l= (visit the
-checklists file).
+checklist templates file).
 
 ** Changed
 *** Disposition runner now sets TODO state before archiving

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -48,6 +48,9 @@ lists. Each top-level heading is a template; ~org-gtd-checklist-template-insert~
 stamps a fresh copy at point, and ~org-gtd-checklist-template-visit~ opens the
 file for editing. Checkboxes now reset automatically — subtree-wide,
 statistics cookies included — when a repeating heading re-arms.
+~org-gtd-upgrade-v4-to-v5~ scans your agenda files and reports existing
+repeating headings that already carry checkboxes, so this new reset
+behavior never takes you by surprise.
 
 *** Guided review sessions
 ~org-gtd-review~ runs guided, pausable, customizable review sessions;

--- a/Eldev
+++ b/Eldev
@@ -40,8 +40,12 @@
   "Whether to show verbose output.")
 (defvar org-gtd-etest-stop-on-failure nil
   "Whether to stop on first failure.")
+(defvar org-gtd-etest-seed nil
+  "Fixed random seed for reproducible test ordering.
+When nil, e-unit picks a random seed.  Set with `--seed=N' to
+reproduce a specific ordering (e.g. a seed-dependent flake).")
 
-(eldev-defcommand org-gtd-etest (&rest _parameters)
+(eldev-defcommand org-gtd-etest (&rest parameters)
   "Run e-unit tests.
 
 E-unit tests are in the test/ directory with subdirectories:
@@ -49,7 +53,12 @@ E-unit tests are in the test/ directory with subdirectories:
   - test/integration/ Integration tests
   - test/acceptance/  Acceptance tests
 
-E-unit now searches recursively, so we just point it at the root test directory."
+With no PARAMETERS, runs every test under test/ recursively.
+Each PARAMETER may be a test file or a directory; only the given
+targets are run.  Examples:
+  eldev etest test/unit/accessors-test.el
+  eldev etest test/integration
+  eldev etest --seed=1783402152928884            ; reproduce an ordering"
   :aliases    (etest)
   :category   testing
 
@@ -58,37 +67,51 @@ E-unit now searches recursively, so we just point it at the root test directory.
 
   (eldev-load-project-dependencies 'test)
   (require 'e-unit)
+  ;; Install the short-syntax aliases (deftest, setup-suite, around-each,
+  ;; assert-*, ...) up front.  Test-helper files call these at load time, so
+  ;; they must exist before any single file is loaded -- otherwise running one
+  ;; file in isolation fails with "Symbol's function definition is void:
+  ;; setup-suite" (in a full run an earlier file happens to initialize first).
+  (e-unit-initialize)
 
-  (let ((root-dir "test"))
+  ;; Configure e-unit.  Pin the seed when one was requested so the run
+  ;; is reproducible; otherwise e-unit picks a random seed.
+  (e-unit-configure :verbose org-gtd-etest-verbose
+                    :stop-on-failure org-gtd-etest-stop-on-failure
+                    :seed org-gtd-etest-seed)
 
-    ;; Configure e-unit
-    (e-unit-configure :verbose org-gtd-etest-verbose
-                      :stop-on-failure org-gtd-etest-stop-on-failure)
+  ;; Set reporter
+  (e-unit-set-reporter org-gtd-etest-reporter)
 
-    ;; Set reporter
-    (e-unit-set-reporter org-gtd-etest-reporter)
+  ;; Resolve targets: explicit parameters, or the whole test/ tree.
+  (let ((targets (or parameters '("test"))))
+    (dolist (target targets)
+      (unless (file-exists-p target)
+        (error "Test target does not exist: %s" target)))
 
-    ;; Check if test directory exists
-    (if (not (file-directory-p root-dir))
-        (message "No test directory found (%s). Create it and add *-test.el files to run e-unit tests." root-dir)
+    ;; Run each target (directory -> recursive, file -> single file),
+    ;; accumulating results so the exit code reflects the whole run.
+    (let ((results '()))
+      (dolist (target targets)
+        (setq results
+              (append results
+                      (if (file-directory-p target)
+                          (e-unit-run-directory target)
+                        (e-unit-run-file target)))))
 
-      ;; Run all tests recursively from root directory
-      (let ((results (e-unit-run-directory root-dir)))
+      (if (null results)
+          (message "No e-unit tests executed")
 
-        (if (null results)
-            (message "No e-unit tests executed")
+        (let ((passed (length (cl-remove-if-not
+                               (lambda (r) (eq (plist-get r :status) 'pass))
+                               results)))
+              (failed (length (cl-remove-if-not
+                               (lambda (r) (memq (plist-get r :status) '(fail error)))
+                               results))))
 
-          (let* ((total (length results))
-                 (passed (length (cl-remove-if-not
-                                  (lambda (r) (eq (plist-get r :status) 'pass))
-                                  results)))
-                 (failed (length (cl-remove-if-not
-                                  (lambda (r) (memq (plist-get r :status) '(fail error)))
-                                  results))))
-
-            ;; Update Eldev counters - this sets the exit code
-            (setq eldev-test-num-passed passed)
-            (setq eldev-test-num-failed failed)))))))
+          ;; Update Eldev counters - this sets the exit code
+          (setq eldev-test-num-passed passed)
+          (setq eldev-test-num-failed failed))))))
 
 ;; Define options for etest command
 ;; Note: command name is gtd-etest (eldev strips "org-" prefix)
@@ -111,3 +134,10 @@ E-unit now searches recursively, so we just point it at the root test directory.
   :options        (-s --stop)
   :for-command    gtd-etest
   (setf org-gtd-etest-stop-on-failure t))
+
+(eldev-defoption org-gtd-etest-set-seed (seed)
+  "Pin the random seed for reproducible test ordering"
+  :options        (--seed)
+  :for-command    gtd-etest
+  :value          N
+  (setf org-gtd-etest-seed (string-to-number seed)))

--- a/doc/reference.org
+++ b/doc/reference.org
@@ -598,7 +598,7 @@ After configuring, run ~M-x org-gtd-reflect-missed-with-custom~ to see all stand
 
 *Default*: A complete Weekly Review profile in three phases: Get Clear, Get Current, Get Creative
 
-*Purpose*: Defines the ritual ~org-gtd-review~ walks you through. Each phase is ~(PHASE-NAME . STEPS)~; each step is a plist with ~:title~, ~:type~ (one of ~prompt~, ~command~, ~view~, ~checklist~), an optional ~:instruction~, and the type-specific key ~:command~, ~:view~, or ~:checklist~ (a template name from your checklists file).
+*Purpose*: Defines the ritual ~org-gtd-review~ walks you through. Each phase is ~(PHASE-NAME . STEPS)~; each step is a plist with ~:title~, ~:type~ (one of ~prompt~, ~command~, ~view~, ~checklist~), an optional ~:instruction~, and the type-specific key ~:command~, ~:view~, or ~:checklist~ (a template name from your checklist templates file).
 
 *When to customize*: To reorder or trim the Weekly Review, point ~:view~ steps at your own views, or add profiles of your own (a daily shutdown, a monthly horizons review). With several profiles configured, ~org-gtd-review~ prompts for which one to run.
 
@@ -934,7 +934,7 @@ This section lists all interactive commands available in org-gtd, organized by w
 | d   | Reflect: upcoming delegated       |
 | r   | Reflect: completed items          |
 | R   | Reflect: completed projects       |
-| l   | Reflect: checklists               |
+| l   | Reflect: checklist templates      |
 | A   | Archive completed items           |
 | S   | Stuck items sub-menu              |
 | M   | Missed items sub-menu             |
@@ -1526,23 +1526,23 @@ Both are valuable. Missed helps you catch problems. Upcoming helps you prevent t
 
 *** Checklist Commands
 
-**** ~org-gtd-checklist-insert~
+**** ~org-gtd-checklist-template-insert~
 
 *When to use*: Whenever you need a fresh copy of a reusable checklist (a packing list, release steps, mind-sweep triggers)
 
 *What it does*:
-- Offers the template names from =checklists.org= for completion
+- Offers the template names from =checklist-templates.org= for completion
 - Inserts a fresh copy of the chosen template as a subtree at point (on a heading line, as that heading's first child)
 - The copy is plain org; org-gtd does not track it
 
-**** ~org-gtd-checklist-visit~
+**** ~org-gtd-checklist-template-visit~
 
 *Binding*: ~l~ from the command center
 
 *When to use*: To add, edit, or retire checklist templates
 
 *What it does*:
-- Opens =checklists.org= in ~org-gtd-directory~, creating and seeding it with starter templates on first use
+- Opens =checklist-templates.org= in ~org-gtd-directory~, creating and seeding it with starter templates on first use
 - Each top-level heading is a template; editing this file is how you customize your checklists
 
 See [[#checklists][Checklists]] for the file format, the checkbox reset on repeat, and the recurring-checklist pattern.
@@ -2551,7 +2551,7 @@ These commands create GTD items programmatically (useful for automation and Emac
 *When to use*: First-time setup (safe to run again at any time)
 
 *What it does*:
-- Ensures ~org-gtd-directory~ and the GTD files exist: the tasks file, the inbox, and =checklists.org= with its starter templates
+- Ensures ~org-gtd-directory~ and the GTD files exist: the tasks file, the inbox, and =checklist-templates.org= with its starter templates
 - Offers to schedule a recurring Weekly Review via ~org-gtd-review-schedule~ (skips the offer when a reminder already exists)
 - Idempotent: anything already in place is simply reported as ready
 

--- a/doc/reference.org
+++ b/doc/reference.org
@@ -590,6 +590,20 @@ After configuring, run ~M-x org-gtd-reflect-missed-with-custom~ to see all stand
 
 *Backward compatibility*: The old variable name ~org-gtd-oops-custom-views~ still works but will be removed in a future version.
 
+*** Guided Review Configuration
+
+**** ~org-gtd-review-profiles~
+
+*Type*: Alist of ~(PROFILE-NAME . PHASES)~
+
+*Default*: A complete Weekly Review profile in three phases: Get Clear, Get Current, Get Creative
+
+*Purpose*: Defines the ritual ~org-gtd-review~ walks you through. Each phase is ~(PHASE-NAME . STEPS)~; each step is a plist with ~:title~, ~:type~ (one of ~prompt~, ~command~, ~view~, ~checklist~), an optional ~:instruction~, and the type-specific key ~:command~, ~:view~, or ~:checklist~ (a template name from your checklists file).
+
+*When to customize*: To reorder or trim the Weekly Review, point ~:view~ steps at your own views, or add profiles of your own (a daily shutdown, a monthly horizons review). With several profiles configured, ~org-gtd-review~ prompts for which one to run.
+
+See [[#guided-review][Weekly Review (guided)]] for the full default value and a step-by-step explanation.
+
 *** Advanced Item Configuration
 
 **** ~org-gtd-user-types~
@@ -914,11 +928,13 @@ This section lists all interactive commands available in org-gtd, organized by w
 | c   | Capture to inbox                  |
 | p   | Process inbox                     |
 | k   | Clarify item at point             |
+| w   | Reflect: Weekly Review (guided)   |
 | a   | Reflect: area of focus            |
 | y   | Reflect: someday/maybe            |
 | d   | Reflect: upcoming delegated       |
 | r   | Reflect: completed items          |
 | R   | Reflect: completed projects       |
+| l   | Reflect: checklists               |
 | A   | Archive completed items           |
 | S   | Stuck items sub-menu              |
 | M   | Missed items sub-menu             |
@@ -1025,6 +1041,35 @@ C-c C-c to save
 - Useful for "get things done" focus mode
 
 *** Reflect Commands
+
+**** ~org-gtd-review~
+
+*Binding*: ~w~ from the command center
+
+*When to use*: Weekly, or whenever you sit down for a full review
+
+*What it does*:
+- Runs a guided, step-by-step review session in a =*GTD Review*= console buffer
+- The ritual comes from ~org-gtd-review-profiles~ (a Weekly Review ships as the default; with several profiles configured, prompts for one)
+- Keys: ~n~ do/advance, ~s~ skip, ~c~ capture, ~p~ pause, ~q~ quit
+- Checkpoints progress to disk at every step, so a paused (or crashed) session is offered for resumption on the next invocation
+
+*Arguments*: Optional PROFILE-NAME to select a profile non-interactively
+
+See [[#guided-review][Weekly Review (guided)]] for the full walkthrough.
+
+**** ~org-gtd-review-schedule~
+
+*When to use*: Once, to make the review a recurring commitment
+
+*What it does*:
+- Prompts for a profile (when you have several), a first date, and an org repeater (e.g. ~.+1w~)
+- Creates a habit named after the profile, so the reminder appears in your engage view
+- Validates the repeater and asks before scheduling a duplicate reminder
+
+*Arguments*: Optional PROFILE-NAME, DATE (~YYYY-MM-DD~), and REPEATER
+
+See [[#guided-review][Weekly Review (guided)]] for details.
 
 **** ~org-gtd-reflect-stuck-projects~
 
@@ -1478,6 +1523,29 @@ Both are valuable. Missed helps you catch problems. Upcoming helps you prevent t
 | Command | Shows | Use When |
 |---------|-------|----------|
 | ~org-gtd-reflect-upcoming-delegated~ | All delegated items with future check-in dates | Weekly planning, early completion responses |
+
+*** Checklist Commands
+
+**** ~org-gtd-checklist-insert~
+
+*When to use*: Whenever you need a fresh copy of a reusable checklist (a packing list, release steps, mind-sweep triggers)
+
+*What it does*:
+- Offers the template names from =checklists.org= for completion
+- Inserts a fresh copy of the chosen template as a subtree at point (on a heading line, as that heading's first child)
+- The copy is plain org; org-gtd does not track it
+
+**** ~org-gtd-checklist-visit~
+
+*Binding*: ~l~ from the command center
+
+*When to use*: To add, edit, or retire checklist templates
+
+*What it does*:
+- Opens =checklists.org= in ~org-gtd-directory~, creating and seeding it with starter templates on first use
+- Each top-level heading is a template; editing this file is how you customize your checklists
+
+See [[#checklists][Checklists]] for the file format, the checkbox reset on repeat, and the recurring-checklist pattern.
 
 *** Custom View Commands
 
@@ -2477,6 +2545,19 @@ These commands create GTD items programmatically (useful for automation and Emac
 #+end_src
 
 *** Utility Commands
+
+**** ~org-gtd-init-system~
+
+*When to use*: First-time setup (safe to run again at any time)
+
+*What it does*:
+- Ensures ~org-gtd-directory~ and the GTD files exist: the tasks file, the inbox, and =checklists.org= with its starter templates
+- Offers to schedule a recurring Weekly Review via ~org-gtd-review-schedule~ (skips the offer when a reminder already exists)
+- Idempotent: anything already in place is simply reported as ready
+
+*Does not*: touch ~org-agenda-files~ or TODO keywords — those remain manual configuration (see [[#configuring][Configuring]])
+
+See [[#guided-review][Weekly Review (guided)]] for details.
 
 **** ~org-gtd-setup-keywords-wizard~
 

--- a/doc/setting-up-org-gtd.org
+++ b/doc/setting-up-org-gtd.org
@@ -761,7 +761,7 @@ The command center is organized for both discovery and quick access:
 
 - *Engage* (~e~, ~@~, ~n~) :: What to work on now
 - *Capture & Process* (~c~, ~p~, ~k~) :: Add items and process inbox
-- *Reflect* (~w~, ~a~, ~y~, ~d~, ~r~, ~R~, ~l~) :: Guided Weekly Review, review areas, someday items, completed work, checklists
+- *Reflect* (~w~, ~a~, ~y~, ~d~, ~r~, ~R~, ~l~) :: Guided Weekly Review, review areas, someday items, completed work, checklist templates
 - *Review System* (~S~, ~M~) :: Sub-menus for stuck and missed items
 - *Archive* (~A~) :: Archive completed items
 

--- a/doc/setting-up-org-gtd.org
+++ b/doc/setting-up-org-gtd.org
@@ -220,6 +220,8 @@ You need to configure three things for org-gtd to work:
 
 See the configuration sections below for details.
 
+To create the GTD files and optionally schedule a recurring Weekly Review reminder in one step, run ~M-x org-gtd-init-system~ (see [[#guided-review][Weekly Review (guided)]]).
+
 *Optional*: Enable ~org-gtd-mode~ if you want to see your inbox count in the mode-line (e.g., =GTD[5]=).
 
 *** Complete Configuration Examples
@@ -759,7 +761,7 @@ The command center is organized for both discovery and quick access:
 
 - *Engage* (~e~, ~@~, ~n~) :: What to work on now
 - *Capture & Process* (~c~, ~p~, ~k~) :: Add items and process inbox
-- *Reflect* (~a~, ~y~, ~d~, ~r~, ~R~) :: Review areas, someday items, completed work
+- *Reflect* (~w~, ~a~, ~y~, ~d~, ~r~, ~R~, ~l~) :: Guided Weekly Review, review areas, someday items, completed work, checklists
 - *Review System* (~S~, ~M~) :: Sub-menus for stuck and missed items
 - *Archive* (~A~) :: Archive completed items
 

--- a/doc/using-org-gtd.org
+++ b/doc/using-org-gtd.org
@@ -34,6 +34,7 @@ These are the commands you'll use most:
 | ~org-gtd-engage~ | See actionable items | Daily (your "work from" view) |
 | ~org-gtd-show-all-next~ | See only NEXT actions | When you want to focus on actions |
 | ~org-gtd-review~ | Guided Weekly Review session | Weekly |
+| ~org-gtd-checklist-insert~ | Insert a reusable checklist at point | Packing lists, release steps, mind sweeps |
 | ~org-gtd-reflect-stuck-projects~ | Find stuck projects | Weekly review |
 | ~org-gtd-reflect-someday-review~ | Review someday items one-by-one | Weekly/monthly review |
 | ~org-gtd-projects-fix-all-todo-keywords~ | Fix task states after external edits | After mobile/web edits |
@@ -576,13 +577,15 @@ Now it's a real habit: ~org-gtd-engage~ shows it on schedule, you work through t
 
 When a repeating heading *re-arms* — you mark it done and org's repeater flips it back to a not-done state for the next occurrence — org-gtd clears every checkbox in that heading's subtree, including boxes under child headings, and updates any ~[1/3]~-style statistics cookies. The next run starts fresh.
 
-The guard mirrors org's own re-arm rule exactly, so the reset happens only when org actually re-arms the heading:
+The reset follows org's own re-arm rule exactly — it happens only when org actually re-arms the heading:
 
 - A heading with no repeater never resets: a plain ~DONE~ keeps its record.
 - A zero-interval repeater (like ~.+0w~, org's idiom for "this repeating task is finished for good") does not re-arm, so the checked boxes are preserved.
 - A done-to-done transition (e.g. changing ~DONE~ to ~CANCELED~) doesn't reset.
 
 This applies to *every* repeating heading with checkboxes — spawned from a template or written by hand. The hook is installed by ~org-gtd-mode~.
+
+*See also*: [[#commands-reference][Commands Reference]] for ~org-gtd-checklist-insert~ and ~org-gtd-checklist-visit~.
 
 ** Weekly Review (guided)
 :PROPERTIES:
@@ -700,6 +703,8 @@ If a reminder for one of your profiles already exists, the command asks before s
 Two things it deliberately does *not* do, because they belong in your Emacs configuration: adding your GTD files to ~org-agenda-files~, and TODO keyword setup. Those remain manual steps — see [[#configuring][Configuring]].
 
 You never /have/ to run it: every file it creates is also created lazily the first time something needs it.
+
+*See also*: [[#commands-reference][Commands Reference]] for ~org-gtd-review~, ~org-gtd-review-schedule~, and ~org-gtd-init-system~, and [[#config-vars-reference][Configuration Variables Reference]] for ~org-gtd-review-profiles~.
 
 ** Understanding GTD Item Types
 :PROPERTIES:
@@ -911,6 +916,8 @@ This means a delegated action moved to someday will remember who it was delegate
 - Shows habit graph in agenda views
 
 *Note*: See org-mode documentation for habit repeat patterns and tracking.
+
+*See also*: [[#recurring-checklists][Recurring checklists: compose with habits]] for turning a reusable checklist into a repeating habit whose checkboxes reset on each repeat.
 
 *** Knowledge [K]
 

--- a/doc/using-org-gtd.org
+++ b/doc/using-org-gtd.org
@@ -34,7 +34,7 @@ These are the commands you'll use most:
 | ~org-gtd-engage~ | See actionable items | Daily (your "work from" view) |
 | ~org-gtd-show-all-next~ | See only NEXT actions | When you want to focus on actions |
 | ~org-gtd-review~ | Guided Weekly Review session | Weekly |
-| ~org-gtd-checklist-insert~ | Insert a reusable checklist at point | Packing lists, release steps, mind sweeps |
+| ~org-gtd-checklist-template-insert~ | Insert a reusable checklist at point | Packing lists, release steps, mind sweeps |
 | ~org-gtd-reflect-stuck-projects~ | Find stuck projects | Weekly review |
 | ~org-gtd-reflect-someday-review~ | Review someday items one-by-one | Weekly/monthly review |
 | ~org-gtd-projects-fix-all-todo-keywords~ | Fix task states after external edits | After mobile/web edits |
@@ -527,13 +527,13 @@ The command isn't bound by default because org-agenda-mode already has many keyb
 :CUSTOM_ID: checklists
 :END:
 
-Some lists you use over and over: packing for a trip, releasing software, the trigger list of a Weekly Review mind sweep. org-gtd stores these as templates in a file called ~checklists.org~ in ~org-gtd-directory~, and lets you stamp out a fresh copy whenever you need one.
+Some lists you use over and over: packing for a trip, releasing software, the trigger list of a Weekly Review mind sweep. org-gtd stores these as templates in a file called ~checklist-templates.org~ in ~org-gtd-directory~, and lets you stamp out a fresh copy whenever you need one.
 
 The file is created the first time anything touches it, seeded with two starter templates: "Weekly Review triggers" and "Mind sweep prompts". They're yours — edit or delete them freely.
 
 *** The template file
 
-Each top-level heading in ~checklists.org~ is a template; its checkbox items are the checklist:
+Each top-level heading in ~checklist-templates.org~ is a template; its checkbox items are the checklist:
 
 #+begin_example
 ,* Beach packing
@@ -547,13 +547,13 @@ Two conventions to respect:
 - Templates are *top-level headings*. Sub-headings inside a template are copied along when you spawn it, but only top-level headings appear as template names.
 - Items are *dash-style checkboxes* (~- [ ]~). Other list bullets are not recognized as checklist items.
 
-That's the whole format: no TODO keywords, no properties, nothing org-gtd-specific. *Editing this file is how you customize your checklists.* Open it with ~M-x org-gtd-checklist-visit~ (or ~l~ from the command center) and use ordinary org editing. A heading marked with org's ~COMMENT~ keyword is ignored — a handy way to retire a template without deleting it.
+That's the whole format: no TODO keywords, no properties, nothing org-gtd-specific. *Editing this file is how you customize your checklists.* Open it with ~M-x org-gtd-checklist-template-visit~ (or ~l~ from the command center) and use ordinary org editing. A heading marked with org's ~COMMENT~ keyword is ignored — a handy way to retire a template without deleting it.
 
 The file is not part of your agenda: templates are content, not tasks.
 
 *** Spawning a checklist
 
-Call ~M-x org-gtd-checklist-insert~ in any org buffer. It offers your template names for completion, then inserts a fresh copy of the chosen template as a subtree:
+Call ~M-x org-gtd-checklist-template-insert~ in any org buffer. It offers your template names for completion, then inserts a fresh copy of the chosen template as a subtree:
 
 - On a heading line, the copy becomes the *first child* of that heading.
 - In body text, the copy is inserted at point, as a child of the heading you're under (or as a top-level heading when there's no heading above point).
@@ -567,7 +567,7 @@ The copy is plain org. org-gtd does not track it, and checking off its boxes nev
 
 Want your packing list — or your mind-sweep trigger list — as a recurring task in your system? Compose the pieces you already have:
 
-1. In your inbox (or any org file), ~M-x org-gtd-checklist-insert~ and pick the template.
+1. In your inbox (or any org file), ~M-x org-gtd-checklist-template-insert~ and pick the template.
 2. ~M-x org-gtd-clarify-item~ on the new heading; rename it if you like.
 3. Organize it as a *Habit* with a repeater (say, ~.+1w~).
 
@@ -585,7 +585,7 @@ The reset follows org's own re-arm rule exactly — it happens only when org act
 
 This applies to *every* repeating heading with checkboxes — spawned from a template or written by hand. The hook is installed by ~org-gtd-mode~.
 
-*See also*: [[#commands-reference][Commands Reference]] for ~org-gtd-checklist-insert~ and ~org-gtd-checklist-visit~.
+*See also*: [[#commands-reference][Commands Reference]] for ~org-gtd-checklist-template-insert~ and ~org-gtd-checklist-template-visit~.
 
 ** Weekly Review (guided)
 :PROPERTIES:
@@ -620,7 +620,7 @@ A review is made of four kinds of steps. Here's what ~n~ does on each:
 - prompt :: Read the instruction, do the thing in the real world, press ~n~ to move on.
 - command :: Two presses. The first ~n~ runs the step's command (for example ~org-gtd-process-inbox~). When you're done, come back to the review buffer and press ~n~ again to confirm and advance — or ~s~ if you're leaving it unfinished. If the command signals an error, the step doesn't count as started; ~n~ simply retries it.
 - view :: Two presses, same shape. The first ~n~ opens the step's agenda view in another window; browse it and act on what needs acting. The second ~n~ advances.
-- checklist :: Walks the items of a named template from your [[#checklists][checklists file]], one item at a time. The first ~n~ shows the first item; each further ~n~ shows the next; press ~c~ whenever an item shakes something loose. The template file itself is never modified. An empty or missing checklist just says so and moves on.
+- checklist :: Walks the items of a named template from your [[#checklists][checklist templates file]], one item at a time. The first ~n~ shows the first item; each further ~n~ shows the next; press ~c~ whenever an item shakes something loose. The template file itself is never modified. An empty or missing checklist just says so and moves on.
 
 *** Pause, resume, and crash recovery
 
@@ -630,7 +630,7 @@ There is a single checkpoint slot. Declining the resume offer starts a fresh ses
 
 *** Customizing the ritual: org-gtd-review-profiles
 
-The whole ritual is data. ~org-gtd-review-profiles~ is an alist of profiles; each profile is a list of named phases; each phase is a list of steps; each step is a plist with a ~:title~, a ~:type~ (one of ~prompt~, ~command~, ~view~, ~checklist~), an optional ~:instruction~, and the type-specific key ~:command~, ~:view~, or ~:checklist~ (a template name from your checklists file).
+The whole ritual is data. ~org-gtd-review-profiles~ is an alist of profiles; each profile is a list of named phases; each phase is a list of steps; each step is a plist with a ~:title~, a ~:type~ (one of ~prompt~, ~command~, ~view~, ~checklist~), an optional ~:instruction~, and the type-specific key ~:command~, ~:view~, or ~:checklist~ (a template name from your checklist templates file).
 
 The Weekly Review ships as the default value, so customizing means editing this variable — reorder steps, delete what you don't use, point ~:view~ steps at [[#view-dsl-reference][your own views]], or add entirely new profiles (a daily shutdown, a monthly horizons review). When more than one profile is configured, ~org-gtd-review~ asks which one to run. Malformed profiles are rejected up front with an error that names the offending phase or step and shows the expected shape.
 
@@ -698,7 +698,7 @@ If a reminder for one of your profiles already exists, the command asks before s
 
 *** First-time setup: org-gtd-init-system
 
-~M-x org-gtd-init-system~ is a small first-run concierge. It ensures ~org-gtd-directory~ and the GTD files exist — the tasks file, the inbox, and ~checklists.org~ with its starter templates — and then offers to schedule a recurring Weekly Review (skipping the offer when a reminder already exists). It is idempotent: run it again anytime, and anything already in place is simply reported as ready.
+~M-x org-gtd-init-system~ is a small first-run concierge. It ensures ~org-gtd-directory~ and the GTD files exist — the tasks file, the inbox, and ~checklist-templates.org~ with its starter templates — and then offers to schedule a recurring Weekly Review (skipping the offer when a reminder already exists). It is idempotent: run it again anytime, and anything already in place is simply reported as ready.
 
 Two things it deliberately does *not* do, because they belong in your Emacs configuration: adding your GTD files to ~org-agenda-files~, and TODO keyword setup. Those remain manual steps — see [[#configuring][Configuring]].
 

--- a/doc/using-org-gtd.org
+++ b/doc/using-org-gtd.org
@@ -33,6 +33,7 @@ These are the commands you'll use most:
 | ~org-gtd-organize~ | Organize current item | During processing (in clarify buffer) |
 | ~org-gtd-engage~ | See actionable items | Daily (your "work from" view) |
 | ~org-gtd-show-all-next~ | See only NEXT actions | When you want to focus on actions |
+| ~org-gtd-review~ | Guided Weekly Review session | Weekly |
 | ~org-gtd-reflect-stuck-projects~ | Find stuck projects | Weekly review |
 | ~org-gtd-reflect-someday-review~ | Review someday items one-by-one | Weekly/monthly review |
 | ~org-gtd-projects-fix-all-todo-keywords~ | Fix task states after external edits | After mobile/web edits |
@@ -401,7 +402,7 @@ You can call ~org-gtd-show-all-next~ to only see NEXT actions, nothing scheduled
 
 You can use ~M-x org-gtd-reflect-missed-engagements~ to find appointments you missed, delegated items needing check-ins, and late projects. This is your safety net for catching things that slipped through the cracks.
 
-The weekly review is not yet implemented.
+For the Reflect step's central ritual, org-gtd ships a guided, pausable Weekly Review session: see [[#guided-review][Weekly Review (guided)]].
 
 **** Quick Task Actions from the Agenda
 :PROPERTIES:
@@ -518,6 +519,187 @@ The command isn't bound by default because org-agenda-mode already has many keyb
 #+begin_src emacs-lisp
 (define-key org-agenda-mode-map (kbd "C-c .") #'org-gtd-agenda-transient)
 #+end_src
+
+** Checklists
+:PROPERTIES:
+:DESCRIPTION: Reusable checklist templates you can spawn anywhere
+:CUSTOM_ID: checklists
+:END:
+
+Some lists you use over and over: packing for a trip, releasing software, the trigger list of a Weekly Review mind sweep. org-gtd stores these as templates in a file called ~checklists.org~ in ~org-gtd-directory~, and lets you stamp out a fresh copy whenever you need one.
+
+The file is created the first time anything touches it, seeded with two starter templates: "Weekly Review triggers" and "Mind sweep prompts". They're yours — edit or delete them freely.
+
+*** The template file
+
+Each top-level heading in ~checklists.org~ is a template; its checkbox items are the checklist:
+
+#+begin_example
+,* Beach packing
+- [ ] Sunscreen
+- [ ] Swimsuit
+- [ ] Beach towel
+#+end_example
+
+Two conventions to respect:
+
+- Templates are *top-level headings*. Sub-headings inside a template are copied along when you spawn it, but only top-level headings appear as template names.
+- Items are *dash-style checkboxes* (~- [ ]~). Other list bullets are not recognized as checklist items.
+
+That's the whole format: no TODO keywords, no properties, nothing org-gtd-specific. *Editing this file is how you customize your checklists.* Open it with ~M-x org-gtd-checklist-visit~ (or ~l~ from the command center) and use ordinary org editing. A heading marked with org's ~COMMENT~ keyword is ignored — a handy way to retire a template without deleting it.
+
+The file is not part of your agenda: templates are content, not tasks.
+
+*** Spawning a checklist
+
+Call ~M-x org-gtd-checklist-insert~ in any org buffer. It offers your template names for completion, then inserts a fresh copy of the chosen template as a subtree:
+
+- On a heading line, the copy becomes the *first child* of that heading.
+- In body text, the copy is inserted at point, as a child of the heading you're under (or as a top-level heading when there's no heading above point).
+
+The copy is plain org. org-gtd does not track it, and checking off its boxes never touches the template file.
+
+*** Recurring checklists: compose with habits
+:PROPERTIES:
+:CUSTOM_ID: recurring-checklists
+:END:
+
+Want your packing list — or your mind-sweep trigger list — as a recurring task in your system? Compose the pieces you already have:
+
+1. In your inbox (or any org file), ~M-x org-gtd-checklist-insert~ and pick the template.
+2. ~M-x org-gtd-clarify-item~ on the new heading; rename it if you like.
+3. Organize it as a *Habit* with a repeater (say, ~.+1w~).
+
+Now it's a real habit: ~org-gtd-engage~ shows it on schedule, you work through the boxes, you mark it ~DONE~ — and the checkboxes reset themselves for next time, as described below.
+
+*** Checkbox reset on repeat
+
+When a repeating heading *re-arms* — you mark it done and org's repeater flips it back to a not-done state for the next occurrence — org-gtd clears every checkbox in that heading's subtree, including boxes under child headings, and updates any ~[1/3]~-style statistics cookies. The next run starts fresh.
+
+The guard mirrors org's own re-arm rule exactly, so the reset happens only when org actually re-arms the heading:
+
+- A heading with no repeater never resets: a plain ~DONE~ keeps its record.
+- A zero-interval repeater (like ~.+0w~, org's idiom for "this repeating task is finished for good") does not re-arm, so the checked boxes are preserved.
+- A done-to-done transition (e.g. changing ~DONE~ to ~CANCELED~) doesn't reset.
+
+This applies to *every* repeating heading with checkboxes — spawned from a template or written by hand. The hook is installed by ~org-gtd-mode~.
+
+** Weekly Review (guided)
+:PROPERTIES:
+:DESCRIPTION: A pausable, step-by-step guided review session
+:CUSTOM_ID: guided-review
+:END:
+
+GTD's Reflect step asks you to step back regularly and get your system clear, current, and creative. Its central ritual is the Weekly Review. ~M-x org-gtd-review~ (or ~w~ from the command center) walks you through it one step at a time, so you don't have to hold the ritual in your head — sit down and press ~n~.
+
+*** Running a session
+
+The session opens a console buffer, =*GTD Review*=, showing the profile name, a phase tracker, and the current step with its instruction. The keys are advertised in the header line:
+
+| Key | Action |
+|-|-|
+| ~n~ | Do the current step, or advance past it |
+| ~s~ | Skip this step, for this run only |
+| ~c~ | Capture something to the inbox (available on every step) |
+| ~p~ | Pause; resume later with ~M-x org-gtd-review~ |
+| ~q~ | Quit; offers to keep or abandon your progress |
+
+Capture deserves emphasis: any step of a review can shake something loose, and ~c~ is always one keypress away.
+
+Each phase boundary shows a checkpoint message ("Get Clear complete — on to Get Current."). When the session finishes, you get a tally of steps done and skipped, your window configuration is restored, and — until you've scheduled a review reminder — a one-time tip points you at ~org-gtd-review-schedule~.
+
+Only one session runs at a time; if one is already active, ~org-gtd-review~ tells you to finish or quit it first.
+
+*** Step types
+
+A review is made of four kinds of steps. Here's what ~n~ does on each:
+
+- prompt :: Read the instruction, do the thing in the real world, press ~n~ to move on.
+- command :: Two presses. The first ~n~ runs the step's command (for example ~org-gtd-process-inbox~). When you're done, come back to the review buffer and press ~n~ again to confirm and advance — or ~s~ if you're leaving it unfinished. If the command signals an error, the step doesn't count as started; ~n~ simply retries it.
+- view :: Two presses, same shape. The first ~n~ opens the step's agenda view in another window; browse it and act on what needs acting. The second ~n~ advances.
+- checklist :: Walks the items of a named template from your [[#checklists][checklists file]], one item at a time. The first ~n~ shows the first item; each further ~n~ shows the next; press ~c~ whenever an item shakes something loose. The template file itself is never modified. An empty or missing checklist just says so and moves on.
+
+*** Pause, resume, and crash recovery
+
+The session checkpoints itself to a small file, =review-state.eld= in ~org-gtd-directory~ — once when it starts, and again at every step boundary and every checklist-walk advance. Pausing with ~p~, killing the buffer, or even a crashed Emacs loses nothing: the next ~M-x org-gtd-review~ offers to resume exactly where you were. Work done mid-step — a half-processed inbox, say — lives in your org files anyway, so resuming a command step simply re-offers it.
+
+There is a single checkpoint slot. Declining the resume offer starts a fresh session, whose first checkpoint replaces the old one. To abandon a session outright, press ~q~ and answer no to "Keep progress" — that deletes the checkpoint. If you edit your profiles while a session is paused and the saved position no longer fits, org-gtd says so and starts over.
+
+*** Customizing the ritual: org-gtd-review-profiles
+
+The whole ritual is data. ~org-gtd-review-profiles~ is an alist of profiles; each profile is a list of named phases; each phase is a list of steps; each step is a plist with a ~:title~, a ~:type~ (one of ~prompt~, ~command~, ~view~, ~checklist~), an optional ~:instruction~, and the type-specific key ~:command~, ~:view~, or ~:checklist~ (a template name from your checklists file).
+
+The Weekly Review ships as the default value, so customizing means editing this variable — reorder steps, delete what you don't use, point ~:view~ steps at [[#view-dsl-reference][your own views]], or add entirely new profiles (a daily shutdown, a monthly horizons review). When more than one profile is configured, ~org-gtd-review~ asks which one to run. Malformed profiles are rejected up front with an error that names the offending phase or step and shows the expected shape.
+
+Here is the full default, as a starting point for your own:
+
+#+begin_src elisp
+(setq org-gtd-review-profiles
+      '(("Weekly Review"
+         ("Get Clear"
+          (:title "Gather loose materials"
+           :type prompt
+           :instruction "Collect loose papers, receipts, and notes.  Capture each one into the inbox.")
+          (:title "Mind sweep"
+           :type checklist
+           :checklist "Weekly Review triggers"
+           :instruction "Walk each trigger.  Press c to capture whatever it shakes loose.")
+          (:title "Inbox to zero"
+           :type command
+           :command org-gtd-process-inbox
+           :instruction "Process every inbox item.  Come back here and press n when the inbox is empty."))
+         ("Get Current"
+          (:title "Review missed items"
+           :type view
+           :view org-gtd-reflect-missed-items
+           :instruction "Reschedule, complete, or cancel anything that slipped.")
+          (:title "Review Waiting-For"
+           :type view
+           :view org-gtd-reflect-upcoming-delegated
+           :instruction "Nudge, close, or re-delegate each delegated item.")
+          (:title "Review next actions"
+           :type view
+           :view org-gtd-show-all-next
+           :instruction "Mark done what is done; check these still feel current.")
+          (:title "Review stuck projects"
+           :type view
+           :view org-gtd-reflect-stuck-projects
+           :instruction "Give every active project a next action."))
+         ("Get Creative"
+          (:title "Review Someday/Maybe"
+           :type view
+           :view org-gtd-reflect-someday-maybe
+           :instruction "Reactivate anything whose time has come.")
+          (:title "Capture new ideas"
+           :type prompt
+           :instruction "Any creative, risky, or fun ideas?  Capture them.")))))
+#+end_src
+
+*** Scheduling the review: org-gtd-review-schedule
+
+A Weekly Review only works if it actually happens weekly. ~M-x org-gtd-review-schedule~ prompts for a profile (when you have more than one), a first date, and a repeat interval, then creates an ordinary org-gtd habit named after the profile — so the reminder shows up in your engage view like any other habit:
+
+#+begin_example
+,* Weekly Review
+SCHEDULED: <2026-07-10 Fri .+1w>
+:PROPERTIES:
+:ORG_GTD:  Habit
+:STYLE:    habit
+:END:
+Run M-x org-gtd-review when you sit down for this.
+#+end_example
+
+The repeat interval is a standard org repeater: ~.+1w~ means "a week after I actually do it" (the usual choice for reviews), ~+1w~ is a fixed calendar cadence, and ~++1w~ jumps to the next future occurrence. Units are ~h~, ~d~, ~w~, ~m~, ~y~, and habit-style maximum intervals like ~.+2d/4d~ are accepted. Anything else is rejected with an explanation.
+
+If a reminder for one of your profiles already exists, the command asks before scheduling another one.
+
+*** First-time setup: org-gtd-init-system
+
+~M-x org-gtd-init-system~ is a small first-run concierge. It ensures ~org-gtd-directory~ and the GTD files exist — the tasks file, the inbox, and ~checklists.org~ with its starter templates — and then offers to schedule a recurring Weekly Review (skipping the offer when a reminder already exists). It is idempotent: run it again anytime, and anything already in place is simply reported as ready.
+
+Two things it deliberately does *not* do, because they belong in your Emacs configuration: adding your GTD files to ~org-agenda-files~, and TODO keyword setup. Those remain manual steps — see [[#configuring][Configuring]].
+
+You never /have/ to run it: every file it creates is also created lazily the first time something needs it.
 
 ** Understanding GTD Item Types
 :PROPERTIES:

--- a/docs/plans/2026-07-06-checklists-and-guided-review-design.md
+++ b/docs/plans/2026-07-06-checklists-and-guided-review-design.md
@@ -62,9 +62,9 @@ Each top-level heading is a template:
 ### 1.2 `org-gtd-checklist-insert` (autoloaded)
 
 `completing-read` over template headings, then copies the chosen subtree to point.
-With a prefix argument, prompts for a refile-style target instead. **Pure copy** —
-no repeater prompt, no properties added. A spawned instance is an ordinary org
-subtree; org-gtd tracks nothing about it.
+**Pure copy** — no repeater prompt, no properties added. A spawned instance is an
+ordinary org subtree; org-gtd tracks nothing about it. (Prefix-arg refile-style
+targeting was considered and deferred — see §7.)
 
 ### 1.3 Checkbox reset on repeat
 
@@ -170,13 +170,15 @@ SCHEDULED: <2026-07-10 Fri .+1w>
 Run M-x org-gtd-review when you sit down for this.
 ```
 
-Offered from the command center, mentioned in the manual, and hinted once on the
-review completion screen.
+Not a command-center row of its own: it is reachable via `M-x`, hinted once on
+the review completion screen (the one-time tip), offered by `org-gtd-init-system`,
+and mentioned in the manual.
 
 ### 3.2 `org-gtd-init-system`
 
-A thin, **idempotent** concierge for first-time setup; each step reports
-"already done ✓" and skips when satisfied. Lazy init stays fully intact —
+A thin, **idempotent** concierge for first-time setup; steps skip when already
+satisfied. (As implemented, it reports one consolidated "✓ GTD files ready"
+line rather than a per-step ✓ line.) Lazy init stays fully intact —
 nothing ever requires having run this. Steps (deliberately minimal):
 
 1. Ensure `org-gtd-directory`, `org-gtd-tasks.org`, and `checklists.org`
@@ -230,8 +232,8 @@ All in the teaching voice — message + skip, never a stack trace.
 
 Via the `/test` skill, using existing builders and mock-gtd helpers.
 
-- **Unit:** items parser; file seeding (content, idempotence); insert (at point,
-  prefix-arg target); reset hook (repeat vs. plain DONE; nested boxes); profile
+- **Unit:** items parser; file seeding (content, idempotence); insert at point;
+  reset hook (repeat vs. plain DONE; nested boxes); profile
   shape validation; state-file round-trip; init-system idempotence.
 - **Integration:** full Weekly Review run with `with-simulated-input`, including
   a checklist walk with mid-walk capture; pause then resume across two sessions;
@@ -241,6 +243,8 @@ Via the `/test` skill, using existing builders and mock-gtd helpers.
 
 - Stats block, review-completion log, back-step (`b`), invariant guard on
   project walks (REF-02 §4/§6).
+- Prefix-arg refile-style targeting for `org-gtd-checklist-insert` (v1 inserts
+  at point only).
 - Generalizing `org-gtd-someday-review` into a profile of this engine.
 - Checklist manager transient / Cluster-E CRUD conformance.
 - `CHECKLIST_KIND` (revisit if a consumer ever needs filtering by kind).

--- a/docs/plans/2026-07-06-checklists-and-guided-review-design.md
+++ b/docs/plans/2026-07-06-checklists-and-guided-review-design.md
@@ -1,0 +1,257 @@
+# Checklists and Guided Weekly Review — Design
+
+**Date:** 2026-07-06
+**Implements:** REC-CHK-01 (first-class checklists / trigger lists), REC-REF-02 (guided three-phase Weekly Review)
+**Supersedes in part:** `docs/feature-analysis/ux-workflows/REC-CHK-01.md`, `REC-REF-02.md` — see "Divergences" below.
+
+## Summary
+
+Two features, designed together because a review step can walk a trigger list:
+
+- **Checklists**: reusable named lists (Weekly Review trigger list, packing lists) stored as
+  plain org headings in `checklists.org`. One file convention, one insert command, one
+  checkbox-reset hook. No new GTD type, no manager UI, no new properties.
+- **Guided review**: `M-x org-gtd-review` runs a customizable multi-phase session
+  (Get Clear → Get Current → Get Creative by default) in a `*GTD Review*` buffer,
+  with pause/resume. Step sequences ("profiles") live in a defcustom.
+- **Installation**: `org-gtd-review-schedule` seeds a recurring Weekly Review habit;
+  `org-gtd-init-system` is a thin idempotent concierge for first-time setup.
+
+### Key decisions (divergences from the UX-workflow docs)
+
+| Decision | UX doc said | This design says | Why |
+|---|---|---|---|
+| Checklist instances | New `checklist` type in registry, `ORG_GTD: Checklist` | Plain org subtrees, no type | YAGNI; avoids registry/organize-transient churn; reset hook works for any heading |
+| Template store | `org-gtd-checklists` defcustom + transient CRUD manager | `checklists.org`, bare headings | Editing an org file is the ultimate no-elisp UX; syncs to mobile/git; deletes the whole manager surface |
+| `CHECKLIST_KIND` property | kind: trigger-list/packing/verb-starter | Dropped | Nothing consumes it; consumers reference checklists by name |
+| `RESET_CHECK_BOXES` property | Per-heading opt-in | Dropped | The repeater is the signal: reset fires only when a heading repeats |
+| Recurrence mechanism | org-edna `RESET` | Plain org repeaters | Matches how habits already work; edna stays project-dependency-only |
+| Manager UI (Cluster E CRUD) | Full list/builder/preview transient pair | Visit-file command + `org-gtd-checklist-insert` | Follows from org-file storage; decouples from the View Builder work |
+| Command-center key | `k` "Checklists…" | `l` (and `w` for review) | `k` is already taken (Capture & Process group) |
+| Engine scope | Full console: stats block, review log, back-step, someday-review generalized | Lean session + pause/resume | Stats/log/back-step layer on later; `someday-review` untouched |
+
+## 1. Checklists
+
+### 1.1 Template file: `checklists.org`
+
+Lives in `org-gtd-directory`, created lazily via `org-gtd--ensure-file-exists`
+(which already takes `initial-contents`). Seeded on first creation with starter
+templates: **Weekly Review triggers** and **Mind sweep prompts** (content adapted
+from the GTD trigger lists; editable, deletable).
+
+Each top-level heading is a template:
+
+```org
+* Weekly Review triggers
+- [ ] Boss?
+- [ ] Car maintenance?
+- [ ] Promises to family?
+
+* Beach packing
+- [ ] Sunscreen
+- [ ] Swimsuit
+- [ ] Beach towel
+```
+
+- Name = heading title; items = its `- [ ]` checkboxes.
+- No TODO keywords, no properties, nothing org-gtd-specific.
+- Not added to `org-agenda-files` (templates are content, not tasks).
+- Users organize and extend the file with ordinary org editing — that *is* the
+  customization UX.
+
+### 1.2 `org-gtd-checklist-insert` (autoloaded)
+
+`completing-read` over template headings, then copies the chosen subtree to point.
+With a prefix argument, prompts for a refile-style target instead. **Pure copy** —
+no repeater prompt, no properties added. A spawned instance is an ordinary org
+subtree; org-gtd tracks nothing about it.
+
+### 1.3 Checkbox reset on repeat
+
+In `org-gtd-hooks.el`, installed by `org-gtd-mode` like the existing hooks:
+when a repeating heading re-arms (repeater fires on DONE, org resets it to TODO),
+call org core's `org-reset-checkbox-state-subtree` on it. Fires **only** on
+repeater re-arm, never on a plain DONE. Core org already handles nested boxes
+and `[1/3]` statistics cookies. Applies to any repeating heading with checkboxes,
+spawned or hand-written. ~20 lines.
+
+### 1.4 Reading a checklist as data
+
+Internal `org-gtd-checklist--items NAME` → ordered list of item strings parsed
+from the named subtree. Consumed by the review engine's `checklist` step; future
+consumers (e.g. project verb lists, PRJ-10) reference templates by name the same way.
+
+### 1.5 Recurring checklist-as-task = composition
+
+The workflow for "I want my trigger list as a recurring task in my system":
+`org-gtd-checklist-insert` into the inbox (or any heading), then clarify and
+organize it **as a habit**. The checkboxes ride along with the subtree, engage
+shows it because it is a real habit, and the reset hook (1.3) clears the boxes
+each time the repeater fires. Same pattern for a recurring packing list. The
+manual documents this as *the* pattern; no new code.
+
+## 2. Guided review engine
+
+### 2.1 Profiles: `org-gtd-review-profiles`
+
+A defcustom: alist of `profile-name → list of phases`; each phase is
+`(phase-name . steps)`; each step a small plist. The **Weekly Review ships as
+the default value**, so customization = editing the variable (setq or customize).
+
+```elisp
+(setq org-gtd-review-profiles
+ '(("Weekly Review"
+    ("Get Clear"
+     (:title "Gather loose papers and materials" :type prompt
+      :instruction "Collect everything loose into your inbox.")
+     (:title "Mind sweep" :type checklist
+      :checklist "Weekly Review triggers")
+     (:title "Inbox to zero" :type command
+      :command org-gtd-process-inbox))
+    ("Get Current"
+     (:title "Review calendar" :type view :view org-gtd-reflect-missed-items)
+     (:title "Review Waiting-For" :type view :view org-gtd-reflect-upcoming-delegated)
+     ...)
+    ("Get Creative"
+     (:title "Review Someday/Maybe" :type view :view org-gtd-reflect-someday-maybe)
+     (:title "Any new ideas?" :type prompt
+      :instruction "Capture any creative, risky, or fun ideas.")))))
+```
+
+Step types (v1):
+
+| `:type` | keys used | behavior on `n` |
+|---|---|---|
+| `prompt` | shows `:instruction` | mark done, advance |
+| `command` | — | call `:command`; on return, advance |
+| `view` | — | show `:view` in other window; browse; `n` again advances |
+| `checklist` | `c` capture, `n` next item | walk `:checklist` items one at a time; `c` captures to inbox mid-walk. Ephemeral — the template file is never modified |
+
+### 2.2 Session
+
+`M-x org-gtd-review` (autoloaded; optional profile arg; profile picker only when
+more than one profile is configured). Snapshots the window configuration, opens
+`*GTD Review*`: profile name, phase tracker, `Step 2/4`, current instruction.
+Header line advertises the live keys — same idiom as `org-gtd-someday-review`.
+
+Keys: `n` do/advance · `s` skip step · `p` pause · `q` quit (offers *Pause / Abandon*).
+
+Phase boundaries show a one-line checkpoint message. Completion shows simple
+counts (steps done/skipped), a one-time tip about `org-gtd-review-schedule` if
+no reminder exists yet, and restores the window configuration.
+
+### 2.3 Pause / resume
+
+Session state (profile name, phase index, step index, position within a checklist
+walk, counts) serializes to `review-state.eld` in `org-gtd-directory` (visible,
+Emacs read-syntax). Next `org-gtd-review` offers *Resume / Start over*. Abandon
+deletes the file. State saves at step boundaries plus walk position; pausing
+mid-`command` resumes by re-offering that step (work already done — e.g. a
+half-emptied inbox — is naturally reflected in the files themselves).
+
+`org-gtd-someday-review` is untouched: the engine borrows its header-line /
+read-only idioms, not its code. Generalizing it into a profile is deferred.
+
+## 3. Installation workflows
+
+### 3.1 `org-gtd-review-schedule`
+
+Prompts for profile, day, and frequency; creates a habit via the existing
+`org-gtd-configure-as-type` path — exactly what organizing a captured item as a
+habit produces today:
+
+```org
+* Weekly Review
+SCHEDULED: <2026-07-10 Fri .+1w>
+:PROPERTIES:
+:ORG_GTD: Habits
+:STYLE: habit
+:END:
+Run M-x org-gtd-review when you sit down for this.
+```
+
+Offered from the command center, mentioned in the manual, and hinted once on the
+review completion screen.
+
+### 3.2 `org-gtd-init-system`
+
+A thin, **idempotent** concierge for first-time setup; each step reports
+"already done ✓" and skips when satisfied. Lazy init stays fully intact —
+nothing ever requires having run this. Steps (deliberately minimal):
+
+1. Ensure `org-gtd-directory`, `org-gtd-tasks.org`, and `checklists.org`
+   (with starter content) exist — the same lazy-init calls, run eagerly.
+2. Offer `org-gtd-review-schedule`: "Schedule a recurring Weekly Review? (y/n)".
+
+Explicitly out of scope for now: `org-agenda-files` checks and the keywords
+wizard (they remain documented manual steps / `org-gtd-setup-keywords-wizard`).
+
+### 3.3 New-user story
+
+Run `org-gtd-init-system` (or just `org-gtd-review` — checklists.org self-seeds
+on first touch), accept the completion-screen tip, done: the system now reminds
+them weekly, with a mind-sweep trigger list ready to walk.
+
+## 4. Wiring
+
+- **New modules:** `org-gtd-checklist.el` (insert command, items parser, seeding)
+  and `org-gtd-review.el` (profiles defcustom + engine). The `org-gtd-review.el`
+  filename is free — the old module became `org-gtd-reflect.el` in 4.0.0, and the
+  ritual is properly called "Weekly Review" (Reflect is the phase name).
+- **Autoloads:** `org-gtd-review`, `org-gtd-review-schedule`,
+  `org-gtd-checklist-insert`, `org-gtd-init-system`.
+- **Hooks:** reset-on-repeat in `org-gtd-hooks.el`, installed by `org-gtd-mode`.
+- **Command center**, Reflect group (keys verified free):
+  `w · Weekly Review (guided…)` → `org-gtd-review`;
+  `l · Checklists` → visit `checklists.org`.
+- **Unchanged:** type registry, organize transient + parity test,
+  `org-gtd-someday-review`, org-edna usage, the View Builder yx tree (checklists
+  no longer follow the Cluster-E CRUD idiom, so that work is decoupled).
+- **Docs:** manual gains Checklists and Weekly Review sections (including the
+  composition pattern, 1.5); the two feature-analysis UX docs get a divergence
+  note pointing here.
+
+## 5. Edge cases
+
+All in the teaching voice — message + skip, never a stack trace.
+
+- **Step references a missing checklist** (template renamed/deleted): show
+  "No checklist named 'X' — edit checklists.org, or `s` to skip"; session continues.
+- **Empty states auto-satisfy:** an empty checklist walk or a view step over zero
+  items shows "Nothing here — nice"; `n` moves on. A brand-new user can run the
+  full ritual.
+- **Resume vs. changed profile:** if `org-gtd-review-profiles` changed since
+  pausing (index out of range, profile gone), offer *Start over* instead of
+  restoring into the wrong step.
+- **Reset precision:** repeater re-arm only, never plain DONE.
+- **Window config** restored on every exit path: complete, pause, abandon, error.
+
+## 6. Testing
+
+Via the `/test` skill, using existing builders and mock-gtd helpers.
+
+- **Unit:** items parser; file seeding (content, idempotence); insert (at point,
+  prefix-arg target); reset hook (repeat vs. plain DONE; nested boxes); profile
+  shape validation; state-file round-trip; init-system idempotence.
+- **Integration:** full Weekly Review run with `with-simulated-input`, including
+  a checklist walk with mid-walk capture; pause then resume across two sessions;
+  `org-gtd-review-schedule` produces a working habit.
+
+## 7. Deferred (explicitly not in this cut)
+
+- Stats block, review-completion log, back-step (`b`), invariant guard on
+  project walks (REF-02 §4/§6).
+- Generalizing `org-gtd-someday-review` into a profile of this engine.
+- Checklist manager transient / Cluster-E CRUD conformance.
+- `CHECKLIST_KIND` (revisit if a consumer ever needs filtering by kind).
+- Instance↔template linking / edit propagation.
+- `org-agenda-files` and keywords steps in `org-gtd-init-system`.
+- Daily/monthly/quarterly cadence profiles (ship as documented examples first).
+
+## 8. Provenance
+
+- `docs/feature-analysis/ux-workflows/REC-REF-02.md`, `REC-CHK-01.md` (UX corpus);
+  adjudications 2026-06-05 #1 and V-10.
+- Design decisions made interactively 2026-07-06 (brainstorming session):
+  no-type instances → org-file templates → no manager → defcustom profiles →
+  lean engine + pause/resume → habit-based reminder → minimal init-system.

--- a/docs/plans/2026-07-06-checklists-and-guided-review-design.md
+++ b/docs/plans/2026-07-06-checklists-and-guided-review-design.md
@@ -123,7 +123,7 @@ Step types (v1):
 | `:type` | keys used | behavior on `n` |
 |---|---|---|
 | `prompt` | shows `:instruction` | mark done, advance |
-| `command` | — | call `:command`; on return, advance |
+| `command` | — | `n` launches `:command`; on the user's next `n`, advance |
 | `view` | — | show `:view` in other window; browse; `n` again advances |
 | `checklist` | `c` capture, `n` next item | walk `:checklist` items one at a time; `c` captures to inbox mid-walk. Ephemeral — the template file is never modified |
 

--- a/docs/plans/2026-07-06-checklists-and-guided-review-design.md
+++ b/docs/plans/2026-07-06-checklists-and-guided-review-design.md
@@ -248,7 +248,64 @@ Via the `/test` skill, using existing builders and mock-gtd helpers.
 - `org-agenda-files` and keywords steps in `org-gtd-init-system`.
 - Daily/monthly/quarterly cadence profiles (ship as documented examples first).
 
-## 8. Provenance
+## 8. Corpus impact — what to pull from the feature-analysis corpus later
+
+Status of every corpus element this design touches, so future work can keep
+pulling from `docs/feature-analysis/` without re-litigating. **Rejected** means
+"do not implement later — the decision went the other way"; **still open** means
+"valid future work; read it through this design's contracts."
+
+### REC-CHK-01
+
+- **Implemented (as specified):** named reusable checklists; insert command;
+  bundled starter trigger lists; checkbox reset so lists are re-runnable.
+- **Implemented (differently — read this design, not the corpus doc):**
+  storage is `checklists.org`, not an `org-gtd-checklists` defcustom;
+  reset keys off repeater re-arm, not a reset-policy field.
+- **Rejected:** checklist type in the registry; `CHECKLIST_KIND` and
+  `RESET_CHECK_BOXES` properties; org-edna `RESET` recurrence; the Cluster-E
+  CRUD manager/builder transient pair for checklists; `ORG_GTD: Checklist`
+  instances.
+- **Still open:** a slim manager transient *over the file* (list/jump/insert)
+  if discoverability warrants; instance↔template linking; `kind` filtering if
+  a consumer ever needs it.
+- **Contract for downstream corpus docs** (REC-PRJ-10, REC-CAP-09, REC-CHK-02,
+  REC-CAP-06, REC-PRJ-07 all cite CHK-01's data model): a checklist is a named
+  top-level subtree in `checklists.org`; consumers reference it **by name** and
+  read items via `org-gtd-checklist--items`. Their references to `kind`,
+  spec alists, or the manager surface are stale.
+
+### REC-REF-02
+
+- **Implemented (lean):** guided multi-phase session; configurable profiles
+  (defcustom, Weekly default); step types `prompt`/`command`/`view`/`checklist`;
+  session keys `n s p q`; phase checkpoints; pause/resume; completion counts;
+  the REF-01 reminder rider via `org-gtd-review-schedule`.
+- **Rejected:** org-edna involvement; hidden `.review-state.el`
+  (now visible `review-state.eld`).
+- **Still open (deferred, valid pulls):**
+  - the **`walk` step type** — iterating *org headings* (projects, someday
+    items) one at a time in WIP buffers with per-item actions (`c x d`) and the
+    no-next-action **invariant guard**. Note our `checklist` step walks item
+    *strings*, not headings; the org-item walk is the missing piece REF-06 and
+    the someday-review generalization both need;
+  - stats block (the X-15 completeness readout), review-completion log,
+    back-step `b`, in-session `,` customize;
+  - generalizing `org-gtd-someday-review` into a profile;
+  - cadence-ladder profiles (daily/monthly/quarterly/annual, REF-05/WF-22);
+  - action bars generated from `:allowed-actions` (the corpus's registry-parity
+    idea) — steps currently declare behavior via `:type` only.
+- **Contract for Cluster A siblings** (REC-REF-06, REC-CAP-09, REC-X-15): the
+  engine they inherit is profiles + typed steps + `n s p q` + pause/resume —
+  *not* the full console in the corpus doc. REF-06/CAP-09 are "just another
+  profile" only once the `walk` step type lands; X-15 still needs the stats
+  block.
+
+When implementation lands, update `docs/feature-analysis/audit/` and
+`gaps/recommended-not-implemented.md` from this section — the mapping above is
+meant to make that mechanical.
+
+## 9. Provenance
 
 - `docs/feature-analysis/ux-workflows/REC-REF-02.md`, `REC-CHK-01.md` (UX corpus);
   adjudications 2026-06-05 #1 and V-10.

--- a/docs/plans/2026-07-06-checklists-and-guided-review-plan.md
+++ b/docs/plans/2026-07-06-checklists-and-guided-review-plan.md
@@ -1,0 +1,1381 @@
+# Checklists + Guided Weekly Review Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement the design in `docs/plans/2026-07-06-checklists-and-guided-review-design.md`: plain-org checklist templates (`checklists.org` + insert command + reset-on-repeat hook) and a guided, pausable, profile-driven review session (`org-gtd-review`), plus `org-gtd-review-schedule` and `org-gtd-init-system`.
+
+**Architecture:** Two new modules — `org-gtd-checklist.el` (file convention, parser, insert, reset hook) and `org-gtd-review.el` (profiles defcustom + session engine in a `*GTD Review*` special-mode buffer with pause/resume via `review-state.eld`) — plus a tiny `org-gtd-init.el`. No changes to the type registry or organize transient. The reset hook is installed by `org-gtd-mode` exactly like the existing `org-after-todo-state-change-hook` functions.
+
+**Tech Stack:** Emacs Lisp (28.1+), org-mode, transient (command center rows only), f.el, e-unit test framework with `ogt-eunit-with-mock-gtd`, `with-simulated-input`.
+
+---
+
+## Ground rules for the executor
+
+- **Run tests ONLY via the `/test` skill** (Skill tool, `skill: test`, `args: <test-file-path>` for one file, no args for full suite). Never run `eldev` directly. Test selection is file-level only.
+- **TDD**: every task writes the failing test first, sees it fail, implements, sees it pass, commits.
+- **New `.el` files** must copy the header boilerplate (Copyright/GPL/Commentary) and footer (`provide` + `;;; ... ends here`) from `org-gtd-files.el`, adjusting the description. `lexical-binding: t` in the first line. Checkdoc-clean docstrings (imperative first line, ≤ 80 cols).
+- **Test files** follow `test/unit/files-test.el` exactly: `(require 'ogt-eunit-prelude "test/helpers/prelude.el")`, `(e-unit-initialize)`, `around-each` wrapping `ogt-eunit-with-mock-gtd`, `deftest group/name ()` naming, `assert-equal` / `assert-nil` / `assert-match` assertions, `(provide 'xxx-test)` footer.
+- **Mock FS facts**: `org-gtd-directory` is `/mock:/gtd/`; the mock spec pre-creates `inbox.org`, `org-gtd-tasks.org`, `org-gtd-calendar.org`, `org-gtd-incubate.org` as empty files — it does **not** pre-create `checklists.org`, so seeding is testable. Use `(let ((org-inhibit-logging t)) ...)` around `org-todo` calls.
+- Commit after every green test with the message given in the task.
+
+---
+
+### Task 1: Checklist file, seeding, and visit command
+
+**Files:**
+- Create: `org-gtd-checklist.el`
+- Create: `test/unit/checklist-test.el`
+
+**Step 1: Write the failing tests**
+
+```elisp
+;;; checklist-test.el --- Tests for org-gtd checklists -*- lexical-binding: t; coding: utf-8 -*-
+;; (header boilerplate as per files-test.el)
+;;; Code:
+
+(require 'ogt-eunit-prelude "test/helpers/prelude.el")
+
+(e-unit-initialize)
+
+(around-each (proceed context)
+  (ogt-eunit-with-mock-gtd
+    (funcall proceed context)))
+
+(deftest checklist/file-is-created-with-starter-templates ()
+  "First touch creates checklists.org seeded with starter trigger lists."
+  (let ((buf (org-gtd-checklist--file-buffer)))
+    (with-current-buffer buf
+      (assert-match "\\* Weekly Review triggers" (buffer-string))
+      (assert-match "\\* Mind sweep prompts" (buffer-string))
+      (assert-match "- \\[ \\]" (buffer-string)))))
+
+(deftest checklist/seeding-is-idempotent ()
+  "Touching the file twice does not duplicate the starters."
+  (org-gtd-checklist--file-buffer)
+  (with-current-buffer (org-gtd-checklist--file-buffer)
+    (goto-char (point-min))
+    (assert-equal 1 (count-matches "^\\* Weekly Review triggers$"))))
+
+(provide 'checklist-test)
+;;; checklist-test.el ends here
+```
+
+**Step 2: Run to verify failure**
+
+Use the Skill tool: `skill: test`, `args: test/unit/checklist-test.el`
+Expected: FAIL — `void-function org-gtd-checklist--file-buffer`.
+
+**Step 3: Write minimal implementation**
+
+Create `org-gtd-checklist.el` (full header boilerplate; Commentary: "Reusable checklist templates stored as plain org headings in checklists.org."):
+
+```elisp
+;;;; Requirements
+
+(require 'org)
+(require 'f)
+(require 'org-gtd-core)
+(require 'org-gtd-files)
+
+;;;; Constants
+
+(defconst org-gtd-checklist-file-name "checklists"
+  "Base name of the checklist templates file inside `org-gtd-directory'.")
+
+(defconst org-gtd-checklist--starter-contents
+  "* Weekly Review triggers
+- [ ] Projects started but not completed?
+- [ ] Commitments or promises made to others?
+- [ ] Communications to make or expecting (calls, emails)?
+- [ ] Writing to finish or submit?
+- [ ] Meetings that need to be set or requested?
+- [ ] Decisions that need to be made?
+- [ ] Waiting for someone else's reply or delivery?
+- [ ] Financial or administrative loose ends?
+
+* Mind sweep prompts
+- [ ] Boss, partners, colleagues?
+- [ ] Family and friends?
+- [ ] Household — repairs, maintenance, errands?
+- [ ] Health — appointments, checkups, exercise?
+- [ ] Finances — bills, taxes, banks?
+- [ ] Car or transportation?
+- [ ] Creative ideas, things to learn?
+- [ ] Places to go, people to see?
+"
+  "Contents used to seed a brand-new checklists file.")
+
+;;;; Functions
+
+;;;;; Private
+
+(defun org-gtd-checklist--file-path ()
+  "Return the full path to the checklists file."
+  (org-gtd--path org-gtd-checklist-file-name))
+
+(defun org-gtd-checklist--file-buffer ()
+  "Return a buffer visiting the checklists file, creating it if needed.
+A newly created file is seeded with starter templates."
+  (let ((path (org-gtd-checklist--file-path)))
+    (org-gtd--ensure-file-exists path org-gtd-checklist--starter-contents)
+    (find-file-noselect path)))
+
+;;;;; Commands
+
+;;;###autoload
+(defun org-gtd-checklist-visit ()
+  "Visit the checklist templates file.
+Each top-level heading is a reusable checklist template."
+  (interactive)
+  (pop-to-buffer (org-gtd-checklist--file-buffer)))
+
+;;;; Footer
+
+(provide 'org-gtd-checklist)
+```
+
+**Step 4: Run to verify pass**
+
+`skill: test`, `args: test/unit/checklist-test.el` — Expected: PASS (2 tests).
+
+**Step 5: Commit**
+
+```bash
+git add org-gtd-checklist.el test/unit/checklist-test.el
+git commit -m "feat: add checklists.org template file with starter trigger lists"
+```
+
+---
+
+### Task 2: Template names and items parser
+
+**Files:**
+- Modify: `org-gtd-checklist.el`
+- Modify: `test/unit/checklist-test.el`
+
+**Step 1: Add failing tests**
+
+```elisp
+(deftest checklist/names-lists-top-level-headings ()
+  "Template names are the top-level heading titles."
+  (assert-equal '("Weekly Review triggers" "Mind sweep prompts")
+                (org-gtd-checklist-names)))
+
+(deftest checklist/items-returns-ordered-item-strings ()
+  "Items of a named checklist come back as ordered plain strings."
+  (let ((items (org-gtd-checklist--items "Mind sweep prompts")))
+    (assert-equal "Boss, partners, colleagues?" (car items))
+    (assert-equal 8 (length items))))
+
+(deftest checklist/items-ignores-checked-state ()
+  "A checked box still yields its item text."
+  (with-current-buffer (org-gtd-checklist--file-buffer)
+    (goto-char (point-min))
+    (search-forward "- [ ] Boss")
+    (replace-match "- [X] Boss")
+    (basic-save-buffer))
+  (assert-equal "Boss, partners, colleagues?"
+                (car (org-gtd-checklist--items "Mind sweep prompts"))))
+
+(deftest checklist/items-nil-for-unknown-name ()
+  "Unknown checklist name returns nil, no error."
+  (assert-nil (org-gtd-checklist--items "No such list")))
+```
+
+**Step 2: Run to verify failure** — `args: test/unit/checklist-test.el`, expected `void-function org-gtd-checklist-names`.
+
+**Step 3: Implement** (add to `org-gtd-checklist.el` under Private / a new Public section):
+
+```elisp
+(defun org-gtd-checklist-names ()
+  "Return the list of checklist template names, in file order."
+  (with-current-buffer (org-gtd-checklist--file-buffer)
+    (org-with-wide-buffer
+     (goto-char (point-min))
+     (let (names)
+       (while (re-search-forward "^\\* +\\(.+?\\)[ \t]*$" nil t)
+         (push (match-string-no-properties 1) names))
+       (nreverse names)))))
+
+(defun org-gtd-checklist--items (name)
+  "Return the ordered checkbox item strings of checklist NAME.
+Return nil when no checklist NAME exists or it has no items."
+  (with-current-buffer (org-gtd-checklist--file-buffer)
+    (org-with-wide-buffer
+     (goto-char (point-min))
+     (when (re-search-forward
+            (format "^\\* +%s[ \t]*$" (regexp-quote name)) nil t)
+       (let ((end (save-excursion (org-end-of-subtree t t) (point)))
+             items)
+         (while (re-search-forward
+                 "^[ \t]*- \\[[ Xx-]\\] +\\(.+?\\)[ \t]*$" end t)
+           (push (match-string-no-properties 1) items))
+         (nreverse items))))))
+```
+
+**Step 4: Run to verify pass.**
+
+**Step 5: Commit** — `git commit -m "feat: parse checklist template names and items"`
+
+---
+
+### Task 3: `org-gtd-checklist-insert`
+
+**Files:**
+- Modify: `org-gtd-checklist.el`
+- Modify: `test/unit/checklist-test.el`
+
+**Step 1: Add failing tests**
+
+```elisp
+;; add at top of test file, after the prelude require:
+;; (require 'with-simulated-input)
+
+(deftest checklist/insert-copies-subtree-at-point ()
+  "Insert spawns the named template as a subtree at point."
+  (with-temp-buffer
+    (org-mode)
+    (with-simulated-input "Weekly SPC Review SPC triggers RET"
+      (call-interactively #'org-gtd-checklist-insert))
+    (assert-match "^\\* Weekly Review triggers" (buffer-string))
+    (assert-match "- \\[ \\] Projects started" (buffer-string))))
+
+(deftest checklist/insert-adapts-level-to-context ()
+  "Inserting under an existing heading demotes the copy."
+  (with-temp-buffer
+    (org-mode)
+    (insert "* Trip to the beach\n")
+    (goto-char (point-max))
+    (org-gtd-checklist-insert "Mind sweep prompts")
+    (assert-match "^\\*\\* Mind sweep prompts" (buffer-string))))
+
+(deftest checklist/insert-unknown-name-errors-cleanly ()
+  "Unknown name signals a user-error naming the file."
+  (with-temp-buffer
+    (org-mode)
+    (let ((err (should-error-p (org-gtd-checklist-insert "Nope"))))
+      (assert-non-nil err))))
+```
+
+Note for executor: if the helpers provide no `should-error-p`, use
+`(condition-case e (progn (org-gtd-checklist-insert "Nope") nil) (user-error e))`
+and assert non-nil. Check `test/helpers/assertions.el` first.
+
+**Step 2: Run to verify failure.**
+
+**Step 3: Implement**
+
+```elisp
+;;;###autoload
+(defun org-gtd-checklist-insert (name)
+  "Insert a fresh instance of checklist NAME as a subtree at point.
+The copy is an ordinary org subtree — org-gtd does not track it.
+To make it a recurring task, organize it (e.g. as a habit) with
+`org-gtd-clarify-item' after inserting."
+  (interactive
+   (list (completing-read "Checklist: " (org-gtd-checklist-names) nil t)))
+  (let ((subtree
+         (with-current-buffer (org-gtd-checklist--file-buffer)
+           (org-with-wide-buffer
+            (goto-char (point-min))
+            (unless (re-search-forward
+                     (format "^\\* +%s[ \t]*$" (regexp-quote name)) nil t)
+              (user-error "No checklist named '%s' — edit %s"
+                          name (org-gtd-checklist--file-path)))
+            (buffer-substring-no-properties
+             (line-beginning-position)
+             (save-excursion (org-end-of-subtree t t) (point)))))))
+    (unless (bolp) (insert "\n"))
+    (org-paste-subtree nil subtree)))
+```
+
+**Step 4: Run to verify pass.**
+
+**Step 5: Commit** — `git commit -m "feat: add org-gtd-checklist-insert to spawn template instances"`
+
+---
+
+### Task 4: Checkbox reset on repeater re-arm
+
+**Files:**
+- Modify: `org-gtd-checklist.el`
+- Modify: `org-gtd-mode.el` (hook install ~line 144 block, removal ~line 114 block)
+- Create: `test/unit/checklist-reset-test.el`
+
+**Step 1: Write failing tests**
+
+```elisp
+;;; checklist-reset-test.el --- Tests for checkbox reset on repeat -*- lexical-binding: t -*-
+;; (boilerplate as usual)
+
+(require 'ogt-eunit-prelude "test/helpers/prelude.el")
+
+(e-unit-initialize)
+
+(around-each (proceed context)
+  (ogt-eunit-with-mock-gtd
+    (funcall proceed context)))
+
+(defmacro checklist-reset--with-heading (text &rest body)
+  "Run BODY in an org buffer containing TEXT, point on first heading,
+with the reset hook installed."
+  (declare (indent 1))
+  `(with-temp-buffer
+     (org-mode)
+     (insert ,text)
+     (goto-char (point-min))
+     (add-hook 'org-after-todo-state-change-hook
+               #'org-gtd-checklist--maybe-reset-checkboxes)
+     (unwind-protect (progn ,@body)
+       (remove-hook 'org-after-todo-state-change-hook
+                    #'org-gtd-checklist--maybe-reset-checkboxes))))
+
+(deftest checklist-reset/repeating-heading-resets-boxes-on-done ()
+  "Completing a repeating heading clears its checkboxes and re-arms."
+  (checklist-reset--with-heading
+      "* TODO Weekly triggers\nSCHEDULED: <2026-07-10 Fri .+1w>\n- [X] Boss?\n- [ ] Car?\n"
+    (let ((org-inhibit-logging t) (org-log-repeat nil))
+      (org-todo "DONE"))
+    (assert-nil (string-match-p "\\[X\\]" (buffer-string)))
+    (assert-match "\\* TODO Weekly triggers" (buffer-string))))
+
+(deftest checklist-reset/plain-done-keeps-boxes ()
+  "Completing a non-repeating heading leaves checkboxes alone."
+  (checklist-reset--with-heading
+      "* TODO Beach packing\n- [X] Sunscreen\n- [ ] Towel\n"
+    (let ((org-inhibit-logging t))
+      (org-todo "DONE"))
+    (assert-match "\\[X\\] Sunscreen" (buffer-string))))
+
+(deftest checklist-reset/org-gtd-mode-installs-hook ()
+  "org-gtd-mode adds and removes the reset hook."
+  (org-gtd-mode 1)
+  (assert-non-nil (memq #'org-gtd-checklist--maybe-reset-checkboxes
+                        org-after-todo-state-change-hook))
+  (org-gtd-mode -1)
+  (assert-nil (memq #'org-gtd-checklist--maybe-reset-checkboxes
+                    org-after-todo-state-change-hook)))
+
+(provide 'checklist-reset-test)
+;;; checklist-reset-test.el ends here
+```
+
+**Step 2: Run to verify failure.**
+
+**Step 3: Implement.** In `org-gtd-checklist.el`:
+
+```elisp
+(defun org-gtd-checklist--maybe-reset-checkboxes ()
+  "Clear checkboxes in the subtree when a repeating heading is completed.
+Meant for `org-after-todo-state-change-hook'.  When the heading at
+point carries a repeater and just entered a done state, org re-arms
+it; clearing the boxes makes the next run start fresh.  A plain DONE
+on a non-repeating heading is left untouched."
+  (when (and (org-get-repeat)
+             (member org-state org-done-keywords))
+    (org-reset-checkbox-state-subtree)))
+```
+
+In `org-gtd-mode.el`: add `(require 'org-gtd-checklist)` to the requires, then in the enable block (next to the existing `org-after-todo-state-change-hook` adds around line 144):
+
+```elisp
+(add-hook 'org-after-todo-state-change-hook #'org-gtd-checklist--maybe-reset-checkboxes)
+```
+
+and the matching `remove-hook` in the disable block (~line 114).
+
+If the repeating test fails because org's auto-repeat runs *before* the hook and `org-state` is already "TODO": change the condition to also fire when `(and (org-get-repeat) (equal org-state "TODO") org-last-state (member org-last-state org-done-keywords))` — debug with the actual hook semantics, don't guess; add a temporary `message` to see `org-state`/`org-last-todo-state` values.
+
+**Step 4: Run to verify pass.**
+
+**Step 5: Commit** — `git commit -m "feat: reset checkboxes when a repeating heading re-arms"`
+
+---
+
+### Task 5: Wire checklist module into org-gtd.el and command center
+
+**Files:**
+- Modify: `org-gtd.el` (require list, after line 58 `org-gtd-files`)
+- Modify: `org-gtd-command-center.el` (Reflect group + requires)
+- Modify: `test/unit/command-center-test.el`
+
+**Step 1: Add failing test** (mirror the style of existing tests in `command-center-test.el` — read it first; it likely asserts transient suffixes/bindings):
+
+```elisp
+(deftest command-center/has-checklists-entry ()
+  "The Reflect group binds l to visiting checklists."
+  (let ((layout (get 'org-gtd-command-center 'transient--layout)))
+    (assert-match "org-gtd-checklist-visit" (format "%S" layout))))
+```
+
+**Step 2: Run to verify failure.**
+
+**Step 3: Implement.**
+- `org-gtd.el`: add `(require 'org-gtd-checklist)` after `(require 'org-gtd-files)`.
+- `org-gtd-command-center.el`: add `(require 'org-gtd-checklist)` to requires; add to the "Reflect" column after the `R` row:
+
+```elisp
+    ("l" "Checklists" org-gtd-checklist-visit)
+```
+
+**Step 4: Run to verify pass** (`args: test/unit/command-center-test.el`).
+
+**Step 5: Commit** — `git commit -m "feat: expose checklists from the command center"`
+
+---
+
+### Task 6: Review profiles defcustom + accessors
+
+**Files:**
+- Create: `org-gtd-review.el`
+- Create: `test/unit/review-test.el`
+
+**Step 1: Write failing tests**
+
+```elisp
+;;; review-test.el --- Tests for the guided review engine -*- lexical-binding: t -*-
+;; (boilerplate)
+
+(require 'ogt-eunit-prelude "test/helpers/prelude.el")
+
+(e-unit-initialize)
+
+(around-each (proceed context)
+  (ogt-eunit-with-mock-gtd
+    (setq org-gtd-review--state nil
+          org-gtd-review--window-config nil)
+    (funcall proceed context)))
+
+(deftest review/default-profile-is-weekly-three-phase ()
+  "The shipped default is a Weekly Review with the three GTD phases."
+  (let ((profile (assoc "Weekly Review" org-gtd-review-profiles)))
+    (assert-non-nil profile)
+    (assert-equal '("Get Clear" "Get Current" "Get Creative")
+                  (mapcar #'car (cdr profile)))))
+
+(deftest review/default-mind-sweep-references-starter-checklist ()
+  "The Get Clear phase walks the bundled trigger list."
+  (let* ((phases (cdr (assoc "Weekly Review" org-gtd-review-profiles)))
+         (get-clear (cdr (assoc "Get Clear" phases)))
+         (sweep (seq-find (lambda (s) (eq (plist-get s :type) 'checklist))
+                          get-clear)))
+    (assert-equal "Weekly Review triggers" (plist-get sweep :checklist))))
+
+(provide 'review-test)
+;;; review-test.el ends here
+```
+
+**Step 2: Run to verify failure.**
+
+**Step 3: Implement.** Create `org-gtd-review.el` (full boilerplate; Commentary: "Guided, profile-driven review sessions — Weekly Review by default."):
+
+```elisp
+;;;; Requirements
+
+(require 'org)
+(require 'f)
+(require 'seq)
+(require 'org-gtd-core)
+(require 'org-gtd-files)
+(require 'org-gtd-checklist)
+(require 'org-gtd-create)
+
+;;;; Customization
+
+(defcustom org-gtd-review-profiles
+  '(("Weekly Review"
+     ("Get Clear"
+      (:title "Gather loose materials"
+       :type prompt
+       :instruction "Collect loose papers, receipts, and notes.  Capture each one into the inbox.")
+      (:title "Mind sweep"
+       :type checklist
+       :checklist "Weekly Review triggers"
+       :instruction "Walk each trigger.  Press c to capture whatever it shakes loose.")
+      (:title "Inbox to zero"
+       :type command
+       :command org-gtd-process-inbox
+       :instruction "Process every inbox item.  Come back here and press n when the inbox is empty."))
+     ("Get Current"
+      (:title "Review missed items"
+       :type view
+       :view org-gtd-reflect-missed-items
+       :instruction "Reschedule, complete, or cancel anything that slipped.")
+      (:title "Review Waiting-For"
+       :type view
+       :view org-gtd-reflect-upcoming-delegated
+       :instruction "Nudge, close, or re-delegate each delegated item.")
+      (:title "Review next actions"
+       :type view
+       :view org-gtd-show-all-next
+       :instruction "Mark done what is done; check these still feel current.")
+      (:title "Review stuck projects"
+       :type view
+       :view org-gtd-reflect-stuck-projects
+       :instruction "Give every active project a next action."))
+     ("Get Creative"
+      (:title "Review Someday/Maybe"
+       :type view
+       :view org-gtd-reflect-someday-maybe
+       :instruction "Reactivate anything whose time has come.")
+      (:title "Capture new ideas"
+       :type prompt
+       :instruction "Any creative, risky, or fun ideas?  Capture them.")))
+  "Alist of guided review profiles.
+Each entry is (PROFILE-NAME . PHASES); each phase is
+\(PHASE-NAME . STEPS); each step is a plist with :title, :type
+\(one of `prompt', `command', `view', `checklist'), an optional
+:instruction, and the type-specific key :command, :view, or
+:checklist (a template name in the checklists file)."
+  :group 'org-gtd
+  :type 'sexp)
+
+;;;; Variables
+
+(defvar org-gtd-review--state nil
+  "State plist of the active review session.
+Keys: :profile (name string), :phase (index), :step (index),
+:acted (step-local flag), :walk-items, :walk-pos, :done, :skipped.")
+
+(defvar org-gtd-review--window-config nil
+  "Window configuration to restore when the session ends.")
+
+(defconst org-gtd-review--buffer-name "*GTD Review*")
+
+;;;; Accessors
+
+(defun org-gtd-review--phases ()
+  "Return the phases of the active profile."
+  (cdr (assoc (plist-get org-gtd-review--state :profile)
+              org-gtd-review-profiles)))
+
+(defun org-gtd-review--current-phase ()
+  "Return the (NAME . STEPS) phase the session is in."
+  (nth (plist-get org-gtd-review--state :phase) (org-gtd-review--phases)))
+
+(defun org-gtd-review--current-step ()
+  "Return the step plist the session is on."
+  (nth (plist-get org-gtd-review--state :step)
+       (cdr (org-gtd-review--current-phase))))
+```
+
+(Footer: `provide` etc.)
+
+**Step 4: Run to verify pass.**
+
+**Step 5: Commit** — `git commit -m "feat: add org-gtd-review-profiles with default Weekly Review"`
+
+---
+
+### Task 7: Session buffer, prompt steps, phase advance, completion
+
+**Files:**
+- Modify: `org-gtd-review.el`
+- Modify: `test/unit/review-test.el`
+
+**Step 1: Add failing tests**
+
+```elisp
+(defvar review-test--tiny-profile
+  '(("Tiny"
+     ("Phase A"
+      (:title "Step one" :type prompt :instruction "Do one.")
+      (:title "Step two" :type prompt))
+     ("Phase B"
+      (:title "Step three" :type prompt))))
+  "Minimal all-prompt profile for engine tests.")
+
+(deftest review/start-opens-session-buffer-on-first-step ()
+  "Starting a session renders profile, phase, and step 1."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (assert-match "Tiny" (buffer-string))
+      (assert-match "Phase A" (buffer-string))
+      (assert-match "step 1/2" (buffer-string))
+      (assert-match "Step one" (buffer-string)))))
+
+(deftest review/n-advances-through-steps-and-phases ()
+  "n on prompt steps advances; crossing a phase boundary re-renders."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (assert-match "Step two" (buffer-string))
+      (org-gtd-review-next)
+      (assert-match "Phase B" (buffer-string))
+      (assert-match "Step three" (buffer-string)))))
+
+(deftest review/completing-last-step-ends-session ()
+  "Finishing the last step tears the session down."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (org-gtd-review-next)
+      (org-gtd-review-next))
+    (assert-nil org-gtd-review--state)
+    (assert-nil (get-buffer org-gtd-review--buffer-name))))
+
+(deftest review/skip-counts-separately ()
+  "s advances but tallies into :skipped."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-skip))
+    (assert-equal 1 (plist-get org-gtd-review--state :skipped))
+    (assert-equal 0 (plist-get org-gtd-review--state :done))))
+```
+
+**Step 2: Run to verify failure.**
+
+**Step 3: Implement.** Add to `org-gtd-review.el`:
+
+```elisp
+;;;; Keymap and mode
+
+(defvar org-gtd-review-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "n") #'org-gtd-review-next)
+    (define-key map (kbd "s") #'org-gtd-review-skip)
+    (define-key map (kbd "c") #'org-gtd-review-capture)
+    (define-key map (kbd "p") #'org-gtd-review-pause)
+    (define-key map (kbd "q") #'org-gtd-review-quit)
+    map)
+  "Keymap for `org-gtd-review-mode'.")
+
+(define-derived-mode org-gtd-review-mode special-mode "GTD-Review"
+  "Major mode for the guided review session console.
+
+\\{org-gtd-review-mode-map}"
+  :group 'org-gtd)
+
+(with-eval-after-load 'evil
+  (evil-set-initial-state 'org-gtd-review-mode 'emacs)
+  (add-hook 'org-gtd-review-mode-hook #'evil-emacs-state))
+
+;;;; Rendering
+
+(defun org-gtd-review--header-line (step)
+  "Compute the header line advertising keys for STEP."
+  (concat "[n] Do/advance  [s] Skip  [p] Pause  [q] Quit"
+          (when (eq (plist-get step :type) 'checklist)
+            "  [c] Capture")))
+
+(defun org-gtd-review--phase-tracker ()
+  "Render the phase tracker line."
+  (let ((current (plist-get org-gtd-review--state :phase)))
+    (mapconcat
+     (lambda (pair)
+       (let ((i (car pair)) (name (car (cdr pair))))
+         (cond ((< i current) (format "[✓ %s]" name))
+               ((= i current) (format "▸ %s ◂" name))
+               (t (format "[ %s ]" name)))))
+     (seq-map-indexed (lambda (ph i) (cons i ph)) (org-gtd-review--phases))
+     "  ")))
+
+(defun org-gtd-review--render ()
+  "Render the session buffer from `org-gtd-review--state'."
+  (let* ((state org-gtd-review--state)
+         (phase (org-gtd-review--current-phase))
+         (steps (cdr phase))
+         (step (org-gtd-review--current-step)))
+    (with-current-buffer (get-buffer-create org-gtd-review--buffer-name)
+      (unless (derived-mode-p 'org-gtd-review-mode) (org-gtd-review-mode))
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert (format "%s\n\n" (plist-get state :profile)))
+        (insert (org-gtd-review--phase-tracker) "\n\n")
+        (insert (format "%s — step %d/%d\n\n"
+                        (car phase)
+                        (1+ (plist-get state :step))
+                        (length steps)))
+        (insert (format "  %s\n" (plist-get step :title)))
+        (when-let ((instr (plist-get step :instruction)))
+          (insert (format "\n  %s\n" instr)))
+        (when (and (eq (plist-get step :type) 'checklist)
+                   (plist-get state :walk-items))
+          (let ((items (plist-get state :walk-items))
+                (pos (plist-get state :walk-pos)))
+            (insert (format "\n    → %s   (%d/%d)\n"
+                            (nth pos items) (1+ pos) (length items)))))
+        (goto-char (point-min)))
+      (setq header-line-format (org-gtd-review--header-line step))
+      (pop-to-buffer (current-buffer)))))
+
+;;;; Step advancement
+
+(defun org-gtd-review--complete-step (&optional skipped)
+  "Advance past the current step, tallying SKIPPED or done."
+  (let ((state org-gtd-review--state)
+        (counter (if skipped :skipped :done)))
+    (plist-put state counter (1+ (plist-get state counter)))
+    (plist-put state :acted nil)
+    (plist-put state :walk-items nil)
+    (plist-put state :walk-pos 0)
+    (let ((steps (cdr (org-gtd-review--current-phase)))
+          (next-step (1+ (plist-get state :step))))
+      (if (< next-step (length steps))
+          (progn (plist-put state :step next-step)
+                 (org-gtd-review--render))
+        (let ((phases (org-gtd-review--phases))
+              (next-phase (1+ (plist-get state :phase))))
+          (if (< next-phase (length phases))
+              (progn
+                (message "%s complete — on to %s."
+                         (car (nth (plist-get state :phase) phases))
+                         (car (nth next-phase phases)))
+                (plist-put state :phase next-phase)
+                (plist-put state :step 0)
+                (org-gtd-review--render))
+            (org-gtd-review--finish)))))))
+
+(defun org-gtd-review--teardown ()
+  "Kill the session buffer, clear state, restore windows."
+  (setq org-gtd-review--state nil)
+  (when (get-buffer org-gtd-review--buffer-name)
+    (kill-buffer org-gtd-review--buffer-name))
+  (when org-gtd-review--window-config
+    (set-window-configuration org-gtd-review--window-config)
+    (setq org-gtd-review--window-config nil)))
+
+(defun org-gtd-review--finish ()
+  "Complete the session: report, clean up."
+  (let ((done (plist-get org-gtd-review--state :done))
+        (skipped (plist-get org-gtd-review--state :skipped)))
+    (org-gtd-review--teardown)
+    (message (concat "Review complete: %d steps done, %d skipped.  "
+                     "Tip: M-x org-gtd-review-schedule puts this on your calendar.")
+             done skipped)))
+
+;;;; Commands
+
+(defun org-gtd-review-next ()
+  "Do the current step, or advance past it."
+  (interactive)
+  (let* ((step (org-gtd-review--current-step))
+         (type (plist-get step :type)))
+    (pcase type
+      ('prompt (org-gtd-review--complete-step))
+      (_ (message "Step type %s not implemented yet" type)))))
+
+(defun org-gtd-review-skip ()
+  "Skip the current step for this run only."
+  (interactive)
+  (org-gtd-review--complete-step t))
+
+(defun org-gtd-review-capture ()
+  "Capture something to the inbox mid-review."
+  (interactive)
+  (call-interactively #'org-gtd-capture))
+
+(defun org-gtd-review-pause () "Placeholder." (interactive))
+(defun org-gtd-review-quit () "Placeholder." (interactive) (org-gtd-review--teardown))
+
+;;;; Entry point
+
+;;;###autoload
+(defun org-gtd-review (&optional profile-name)
+  "Run a guided review session.
+With more than one profile in `org-gtd-review-profiles', prompt;
+PROFILE-NAME selects one non-interactively."
+  (interactive)
+  (let* ((names (mapcar #'car org-gtd-review-profiles))
+         (name (or profile-name
+                   (if (cdr names)
+                       (completing-read "Review profile: " names nil t)
+                     (car names)))))
+    (unless (assoc name org-gtd-review-profiles)
+      (user-error "No review profile named '%s'" name))
+    (setq org-gtd-review--window-config (current-window-configuration))
+    (setq org-gtd-review--state
+          (list :profile name :phase 0 :step 0 :acted nil
+                :walk-items nil :walk-pos 0 :done 0 :skipped 0))
+    (org-gtd-review--render)))
+```
+
+`org-gtd-capture` needs `(require 'org-gtd-capture)` — add it to the requires.
+
+**Step 4: Run to verify pass.**
+
+**Step 5: Commit** — `git commit -m "feat: guided review session engine with prompt steps"`
+
+---
+
+### Task 8: `command` and `view` step types
+
+**Files:**
+- Modify: `org-gtd-review.el` (the `pcase` in `org-gtd-review-next`)
+- Modify: `test/unit/review-test.el`
+
+**Step 1: Add failing tests**
+
+```elisp
+(defvar review-test--command-calls 0)
+(defun review-test--command ()
+  "Test command that records invocations."
+  (interactive)
+  (setq review-test--command-calls (1+ review-test--command-calls)))
+
+(deftest review/command-step-runs-command-then-advances ()
+  "First n invokes :command; second n advances."
+  (setq review-test--command-calls 0)
+  (let ((org-gtd-review-profiles
+         '(("T" ("P" (:title "Run it" :type command :command review-test--command)
+                     (:title "After" :type prompt))))))
+    (org-gtd-review "T")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (assert-equal 1 review-test--command-calls)
+      (assert-match "Run it" (buffer-string))   ; still on the step
+      (org-gtd-review-next)
+      (assert-match "After" (buffer-string)))))
+
+(deftest review/view-step-shows-view-then-advances ()
+  "First n calls :view (other window); second n advances."
+  (let ((org-gtd-review-profiles
+         '(("T" ("P" (:title "Look" :type view :view review-test--command)
+                     (:title "After" :type prompt))))))
+    (setq review-test--command-calls 0)
+    (org-gtd-review "T")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (assert-equal 1 review-test--command-calls)
+      (org-gtd-review-next)
+      (assert-match "After" (buffer-string)))))
+
+(deftest review/unknown-step-type-skips-with-message ()
+  "An unknown :type never errors; it advances."
+  (let ((org-gtd-review-profiles
+         '(("T" ("P" (:title "Weird" :type frobnicate)
+                     (:title "After" :type prompt))))))
+    (org-gtd-review "T")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (assert-match "After" (buffer-string)))))
+```
+
+**Step 2: Run to verify failure.**
+
+**Step 3: Implement** — replace the `pcase` in `org-gtd-review-next`:
+
+```elisp
+(pcase type
+  ('prompt (org-gtd-review--complete-step))
+  ('command
+   (if (plist-get org-gtd-review--state :acted)
+       (org-gtd-review--complete-step)
+     (plist-put org-gtd-review--state :acted t)
+     (call-interactively (plist-get step :command))))
+  ('view
+   (if (plist-get org-gtd-review--state :acted)
+       (org-gtd-review--complete-step)
+     (plist-put org-gtd-review--state :acted t)
+     (save-selected-window
+       (call-interactively (plist-get step :view)))))
+  ('checklist (org-gtd-review--walk-next step))
+  (_
+   (message "Step type '%s' is unknown — skipping this step" type)
+   (org-gtd-review--complete-step t)))
+```
+
+Add a placeholder so this compiles: `(defun org-gtd-review--walk-next (_step) "Placeholder." nil)` — Task 9 replaces it.
+
+**Step 4: Run to verify pass.**
+
+**Step 5: Commit** — `git commit -m "feat: command and view step types in review sessions"`
+
+---
+
+### Task 9: `checklist` walk step
+
+**Files:**
+- Modify: `org-gtd-review.el`
+- Modify: `test/unit/review-test.el`
+
+**Step 1: Add failing tests**
+
+```elisp
+(defvar review-test--walk-profile
+  '(("Walk"
+     ("P"
+      (:title "Sweep" :type checklist :checklist "Mind sweep prompts")
+      (:title "After" :type prompt)))))
+
+(deftest review/checklist-step-walks-items-one-at-a-time ()
+  "n loads the walk, then advances item by item, then leaves the step."
+  (let ((org-gtd-review-profiles review-test--walk-profile))
+    (org-gtd-review "Walk")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)                       ; load walk, show item 1
+      (assert-match "Boss, partners, colleagues\\?" (buffer-string))
+      (assert-match "(1/8)" (buffer-string))
+      (org-gtd-review-next)                       ; item 2
+      (assert-match "(2/8)" (buffer-string))
+      (dotimes (_ 7) (org-gtd-review-next))       ; through item 8 and out
+      (assert-match "After" (buffer-string)))))
+
+(deftest review/checklist-step-missing-template-auto-advances ()
+  "A missing/empty checklist self-satisfies instead of erroring."
+  (let ((org-gtd-review-profiles
+         '(("W" ("P" (:title "Sweep" :type checklist :checklist "Nope")
+                     (:title "After" :type prompt))))))
+    (org-gtd-review "W")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (assert-match "After" (buffer-string)))))
+```
+
+**Step 2: Run to verify failure.**
+
+**Step 3: Implement** — replace the placeholder:
+
+```elisp
+(defun org-gtd-review--walk-next (step)
+  "Advance the checklist walk for STEP, loading it on first call."
+  (let ((state org-gtd-review--state))
+    (if (not (plist-get state :acted))
+        (let ((items (org-gtd-checklist--items (plist-get step :checklist))))
+          (if (null items)
+              (progn
+                (message "Nothing in checklist '%s' — moving on.  (Edit %s to add items.)"
+                         (plist-get step :checklist)
+                         (org-gtd-checklist--file-path))
+                (org-gtd-review--complete-step))
+            (plist-put state :acted t)
+            (plist-put state :walk-items items)
+            (plist-put state :walk-pos 0)
+            (org-gtd-review--render)))
+      (let ((next (1+ (plist-get state :walk-pos))))
+        (if (< next (length (plist-get state :walk-items)))
+            (progn (plist-put state :walk-pos next)
+                   (org-gtd-review--render))
+          (org-gtd-review--complete-step))))))
+```
+
+**Step 4: Run to verify pass.**
+
+**Step 5: Commit** — `git commit -m "feat: checklist walk steps in review sessions"`
+
+---
+
+### Task 10: Pause, resume, quit
+
+**Files:**
+- Modify: `org-gtd-review.el`
+- Modify: `test/unit/review-test.el`
+
+**Step 1: Add failing tests**
+
+```elisp
+(deftest review/pause-persists-state-and-tears-down ()
+  "p writes review-state.eld and closes the session."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (org-gtd-review-pause))
+    (assert-nil org-gtd-review--state)
+    (assert-non-nil (file-exists-p (org-gtd-review--state-file)))))
+
+(deftest review/resume-restores-position ()
+  "Starting again after a pause offers resume and restores the step."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (org-gtd-review-pause))
+    (with-simulated-input "y" (org-gtd-review))
+    (with-current-buffer org-gtd-review--buffer-name
+      (assert-match "Step two" (buffer-string)))))
+
+(deftest review/resume-with-changed-profile-starts-over ()
+  "Out-of-range saved state falls back to a fresh session."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (org-gtd-review-pause)))
+  (let ((org-gtd-review-profiles
+         '(("Tiny" ("Only" (:title "Sole" :type prompt))))))
+    (org-gtd-review)                       ; no resume prompt: state invalid
+    (with-current-buffer org-gtd-review--buffer-name
+      (assert-match "Sole" (buffer-string)))
+    (assert-nil (file-exists-p (org-gtd-review--state-file)))))
+
+(deftest review/completion-deletes-state-file ()
+  "Finishing a resumed session removes review-state.eld."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-pause))
+    (with-simulated-input "y" (org-gtd-review))
+    (with-current-buffer org-gtd-review--buffer-name
+      (dotimes (_ 3) (org-gtd-review-next)))
+    (assert-nil (file-exists-p (org-gtd-review--state-file)))))
+```
+
+**Step 2: Run to verify failure.**
+
+**Step 3: Implement.** Add persistence section:
+
+```elisp
+;;;; Pause / resume persistence
+
+(defun org-gtd-review--state-file ()
+  "Return the path of the paused-session state file."
+  (f-join org-gtd-directory "review-state.eld"))
+
+(defun org-gtd-review--save-state ()
+  "Serialize the session state to `org-gtd-review--state-file'."
+  (with-temp-file (org-gtd-review--state-file)
+    (let ((print-length nil) (print-level nil))
+      (prin1 org-gtd-review--state (current-buffer)))))
+
+(defun org-gtd-review--load-state ()
+  "Read a saved session state, or nil."
+  (let ((file (org-gtd-review--state-file)))
+    (when (file-exists-p file)
+      (with-temp-buffer
+        (insert-file-contents file)
+        (goto-char (point-min))
+        (ignore-errors (read (current-buffer)))))))
+
+(defun org-gtd-review--delete-state-file ()
+  "Remove the saved session state, if any."
+  (let ((file (org-gtd-review--state-file)))
+    (when (file-exists-p file) (delete-file file))))
+
+(defun org-gtd-review--state-valid-p (state)
+  "Non-nil when STATE still fits `org-gtd-review-profiles'."
+  (when-let* ((profile (assoc (plist-get state :profile)
+                              org-gtd-review-profiles))
+              (phases (cdr profile))
+              (p (plist-get state :phase))
+              (s (plist-get state :step)))
+    (and (integerp p) (integerp s)
+         (< p (length phases))
+         (< s (length (cdr (nth p phases)))))))
+```
+
+Replace the placeholder pause/quit commands:
+
+```elisp
+(defun org-gtd-review-pause ()
+  "Pause the session; `org-gtd-review' resumes it later."
+  (interactive)
+  (org-gtd-review--save-state)
+  (org-gtd-review--teardown)
+  (message "Review paused — run M-x org-gtd-review to resume."))
+
+(defun org-gtd-review-quit ()
+  "Quit the session, offering to keep or abandon progress."
+  (interactive)
+  (if (y-or-n-p "Keep progress to resume later? ")
+      (org-gtd-review-pause)
+    (org-gtd-review--delete-state-file)
+    (org-gtd-review--teardown)
+    (message "Review abandoned.")))
+```
+
+Rework the entry point to check for saved state, and delete the file in `--finish`:
+
+```elisp
+;;;###autoload
+(defun org-gtd-review (&optional profile-name)
+  "Run a guided review session, resuming a paused one when offered.
+With more than one profile in `org-gtd-review-profiles', prompt;
+PROFILE-NAME selects one non-interactively."
+  (interactive)
+  (let ((saved (org-gtd-review--load-state)))
+    (cond
+     ((and saved (not (org-gtd-review--state-valid-p saved)))
+      (org-gtd-review--delete-state-file)
+      (message "Saved review no longer matches your profiles — starting over.")
+      (org-gtd-review--start-fresh profile-name))
+     ((and saved
+           (y-or-n-p (format "Resume paused '%s' review? "
+                             (plist-get saved :profile))))
+      (setq org-gtd-review--window-config (current-window-configuration))
+      (setq org-gtd-review--state saved)
+      (org-gtd-review--render))
+     (t
+      (org-gtd-review--delete-state-file)
+      (org-gtd-review--start-fresh profile-name)))))
+
+(defun org-gtd-review--start-fresh (profile-name)
+  "Start a new session for PROFILE-NAME (prompting when nil)."
+  (let* ((names (mapcar #'car org-gtd-review-profiles))
+         (name (or profile-name
+                   (if (cdr names)
+                       (completing-read "Review profile: " names nil t)
+                     (car names)))))
+    (unless (assoc name org-gtd-review-profiles)
+      (user-error "No review profile named '%s'" name))
+    (setq org-gtd-review--window-config (current-window-configuration))
+    (setq org-gtd-review--state
+          (list :profile name :phase 0 :step 0 :acted nil
+                :walk-items nil :walk-pos 0 :done 0 :skipped 0))
+    (org-gtd-review--render)))
+```
+
+In `org-gtd-review--finish`, add `(org-gtd-review--delete-state-file)` as the first form.
+
+**Step 4: Run to verify pass.**
+
+**Step 5: Commit** — `git commit -m "feat: pause and resume for guided review sessions"`
+
+---
+
+### Task 11: `org-gtd-review-schedule`
+
+**Files:**
+- Modify: `org-gtd-review.el`
+- Create: `test/unit/review-schedule-test.el`
+
+**Step 1: Write failing test**
+
+```elisp
+;; (standard boilerplate + around-each with mock-gtd)
+
+(deftest review-schedule/creates-habit-with-repeater ()
+  "Scheduling creates a properly-typed habit in the tasks file."
+  (org-gtd-review-schedule "Weekly Review" "2026-07-10" ".+1w")
+  (ogt--save-all-buffers)
+  (with-current-buffer (org-gtd--default-file)
+    (let ((text (buffer-string)))
+      (assert-match "Weekly Review" text)
+      (assert-match ":ORG_GTD: +Habits" text)
+      (assert-match "SCHEDULED: <2026-07-10 [A-Za-z]+ \\.\\+1w>" text)
+      (assert-match "M-x org-gtd-review" text))))
+```
+
+(Executor: check how other tests assert on property drawers — property matching may need `":ORG_GTD:\\s-+Habits"`. Adjust the regexp, not the behavior.)
+
+**Step 2: Run to verify failure.**
+
+**Step 3: Implement**
+
+```elisp
+;;;###autoload
+(defun org-gtd-review-schedule (&optional profile-name date repeater)
+  "Create a recurring habit reminding you to run a review.
+PROFILE-NAME, DATE (YYYY-MM-DD) and REPEATER (org repeater like
+\".+1w\") are prompted for interactively."
+  (interactive)
+  (let* ((names (mapcar #'car org-gtd-review-profiles))
+         (profile (or profile-name
+                      (if (cdr names)
+                          (completing-read "Review profile: " names nil t)
+                        (car names))))
+         (date (or date (org-read-date nil nil nil "First review: ")))
+         (repeater (or repeater
+                       (read-string "How often? (org repeater, e.g. .+1w): "
+                                    nil nil ".+1w"))))
+    (org-gtd-create-item 'habit profile
+                         `((:when . ,(format "<%s %s>" date repeater))))
+    (with-current-buffer (org-gtd--default-file)
+      (org-with-wide-buffer
+       (goto-char (point-min))
+       (when (re-search-forward
+              (format "^\\*+ +.*%s[ \t]*$" (regexp-quote profile)) nil t)
+         (org-end-of-meta-data t)
+         (insert "Run M-x org-gtd-review when you sit down for this.\n")
+         (basic-save-buffer))))
+    (message "'%s' reminder created — it will show up in your engage view."
+             profile)))
+```
+
+**Step 4: Run to verify pass.**
+
+**Step 5: Commit** — `git commit -m "feat: org-gtd-review-schedule creates a recurring review habit"`
+
+---
+
+### Task 12: `org-gtd-init-system`
+
+**Files:**
+- Create: `org-gtd-init.el`
+- Create: `test/unit/init-system-test.el`
+
+**Step 1: Write failing tests**
+
+```elisp
+;; (standard boilerplate + around-each with mock-gtd)
+
+(deftest init-system/creates-all-gtd-files ()
+  "Init ensures tasks, inbox, and seeded checklists files exist."
+  (with-simulated-input "n" (org-gtd-init-system))
+  (assert-non-nil (file-exists-p (org-gtd--path org-gtd-default-file-name)))
+  (assert-non-nil (file-exists-p (org-gtd-inbox-path)))
+  (assert-non-nil (file-exists-p (org-gtd-checklist--file-path))))
+
+(deftest init-system/is-idempotent ()
+  "Running init twice neither errors nor duplicates seeds."
+  (with-simulated-input "n" (org-gtd-init-system))
+  (with-simulated-input "n" (org-gtd-init-system))
+  (with-current-buffer (org-gtd-checklist--file-buffer)
+    (goto-char (point-min))
+    (assert-equal 1 (count-matches "^\\* Weekly Review triggers$"))))
+
+(deftest init-system/offers-review-schedule ()
+  "Answering yes routes into org-gtd-review-schedule."
+  (with-simulated-input "y RET RET RET"
+    (org-gtd-init-system))
+  (ogt--save-all-buffers)
+  (with-current-buffer (org-gtd--default-file)
+    (assert-match ":ORG_GTD: +Habits" (buffer-string))))
+```
+
+(Executor: the `"y RET RET RET"` drives y-or-n-p + the three schedule prompts — profile picker is skipped with a single profile, `org-read-date` and `read-string` take defaults on RET. If `org-read-date` misbehaves under simulated input, call `(org-gtd-review-schedule "Weekly Review" "2026-07-10" ".+1w")` from a `cl-letf`-stubbed `y-or-n-p` instead; the point of the test is the wiring, not the prompts.)
+
+**Step 2: Run to verify failure.**
+
+**Step 3: Implement.** Create `org-gtd-init.el` (boilerplate; Commentary: "Idempotent first-time setup concierge."):
+
+```elisp
+;;;; Requirements
+
+(require 'org-gtd-core)
+(require 'org-gtd-files)
+(require 'org-gtd-capture)
+(require 'org-gtd-checklist)
+(require 'org-gtd-review)
+
+;;;; Commands
+
+;;;###autoload
+(defun org-gtd-init-system ()
+  "Set up org-gtd for first use.  Safe to run again at any time.
+Ensures the GTD files exist (seeding starter checklists) and offers
+to schedule a recurring Weekly Review.  Every step reports and skips
+when already satisfied — lazy initialization elsewhere is untouched."
+  (interactive)
+  (unless (file-directory-p org-gtd-directory)
+    (make-directory org-gtd-directory t))
+  (org-gtd--default-file)
+  (org-gtd-inbox-path)
+  (org-gtd-checklist--file-buffer)
+  (message "✓ GTD files ready in %s" (abbreviate-file-name org-gtd-directory))
+  (if (org-gtd-init--review-reminder-exists-p)
+      (message "✓ A review reminder is already scheduled")
+    (when (y-or-n-p "Schedule a recurring Weekly Review reminder? ")
+      (call-interactively #'org-gtd-review-schedule))))
+
+;;;; Functions
+
+(defun org-gtd-init--review-reminder-exists-p ()
+  "Non-nil when a habit named after a review profile already exists."
+  (with-current-buffer (org-gtd--default-file)
+    (org-with-wide-buffer
+     (goto-char (point-min))
+     (catch 'found
+       (while (re-search-forward org-heading-regexp nil t)
+         (when (and (equal (org-entry-get (point) "ORG_GTD") "Habits")
+                    (assoc (org-get-heading t t t t)
+                           org-gtd-review-profiles))
+           (throw 'found t)))
+       nil))))
+```
+
+**Step 4: Run to verify pass.**
+
+**Step 5: Commit** — `git commit -m "feat: org-gtd-init-system first-run concierge"`
+
+---
+
+### Task 13: Wire review + init into org-gtd.el and command center
+
+**Files:**
+- Modify: `org-gtd.el` (requires)
+- Modify: `org-gtd-command-center.el`
+- Modify: `test/unit/command-center-test.el`
+
+**Step 1: Add failing test**
+
+```elisp
+(deftest command-center/has-guided-review-entry ()
+  "The Reflect group binds w to the guided review."
+  (let ((layout (get 'org-gtd-command-center 'transient--layout)))
+    (assert-match "org-gtd-review" (format "%S" layout))))
+```
+
+**Step 2: Run to verify failure.**
+
+**Step 3: Implement.**
+- `org-gtd.el`: add `(require 'org-gtd-review)` after `(require 'org-gtd-someday-review)` and `(require 'org-gtd-init)` just before `(require 'org-gtd-command-center)`.
+- `org-gtd-command-center.el`: `(require 'org-gtd-review)`; add as the **first** row of the Reflect column:
+
+```elisp
+    ("w" "Weekly Review (guided)" org-gtd-review)
+```
+
+**Step 4: Run to verify pass** (also re-run `test/unit/checklist-test.el` and `test/unit/review-test.el` to catch load-order issues).
+
+**Step 5: Commit** — `git commit -m "feat: guided review and init entries in command center"`
+
+---
+
+### Task 14: Documentation
+
+**Files:**
+- Modify: `doc/org-gtd.org` (new sections)
+- Modify: `CHANGELOG.org` (unreleased entry)
+
+**Step 1: Read** the manual's existing structure (`doc/org-gtd.org`) to match heading levels and tone.
+
+**Step 2: Add a "Checklists" section** covering: the `checklists.org` convention, editing = customizing, `org-gtd-checklist-insert`, the reset-on-repeat behavior, and the composition pattern (insert → clarify → organize as habit for a recurring checklist-as-task).
+
+**Step 3: Add a "Weekly Review (guided)" section** covering: `org-gtd-review`, the profile defcustom with the full default value reproduced, each step type, keys (`n s p q`, `c` on walks), pause/resume, `org-gtd-review-schedule`, `org-gtd-init-system`.
+
+**Step 4: CHANGELOG.org** — add under an Unreleased heading:
+
+```org
+- Add =checklists.org= reusable checklist templates with =org-gtd-checklist-insert=
+- Reset checkboxes automatically when a repeating heading re-arms
+- Add =org-gtd-review=: guided, pausable, customizable review sessions (Weekly Review built in)
+- Add =org-gtd-review-schedule= and =org-gtd-init-system=
+- Command center: =w= guided review, =l= checklists
+```
+
+**Step 5: Commit** — `git commit -m "docs: manual and changelog for checklists and guided review"`
+
+---
+
+### Task 15: Full verification
+
+**Step 1: Full test suite** — Skill tool, `skill: test`, no args. Expected: all green. Fix any regressions (suspect load order and hook leaks first — see memory notes on `around-each`).
+
+**Step 2: Compile clean**
+
+```bash
+~/bin/eldev clean && ~/bin/eldev compile --warnings-as-errors
+```
+
+Expected: no warnings. Byte-compile warnings about undeclared functions mean a missing `require` or `declare-function`.
+
+**Step 3: Lint**
+
+```bash
+~/bin/eldev lint --file="org-gtd-checklist.el" --file="org-gtd-review.el" --file="org-gtd-init.el"
+```
+
+Fix checkdoc/package-lint complaints (docstring format, `:type` specs).
+
+**Step 4: yx bookkeeping**
+
+```bash
+yx start implement-checklists-and-guided-weekly-review-izj1   # if not already
+yx done implement-checklists-and-guided-weekly-review-izj1
+```
+
+**Step 5: Commit any fixes** — `git commit -m "chore: lint and compile fixes for checklist/review modules"`
+
+**Step 6:** Use superpowers:finishing-a-development-branch (the branch already has draft PR #294 — push and mark it ready or hand off per user preference).
+
+---
+
+## Deferred (do NOT implement — tracked in the design doc §7/§8)
+
+Stats block, review log, back-step, org-heading `walk` step type, someday-review generalization, checklist manager transient, `CHECKLIST_KIND`, instance↔template links, agenda-files/keywords steps in init-system.

--- a/org-gtd-checklist.el
+++ b/org-gtd-checklist.el
@@ -1,0 +1,94 @@
+;;; org-gtd-checklist.el --- Reusable checklist templates for org-gtd -*- lexical-binding: t; coding: utf-8 -*-
+;;
+;; Copyright © 2026 Aldric Giacomoni
+
+;; Author: Aldric Giacomoni <trevoke@gmail.com>
+;; This file is not part of GNU Emacs.
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; Reusable checklist templates for org-gtd, stored as plain org
+;; headings in a checklists file inside `org-gtd-directory'.  Each
+;; top-level heading is a template whose checkbox items can be spawned
+;; as a fresh subtree wherever needed.
+;;
+;;; Code:
+
+;;;; Requirements
+
+(require 'org)
+(require 'f)
+
+(require 'org-gtd-core)
+(require 'org-gtd-files)
+
+;;;; Constants
+
+(defconst org-gtd-checklist-file-name "checklists"
+  "Base name of the checklist templates file inside `org-gtd-directory'.")
+
+(defconst org-gtd-checklist--starter-contents
+  "* Weekly Review triggers
+- [ ] Projects started but not completed?
+- [ ] Commitments or promises made to others?
+- [ ] Communications to make or expecting (calls, emails)?
+- [ ] Writing to finish or submit?
+- [ ] Meetings that need to be set or requested?
+- [ ] Decisions that need to be made?
+- [ ] Waiting for someone else's reply or delivery?
+- [ ] Financial or administrative loose ends?
+
+* Mind sweep prompts
+- [ ] Boss, partners, colleagues?
+- [ ] Family and friends?
+- [ ] Household — repairs, maintenance, errands?
+- [ ] Health — appointments, checkups, exercise?
+- [ ] Finances — bills, taxes, banks?
+- [ ] Car or transportation?
+- [ ] Creative ideas, things to learn?
+- [ ] Places to go, people to see?
+"
+  "Contents used to seed a brand-new checklists file.")
+
+;;;; Functions
+
+;;;;; Private
+
+(defun org-gtd-checklist--file-path ()
+  "Return the full path to the checklists file."
+  (org-gtd--path org-gtd-checklist-file-name))
+
+(defun org-gtd-checklist--file-buffer ()
+  "Return a buffer visiting the checklists file, creating it if needed.
+A newly created file is seeded with starter templates."
+  (let ((path (org-gtd-checklist--file-path)))
+    (org-gtd--ensure-file-exists path org-gtd-checklist--starter-contents)
+    (find-file-noselect path)))
+
+;;;;; Commands
+
+;;;###autoload
+(defun org-gtd-checklist-visit ()
+  "Visit the checklist templates file.
+Each top-level heading is a reusable checklist template."
+  (interactive)
+  (pop-to-buffer (org-gtd-checklist--file-buffer)))
+
+;;;; Footer
+
+(provide 'org-gtd-checklist)
+
+;;; org-gtd-checklist.el ends here

--- a/org-gtd-checklist.el
+++ b/org-gtd-checklist.el
@@ -30,7 +30,6 @@
 ;;;; Requirements
 
 (require 'org)
-(require 'f)
 
 (require 'org-gtd-core)
 (require 'org-gtd-files)
@@ -78,14 +77,32 @@ A newly created file is seeded with starter templates."
     (org-gtd--ensure-file-exists path org-gtd-checklist--starter-contents)
     (find-file-noselect path)))
 
+(defun org-gtd-checklist--heading-name ()
+  "Return the normalized template name of the heading at point.
+The name is the bare heading title, without tags, TODO keyword,
+priority cookie or COMMENT keyword."
+  (substring-no-properties (org-get-heading t t t t)))
+
+(defun org-gtd-checklist--goto-template (name)
+  "Move point to the template heading whose normalized title is NAME.
+Search the current buffer's top-level headings, skipping COMMENT
+headings.  Return the heading position, or nil when no template
+matches NAME, in which case point is left unspecified."
+  (goto-char (point-min))
+  (let (found)
+    (while (and (not found)
+                (re-search-forward "^\\* " nil t))
+      (when (and (not (org-in-commented-heading-p t))
+                 (string= name (org-gtd-checklist--heading-name)))
+        (setq found (line-beginning-position))))
+    (when found (goto-char found))))
+
 (defun org-gtd-checklist--items (name)
   "Return the ordered checkbox item strings of checklist NAME.
 Return nil when no checklist NAME exists or it has no items."
   (with-current-buffer (org-gtd-checklist--file-buffer)
     (org-with-wide-buffer
-     (goto-char (point-min))
-     (when (re-search-forward
-            (format "^\\* +%s[ \t]*$" (regexp-quote name)) nil t)
+     (when (org-gtd-checklist--goto-template name)
        (let ((end (save-excursion (org-end-of-subtree t t) (point)))
              items)
          (while (re-search-forward
@@ -96,13 +113,16 @@ Return nil when no checklist NAME exists or it has no items."
 ;;;;; Public
 
 (defun org-gtd-checklist-names ()
-  "Return the list of checklist template names, in file order."
+  "Return the list of checklist template names, in file order.
+Names are the bare heading titles, without tags, TODO keywords or
+priority cookies.  Headings commented out with COMMENT are excluded."
   (with-current-buffer (org-gtd-checklist--file-buffer)
     (org-with-wide-buffer
      (goto-char (point-min))
      (let (names)
-       (while (re-search-forward "^\\* +\\(.+?\\)[ \t]*$" nil t)
-         (push (match-string-no-properties 1) names))
+       (while (re-search-forward "^\\* " nil t)
+         (unless (org-in-commented-heading-p t)
+           (push (org-gtd-checklist--heading-name) names)))
        (nreverse names)))))
 
 ;;;;; Commands
@@ -115,21 +135,25 @@ To make it a recurring task, organize it (e.g. as a habit) with
 `org-gtd-clarify-item' after inserting."
   (interactive
    (list (completing-read "Checklist: " (org-gtd-checklist-names) nil t)))
+  (unless (derived-mode-p 'org-mode)
+    (user-error "Not in an org buffer"))
   (let ((subtree
          (with-current-buffer (org-gtd-checklist--file-buffer)
            (org-with-wide-buffer
-            (goto-char (point-min))
-            (unless (re-search-forward
-                     (format "^\\* +%s[ \t]*$" (regexp-quote name)) nil t)
+            (unless (org-gtd-checklist--goto-template name)
               (user-error "No checklist named '%s' — edit %s"
                           name (org-gtd-checklist--file-path)))
             (buffer-substring-no-properties
-             (line-beginning-position)
+             (point)
              (save-excursion (org-end-of-subtree t t) (point))))))
         ;; Insert as a child of the heading point is under, or at
         ;; top level when the buffer has no heading above point.
         (target-level (1+ (or (org-current-level) 0))))
-    (unless (bolp) (insert "\n"))
+    ;; On a heading line, insert as first child below that heading;
+    ;; never split the heading text at point.
+    (if (org-at-heading-p)
+        (progn (end-of-line) (insert "\n"))
+      (unless (bolp) (insert "\n")))
     (org-paste-subtree target-level subtree)))
 
 ;;;###autoload

--- a/org-gtd-checklist.el
+++ b/org-gtd-checklist.el
@@ -97,6 +97,16 @@ matches NAME, in which case point is left unspecified."
         (setq found (line-beginning-position))))
     (when found (goto-char found))))
 
+(defun org-gtd-checklist--maybe-reset-checkboxes ()
+  "Clear checkboxes in the subtree when a repeating heading is completed.
+Meant for `org-after-todo-state-change-hook'.  When the heading at
+point carries a repeater and just entered a done state, org re-arms
+it; clearing the boxes makes the next run start fresh.  A plain DONE
+on a non-repeating heading is left untouched."
+  (when (and (org-get-repeat)
+             (member org-state org-done-keywords))
+    (org-reset-checkbox-state-subtree)))
+
 (defun org-gtd-checklist--items (name)
   "Return the ordered checkbox item strings of checklist NAME.
 Return nil when no checklist NAME exists or it has no items."

--- a/org-gtd-checklist.el
+++ b/org-gtd-checklist.el
@@ -78,6 +78,33 @@ A newly created file is seeded with starter templates."
     (org-gtd--ensure-file-exists path org-gtd-checklist--starter-contents)
     (find-file-noselect path)))
 
+(defun org-gtd-checklist--items (name)
+  "Return the ordered checkbox item strings of checklist NAME.
+Return nil when no checklist NAME exists or it has no items."
+  (with-current-buffer (org-gtd-checklist--file-buffer)
+    (org-with-wide-buffer
+     (goto-char (point-min))
+     (when (re-search-forward
+            (format "^\\* +%s[ \t]*$" (regexp-quote name)) nil t)
+       (let ((end (save-excursion (org-end-of-subtree t t) (point)))
+             items)
+         (while (re-search-forward
+                 "^[ \t]*- \\[[ Xx-]\\] +\\(.+?\\)[ \t]*$" end t)
+           (push (match-string-no-properties 1) items))
+         (nreverse items))))))
+
+;;;;; Public
+
+(defun org-gtd-checklist-names ()
+  "Return the list of checklist template names, in file order."
+  (with-current-buffer (org-gtd-checklist--file-buffer)
+    (org-with-wide-buffer
+     (goto-char (point-min))
+     (let (names)
+       (while (re-search-forward "^\\* +\\(.+?\\)[ \t]*$" nil t)
+         (push (match-string-no-properties 1) names))
+       (nreverse names)))))
+
 ;;;;; Commands
 
 ;;;###autoload

--- a/org-gtd-checklist.el
+++ b/org-gtd-checklist.el
@@ -108,6 +108,31 @@ Return nil when no checklist NAME exists or it has no items."
 ;;;;; Commands
 
 ;;;###autoload
+(defun org-gtd-checklist-insert (name)
+  "Insert a fresh instance of checklist NAME as a subtree at point.
+The copy is an ordinary org subtree — org-gtd does not track it.
+To make it a recurring task, organize it (e.g. as a habit) with
+`org-gtd-clarify-item' after inserting."
+  (interactive
+   (list (completing-read "Checklist: " (org-gtd-checklist-names) nil t)))
+  (let ((subtree
+         (with-current-buffer (org-gtd-checklist--file-buffer)
+           (org-with-wide-buffer
+            (goto-char (point-min))
+            (unless (re-search-forward
+                     (format "^\\* +%s[ \t]*$" (regexp-quote name)) nil t)
+              (user-error "No checklist named '%s' — edit %s"
+                          name (org-gtd-checklist--file-path)))
+            (buffer-substring-no-properties
+             (line-beginning-position)
+             (save-excursion (org-end-of-subtree t t) (point))))))
+        ;; Insert as a child of the heading point is under, or at
+        ;; top level when the buffer has no heading above point.
+        (target-level (1+ (or (org-current-level) 0))))
+    (unless (bolp) (insert "\n"))
+    (org-paste-subtree target-level subtree)))
+
+;;;###autoload
 (defun org-gtd-checklist-visit ()
   "Visit the checklist templates file.
 Each top-level heading is a reusable checklist template."

--- a/org-gtd-checklist.el
+++ b/org-gtd-checklist.el
@@ -153,6 +153,7 @@ priority cookies.  Headings commented out with COMMENT are excluded."
 The copy is an ordinary org subtree — org-gtd does not track it.
 To make it a recurring task, organize it (e.g. as a habit) with
 `org-gtd-clarify-item' after inserting."
+  (declare (modes org-mode))
   (interactive
    (list (completing-read "Checklist: " (org-gtd-checklist-template-names) nil t)))
   (unless (derived-mode-p 'org-mode)
@@ -169,11 +170,10 @@ To make it a recurring task, organize it (e.g. as a habit) with
         ;; Insert as a child of the heading point is under, or at
         ;; top level when the buffer has no heading above point.
         (target-level (1+ (or (org-current-level) 0))))
-    ;; On a heading line, insert as first child below that heading;
-    ;; never split the heading text at point.
-    (if (org-at-heading-p)
-        (progn (end-of-line) (insert "\n"))
-      (unless (bolp) (insert "\n")))
+    ;; Anchor at the end of the current line so we never split heading
+    ;; or body text at point; `org-paste-subtree' then drops the copy as
+    ;; a correctly-leveled subtree on its own line, with no stray blank.
+    (end-of-line)
     (org-paste-subtree target-level subtree)))
 
 ;;;###autoload

--- a/org-gtd-checklist.el
+++ b/org-gtd-checklist.el
@@ -34,6 +34,10 @@
 (require 'org-gtd-core)
 (require 'org-gtd-files)
 
+;; Dynamically bound by `org-todo' around `org-after-todo-state-change-hook'.
+(defvar org-state)
+(defvar org-last-state)
+
 ;;;; Constants
 
 (defconst org-gtd-checklist-file-name "checklists"
@@ -100,12 +104,18 @@ matches NAME, in which case point is left unspecified."
 (defun org-gtd-checklist--maybe-reset-checkboxes ()
   "Clear checkboxes in the subtree when a repeating heading is completed.
 Meant for `org-after-todo-state-change-hook'.  When the heading at
-point carries a repeater and just entered a done state, org re-arms
-it; clearing the boxes makes the next run start fresh.  A plain DONE
-on a non-repeating heading is left untouched."
-  (when (and (org-get-repeat)
-             (member org-state org-done-keywords))
-    (org-reset-checkbox-state-subtree)))
+point carries a live repeater and just entered a done state from a
+non-done one, org re-arms it; clearing the boxes makes the next run
+start fresh.  The guard mirrors `org-auto-repeat-maybe' exactly, so
+whenever org does not re-arm — a non-repeating heading, a cancelled
+\(zero-interval) repeater, a done-to-done transition — the completion
+record is left untouched."
+  (let ((repeat (org-get-repeat)))
+    (when (and repeat
+               (/= 0 (string-to-number (substring repeat 1)))
+               (member org-state org-done-keywords)
+               (not (member org-last-state org-done-keywords)))
+      (org-reset-checkbox-state-subtree))))
 
 (defun org-gtd-checklist--items (name)
   "Return the ordered checkbox item strings of checklist NAME.

--- a/org-gtd-checklist.el
+++ b/org-gtd-checklist.el
@@ -21,7 +21,7 @@
 ;;; Commentary:
 ;;
 ;; Reusable checklist templates for org-gtd, stored as plain org
-;; headings in a checklists file inside `org-gtd-directory'.  Each
+;; headings in a checklist templates file inside `org-gtd-directory'.  Each
 ;; top-level heading is a template whose checkbox items can be spawned
 ;; as a fresh subtree wherever needed.
 ;;
@@ -40,10 +40,10 @@
 
 ;;;; Constants
 
-(defconst org-gtd-checklist-file-name "checklists"
+(defconst org-gtd-checklist-template-file-name "checklist-templates"
   "Base name of the checklist templates file inside `org-gtd-directory'.")
 
-(defconst org-gtd-checklist--starter-contents
+(defconst org-gtd-checklist-template--starter-contents
   "* Weekly Review triggers
 - [ ] Projects started but not completed?
 - [ ] Commitments or promises made to others?
@@ -64,30 +64,30 @@
 - [ ] Creative ideas, things to learn?
 - [ ] Places to go, people to see?
 "
-  "Contents used to seed a brand-new checklists file.")
+  "Contents used to seed a brand-new checklist templates file.")
 
 ;;;; Functions
 
 ;;;;; Private
 
-(defun org-gtd-checklist--file-path ()
-  "Return the full path to the checklists file."
-  (org-gtd--path org-gtd-checklist-file-name))
+(defun org-gtd-checklist-template--file-path ()
+  "Return the full path to the checklist templates file."
+  (org-gtd--path org-gtd-checklist-template-file-name))
 
-(defun org-gtd-checklist--file-buffer ()
-  "Return a buffer visiting the checklists file, creating it if needed.
+(defun org-gtd-checklist-template--file-buffer ()
+  "Return a buffer visiting the checklist templates file, creating it if needed.
 A newly created file is seeded with starter templates."
-  (let ((path (org-gtd-checklist--file-path)))
-    (org-gtd--ensure-file-exists path org-gtd-checklist--starter-contents)
+  (let ((path (org-gtd-checklist-template--file-path)))
+    (org-gtd--ensure-file-exists path org-gtd-checklist-template--starter-contents)
     (find-file-noselect path)))
 
-(defun org-gtd-checklist--heading-name ()
+(defun org-gtd-checklist-template--heading-name ()
   "Return the normalized template name of the heading at point.
 The name is the bare heading title, without tags, TODO keyword,
 priority cookie or COMMENT keyword."
   (substring-no-properties (org-get-heading t t t t)))
 
-(defun org-gtd-checklist--goto-template (name)
+(defun org-gtd-checklist-template--goto (name)
   "Move point to the template heading whose normalized title is NAME.
 Search the current buffer's top-level headings, skipping COMMENT
 headings.  Return the heading position, or nil when no template
@@ -97,7 +97,7 @@ matches NAME, in which case point is left unspecified."
     (while (and (not found)
                 (re-search-forward "^\\* " nil t))
       (when (and (not (org-in-commented-heading-p t))
-                 (string= name (org-gtd-checklist--heading-name)))
+                 (string= name (org-gtd-checklist-template--heading-name)))
         (setq found (line-beginning-position))))
     (when found (goto-char found))))
 
@@ -117,12 +117,12 @@ record is left untouched."
                (not (member org-last-state org-done-keywords)))
       (org-reset-checkbox-state-subtree))))
 
-(defun org-gtd-checklist--items (name)
+(defun org-gtd-checklist-template--items (name)
   "Return the ordered checkbox item strings of checklist NAME.
 Return nil when no checklist NAME exists or it has no items."
-  (with-current-buffer (org-gtd-checklist--file-buffer)
+  (with-current-buffer (org-gtd-checklist-template--file-buffer)
     (org-with-wide-buffer
-     (when (org-gtd-checklist--goto-template name)
+     (when (org-gtd-checklist-template--goto name)
        (let ((end (save-excursion (org-end-of-subtree t t) (point)))
              items)
          (while (re-search-forward
@@ -132,37 +132,37 @@ Return nil when no checklist NAME exists or it has no items."
 
 ;;;;; Public
 
-(defun org-gtd-checklist-names ()
+(defun org-gtd-checklist-template-names ()
   "Return the list of checklist template names, in file order.
 Names are the bare heading titles, without tags, TODO keywords or
 priority cookies.  Headings commented out with COMMENT are excluded."
-  (with-current-buffer (org-gtd-checklist--file-buffer)
+  (with-current-buffer (org-gtd-checklist-template--file-buffer)
     (org-with-wide-buffer
      (goto-char (point-min))
      (let (names)
        (while (re-search-forward "^\\* " nil t)
          (unless (org-in-commented-heading-p t)
-           (push (org-gtd-checklist--heading-name) names)))
+           (push (org-gtd-checklist-template--heading-name) names)))
        (nreverse names)))))
 
 ;;;;; Commands
 
 ;;;###autoload
-(defun org-gtd-checklist-insert (name)
+(defun org-gtd-checklist-template-insert (name)
   "Insert a fresh instance of checklist NAME as a subtree at point.
 The copy is an ordinary org subtree — org-gtd does not track it.
 To make it a recurring task, organize it (e.g. as a habit) with
 `org-gtd-clarify-item' after inserting."
   (interactive
-   (list (completing-read "Checklist: " (org-gtd-checklist-names) nil t)))
+   (list (completing-read "Checklist: " (org-gtd-checklist-template-names) nil t)))
   (unless (derived-mode-p 'org-mode)
     (user-error "Not in an org buffer"))
   (let ((subtree
-         (with-current-buffer (org-gtd-checklist--file-buffer)
+         (with-current-buffer (org-gtd-checklist-template--file-buffer)
            (org-with-wide-buffer
-            (unless (org-gtd-checklist--goto-template name)
+            (unless (org-gtd-checklist-template--goto name)
               (user-error "No checklist named '%s' — edit %s"
-                          name (org-gtd-checklist--file-path)))
+                          name (org-gtd-checklist-template--file-path)))
             (buffer-substring-no-properties
              (point)
              (save-excursion (org-end-of-subtree t t) (point))))))
@@ -177,11 +177,11 @@ To make it a recurring task, organize it (e.g. as a habit) with
     (org-paste-subtree target-level subtree)))
 
 ;;;###autoload
-(defun org-gtd-checklist-visit ()
+(defun org-gtd-checklist-template-visit ()
   "Visit the checklist templates file.
 Each top-level heading is a reusable checklist template."
   (interactive)
-  (pop-to-buffer (org-gtd-checklist--file-buffer)))
+  (pop-to-buffer (org-gtd-checklist-template--file-buffer)))
 
 ;;;; Footer
 

--- a/org-gtd-clarify.el
+++ b/org-gtd-clarify.el
@@ -34,6 +34,10 @@
 (require 'org-gtd-wip)
 (require 'org-gtd-horizons)
 
+;; Defined in org-gtd-capture (loaded at the org-gtd.el level); declared
+;; here to avoid a require cycle while silencing the compiler.
+(declare-function org-gtd-inbox-path "org-gtd-capture")
+
 ;;;; Customization
 
 (defgroup org-gtd-clarify nil

--- a/org-gtd-command-center.el
+++ b/org-gtd-command-center.el
@@ -31,6 +31,7 @@
 (require 'transient)
 (require 'org-gtd-archive)
 (require 'org-gtd-capture)
+(require 'org-gtd-checklist)
 (require 'org-gtd-clarify)
 (require 'org-gtd-engage)
 (require 'org-gtd-process)
@@ -54,7 +55,8 @@
     ("y" "Someday/maybe" org-gtd-reflect-someday-maybe)
     ("d" "Upcoming delegated" org-gtd-reflect-upcoming-delegated)
     ("r" "Completed items" org-gtd-reflect-completed-items)
-    ("R" "Completed projects" org-gtd-reflect-completed-projects)]
+    ("R" "Completed projects" org-gtd-reflect-completed-projects)
+    ("l" "Checklists" org-gtd-checklist-visit)]
    ["Archive"
     ("A" "Archive completed" org-gtd-archive-completed-items)]]
   ["Review System"

--- a/org-gtd-command-center.el
+++ b/org-gtd-command-center.el
@@ -58,7 +58,7 @@
     ("d" "Upcoming delegated" org-gtd-reflect-upcoming-delegated)
     ("r" "Completed items" org-gtd-reflect-completed-items)
     ("R" "Completed projects" org-gtd-reflect-completed-projects)
-    ("l" "Checklists" org-gtd-checklist-visit)]
+    ("l" "Checklist templates" org-gtd-checklist-template-visit)]
    ["Archive"
     ("A" "Archive completed" org-gtd-archive-completed-items)]]
   ["Review System"

--- a/org-gtd-command-center.el
+++ b/org-gtd-command-center.el
@@ -36,6 +36,7 @@
 (require 'org-gtd-engage)
 (require 'org-gtd-process)
 (require 'org-gtd-reflect)
+(require 'org-gtd-review)
 
 ;;;; Main Transient
 
@@ -51,6 +52,7 @@
     ("p" "Process inbox" org-gtd-process-inbox)
     ("k" "Clarify at point" org-gtd-clarify-item)]]
   [["Reflect"
+    ("w" "Weekly Review (guided)" org-gtd-review)
     ("a" "Area of focus" org-gtd-reflect-area-of-focus)
     ("y" "Someday/maybe" org-gtd-reflect-someday-maybe)
     ("d" "Upcoming delegated" org-gtd-reflect-upcoming-delegated)

--- a/org-gtd-init.el
+++ b/org-gtd-init.el
@@ -37,7 +37,7 @@
 ;;;###autoload
 (defun org-gtd-init-system ()
   "Set up org-gtd for first use.  Safe to run again at any time.
-Ensures the GTD files exist (seeding starter checklists) and offers
+Ensures the GTD files exist (seeding starter checklist templates) and offers
 to schedule a recurring Weekly Review.  Every step reports and skips
 when already satisfied — lazy initialization elsewhere is untouched."
   (interactive)
@@ -47,7 +47,7 @@ when already satisfied — lazy initialization elsewhere is untouched."
           (make-directory org-gtd-directory t))
         (org-gtd--default-file)
         (org-gtd-inbox-path)
-        (org-gtd-checklist--file-buffer))
+        (org-gtd-checklist-template--file-buffer))
     (file-error
      (user-error "Could not create GTD files (%s) — check that %s is writable, or customize org-gtd-directory"
                  (error-message-string err)

--- a/org-gtd-init.el
+++ b/org-gtd-init.el
@@ -1,0 +1,59 @@
+;;; org-gtd-init.el --- First-time setup for org-gtd -*- lexical-binding: t; coding: utf-8 -*-
+;;
+;; Copyright © 2026 Aldric Giacomoni
+
+;; Author: Aldric Giacomoni <trevoke@gmail.com>
+;; This file is not part of GNU Emacs.
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; Idempotent first-time setup concierge.
+;;
+;;; Code:
+
+;;;; Requirements
+
+(require 'org-gtd-core)
+(require 'org-gtd-files)
+(require 'org-gtd-capture)
+(require 'org-gtd-checklist)
+(require 'org-gtd-review)
+
+;;;; Commands
+
+;;;###autoload
+(defun org-gtd-init-system ()
+  "Set up org-gtd for first use.  Safe to run again at any time.
+Ensures the GTD files exist (seeding starter checklists) and offers
+to schedule a recurring Weekly Review.  Every step reports and skips
+when already satisfied — lazy initialization elsewhere is untouched."
+  (interactive)
+  (unless (file-directory-p org-gtd-directory)
+    (make-directory org-gtd-directory t))
+  (org-gtd--default-file)
+  (org-gtd-inbox-path)
+  (org-gtd-checklist--file-buffer)
+  (message "✓ GTD files ready in %s" (abbreviate-file-name org-gtd-directory))
+  (if (org-gtd-review--reminder-exists-p)
+      (message "✓ A review reminder is already scheduled")
+    (when (y-or-n-p "Schedule a recurring Weekly Review reminder? ")
+      (call-interactively #'org-gtd-review-schedule))))
+
+;;;; Footer
+
+(provide 'org-gtd-init)
+
+;;; org-gtd-init.el ends here

--- a/org-gtd-init.el
+++ b/org-gtd-init.el
@@ -41,16 +41,23 @@ Ensures the GTD files exist (seeding starter checklists) and offers
 to schedule a recurring Weekly Review.  Every step reports and skips
 when already satisfied — lazy initialization elsewhere is untouched."
   (interactive)
-  (unless (file-directory-p org-gtd-directory)
-    (make-directory org-gtd-directory t))
-  (org-gtd--default-file)
-  (org-gtd-inbox-path)
-  (org-gtd-checklist--file-buffer)
-  (message "✓ GTD files ready in %s" (abbreviate-file-name org-gtd-directory))
+  (condition-case nil
+      (progn
+        (unless (file-directory-p org-gtd-directory)
+          (make-directory org-gtd-directory t))
+        (org-gtd--default-file)
+        (org-gtd-inbox-path)
+        (org-gtd-checklist--file-buffer))
+    (file-error
+     (user-error "Could not create GTD files — check that %s is writable, or customize org-gtd-directory"
+                 (abbreviate-file-name org-gtd-directory))))
   (if (org-gtd-review--reminder-exists-p)
-      (message "✓ A review reminder is already scheduled")
-    (when (y-or-n-p "Schedule a recurring Weekly Review reminder? ")
-      (call-interactively #'org-gtd-review-schedule))))
+      (message "✓ GTD files ready in %s — a review reminder is already scheduled"
+               (abbreviate-file-name org-gtd-directory))
+    (if (y-or-n-p "Schedule a recurring Weekly Review reminder? ")
+        (call-interactively #'org-gtd-review-schedule)
+      (message "✓ GTD files ready in %s"
+               (abbreviate-file-name org-gtd-directory)))))
 
 ;;;; Footer
 

--- a/org-gtd-init.el
+++ b/org-gtd-init.el
@@ -41,7 +41,7 @@ Ensures the GTD files exist (seeding starter checklists) and offers
 to schedule a recurring Weekly Review.  Every step reports and skips
 when already satisfied — lazy initialization elsewhere is untouched."
   (interactive)
-  (condition-case nil
+  (condition-case err
       (progn
         (unless (file-directory-p org-gtd-directory)
           (make-directory org-gtd-directory t))
@@ -49,7 +49,8 @@ when already satisfied — lazy initialization elsewhere is untouched."
         (org-gtd-inbox-path)
         (org-gtd-checklist--file-buffer))
     (file-error
-     (user-error "Could not create GTD files — check that %s is writable, or customize org-gtd-directory"
+     (user-error "Could not create GTD files (%s) — check that %s is writable, or customize org-gtd-directory"
+                 (error-message-string err)
                  (abbreviate-file-name org-gtd-directory))))
   (if (org-gtd-review--reminder-exists-p)
       (message "✓ GTD files ready in %s — a review reminder is already scheduled"

--- a/org-gtd-mode.el
+++ b/org-gtd-mode.el
@@ -31,6 +31,7 @@
 
 (require 'org-gtd-core)
 (require 'org-gtd-capture)
+(require 'org-gtd-checklist)
 
 (declare-function org-gtd-project--maybe-update-cookies "org-gtd-projects")
 (declare-function org-gtd-agenda-property-add-properties "org-gtd-agenda-property")
@@ -118,6 +119,8 @@ previous values."
   (remove-hook 'org-after-todo-state-change-hook #'org-gtd-next-action--maybe-convert-to-delegated)
   ;; Remove project cancel detection hook
   (remove-hook 'org-after-todo-state-change-hook #'org-gtd-project--maybe-cancel-from-hook)
+  ;; Remove checkbox reset hook for repeating headings
+  (remove-hook 'org-after-todo-state-change-hook #'org-gtd-checklist--maybe-reset-checkboxes)
   ;; Remove agenda property hooks
   (remove-hook 'org-agenda-finalize-hook #'org-gtd-agenda-property-add-properties)
   (remove-hook 'org-finalize-agenda-hook #'org-gtd-agenda-property-add-properties)
@@ -148,6 +151,8 @@ configuration."
   (add-hook 'org-after-todo-state-change-hook #'org-gtd-next-action--maybe-convert-to-delegated)
   ;; Add project cancel detection hook
   (add-hook 'org-after-todo-state-change-hook #'org-gtd-project--maybe-cancel-from-hook)
+  ;; Add checkbox reset hook for repeating headings
+  (add-hook 'org-after-todo-state-change-hook #'org-gtd-checklist--maybe-reset-checkboxes)
   ;; Add agenda property hooks (support both old and new hook names)
   (if (boundp 'org-agenda-finalize-hook)
       (add-hook 'org-agenda-finalize-hook #'org-gtd-agenda-property-add-properties)

--- a/org-gtd-reflect.el
+++ b/org-gtd-reflect.el
@@ -102,6 +102,7 @@ mostly of value for testing purposes."
      (when . past)))
   "GTD view specifications for reflecting on missed items.")
 
+;;;###autoload
 (defun org-gtd-reflect-missed-items (&optional _start-date)
   "Show agenda view with past-due tickler, delegated, or calendar items.
 

--- a/org-gtd-review.el
+++ b/org-gtd-review.el
@@ -163,7 +163,49 @@ step looks like so the error teaches the fix."
                    (not (plist-get step :view)))
           (user-error
            "Review profile '%s', phase '%s': view step \"%s\" is missing :view — name the command that shows the view, like :view org-gtd-engage"
+           name (car phase) (plist-get step :title)))
+        (when (and (eq (plist-get step :type) 'checklist)
+                   (not (plist-get step :checklist)))
+          (user-error
+           "Review profile '%s', phase '%s': checklist step \"%s\" is missing :checklist — name a template from your checklists file, like :checklist \"Weekly Review triggers\""
            name (car phase) (plist-get step :title)))))))
+
+;;;; Pause and Resume Persistence
+
+(defun org-gtd-review--state-file ()
+  "Return the path of the paused-session state file."
+  (f-join org-gtd-directory "review-state.eld"))
+
+(defun org-gtd-review--save-state ()
+  "Serialize the session state to `org-gtd-review--state-file'."
+  (with-temp-file (org-gtd-review--state-file)
+    (let ((print-length nil) (print-level nil))
+      (prin1 org-gtd-review--state (current-buffer)))))
+
+(defun org-gtd-review--load-state ()
+  "Read a saved session state, or nil."
+  (let ((file (org-gtd-review--state-file)))
+    (when (file-exists-p file)
+      (with-temp-buffer
+        (insert-file-contents file)
+        (goto-char (point-min))
+        (ignore-errors (read (current-buffer)))))))
+
+(defun org-gtd-review--delete-state-file ()
+  "Remove the saved session state, if any."
+  (let ((file (org-gtd-review--state-file)))
+    (when (file-exists-p file) (delete-file file))))
+
+(defun org-gtd-review--state-valid-p (state)
+  "Non-nil when STATE still fits `org-gtd-review-profiles'."
+  (when-let* ((profile (assoc (plist-get state :profile)
+                              org-gtd-review-profiles))
+              (phases (cdr profile))
+              (p (plist-get state :phase))
+              (s (plist-get state :step)))
+    (and (integerp p) (integerp s)
+         (< p (length phases))
+         (< s (length (cdr (nth p phases)))))))
 
 ;;;; Keymap and Mode
 
@@ -279,7 +321,12 @@ Capture is always available: any step can shake something loose."
   "End the session when its buffer is killed out from under it.
 Buffer-local `kill-buffer-hook' for `org-gtd-review-mode'.  No-op
 when the session already ended, so `org-gtd-review--teardown' does
-not recurse through the kill it performs itself."
+not recurse through the kill it performs itself.
+
+Deliberately leaves the state file alone: killing the buffer ends
+the session without saving — the state file only exists when the
+user paused, and a stray \\[kill-buffer] must not destroy that
+earlier pause."
   (when org-gtd-review--state
     (org-gtd-review--reset-session)))
 
@@ -290,7 +337,10 @@ not recurse through the kill it performs itself."
     (kill-buffer org-gtd-review--buffer-name)))
 
 (defun org-gtd-review--finish ()
-  "Complete the session: report, clean up."
+  "Complete the session: report, clean up.
+Every completion path funnels through here, so this is where the
+paused-session state file (if any survived a resume) is removed."
+  (org-gtd-review--delete-state-file)
   (let ((done (plist-get org-gtd-review--state :done))
         (skipped (plist-get org-gtd-review--state :skipped)))
     (org-gtd-review--teardown)
@@ -359,19 +409,26 @@ not recurse through the kill it performs itself."
   (call-interactively #'org-gtd-capture))
 
 (defun org-gtd-review-pause ()
-  "Pause the session; placeholder until persistence lands."
-  (interactive))
+  "Pause the session; `org-gtd-review' resumes it later."
+  (interactive)
+  (org-gtd-review--save-state)
+  (org-gtd-review--teardown)
+  (message "Review paused — run M-x org-gtd-review to resume."))
 
 (defun org-gtd-review-quit ()
-  "Quit the session, tearing it down."
+  "Quit the session, offering to keep or abandon progress."
   (interactive)
-  (org-gtd-review--teardown))
+  (if (y-or-n-p "Keep progress to resume later? ")
+      (org-gtd-review-pause)
+    (org-gtd-review--delete-state-file)
+    (org-gtd-review--teardown)
+    (message "Review abandoned.")))
 
 ;;;; Entry Point
 
 ;;;###autoload
 (defun org-gtd-review (&optional profile-name)
-  "Run a guided review session.
+  "Run a guided review session, resuming a paused one when offered.
 With more than one profile in `org-gtd-review-profiles', prompt;
 PROFILE-NAME selects one non-interactively."
   (interactive)
@@ -382,6 +439,22 @@ PROFILE-NAME selects one non-interactively."
   (unless org-gtd-review-profiles
     (user-error
      "No review profiles configured — see `org-gtd-review-profiles'"))
+  (let ((saved (org-gtd-review--load-state)))
+    (cond
+     ((and saved (not (org-gtd-review--state-valid-p saved)))
+      (org-gtd-review--delete-state-file)
+      (message "Saved review no longer matches your profiles — starting over.")
+      (org-gtd-review--start-fresh profile-name))
+     ((and saved
+           (y-or-n-p (format "Resume paused '%s' review? "
+                             (plist-get saved :profile))))
+      (org-gtd-review--begin-session saved))
+     (t
+      (org-gtd-review--delete-state-file)
+      (org-gtd-review--start-fresh profile-name)))))
+
+(defun org-gtd-review--start-fresh (profile-name)
+  "Start a new session for PROFILE-NAME (prompting when nil)."
   (let* ((names (mapcar #'car org-gtd-review-profiles))
          (name (or profile-name
                    (if (cdr names)
@@ -390,15 +463,23 @@ PROFILE-NAME selects one non-interactively."
     (unless (assoc name org-gtd-review-profiles)
       (user-error "No review profile named '%s'" name))
     (org-gtd-review--check-profile (assoc name org-gtd-review-profiles))
-    (setq org-gtd-review--window-config (current-window-configuration))
-    (setq org-gtd-review--state
-          (list :profile name :phase 0 :step 0 :acted nil
-                :walk-items nil :walk-pos 0 :done 0 :skipped 0))
-    (condition-case err
-        (org-gtd-review--render)
-      (error
-       (org-gtd-review--teardown)
-       (signal (car err) (cdr err))))))
+    (org-gtd-review--begin-session
+     (list :profile name :phase 0 :step 0 :acted nil
+           :walk-items nil :walk-pos 0 :done 0 :skipped 0))))
+
+(defun org-gtd-review--begin-session (state)
+  "Install STATE as the live session and render, tearing down on error.
+Snapshots the current window configuration for restore at session
+end.  A resumed session re-snapshots here rather than restoring a
+saved one: a live window configuration cannot be serialized to the
+state file."
+  (setq org-gtd-review--window-config (current-window-configuration))
+  (setq org-gtd-review--state state)
+  (condition-case err
+      (org-gtd-review--render)
+    (error
+     (org-gtd-review--teardown)
+     (signal (car err) (cdr err)))))
 
 ;;;; Footer
 

--- a/org-gtd-review.el
+++ b/org-gtd-review.el
@@ -88,7 +88,7 @@ Each entry is (PROFILE-NAME . PHASES); each phase is
 \(PHASE-NAME . STEPS); each step is a plist with :title, :type
 \(one of `prompt', `command', `view', `checklist'), an optional
 :instruction, and the type-specific key :command, :view, or
-:checklist (a template name in the checklists file)."
+:checklist (a template name in the checklist templates file)."
   :group 'org-gtd
   :type 'sexp)
 
@@ -177,7 +177,7 @@ step looks like so the error teaches the fix."
         (when (and (eq (plist-get step :type) 'checklist)
                    (not (plist-get step :checklist)))
           (user-error
-           "Review profile '%s', phase '%s': checklist step \"%s\" is missing :checklist — name a template from your checklists file, like :checklist \"Weekly Review triggers\""
+           "Review profile '%s', phase '%s': checklist step \"%s\" is missing :checklist — name a template from your checklist templates file, like :checklist \"Weekly Review triggers\""
            name (car phase) (plist-get step :title)))))))
 
 ;;;; Checkpoint and Resume Persistence
@@ -405,12 +405,12 @@ Every walk-position change is checkpointed to disk, so resuming
 lands on the item the user was looking at."
   (let ((state org-gtd-review--state))
     (if (not (plist-get state :acted))
-        (let ((items (org-gtd-checklist--items (plist-get step :checklist))))
+        (let ((items (org-gtd-checklist-template--items (plist-get step :checklist))))
           (if (null items)
               (progn
                 (message "Nothing in checklist '%s' — moving on.  (Edit %s to add items.)"
                          (plist-get step :checklist)
-                         (org-gtd-checklist--file-path))
+                         (org-gtd-checklist-template--file-path))
                 (org-gtd-review--complete-step))
             (plist-put state :acted t)
             (plist-put state :walk-items items)

--- a/org-gtd-review.el
+++ b/org-gtd-review.el
@@ -33,6 +33,7 @@
 (require 'org-gtd-files)
 (require 'org-gtd-checklist)
 (require 'org-gtd-create)
+(require 'org-gtd-types)
 (require 'org-gtd-capture)
 
 ;;;; External Function Declarations
@@ -216,9 +217,9 @@ crashing mid-render."
            (integerp (plist-get state :done))
            (integerp (plist-get state :skipped))
            (listp walk-items)
+           (integerp walk-pos)
            (or (null walk-items)
-               (and (integerp walk-pos)
-                    (>= walk-pos 0)
+               (and (>= walk-pos 0)
                     (< walk-pos (length walk-items))))))))
 
 ;;;; Keymap and Mode
@@ -355,16 +356,36 @@ where the user was."
   (when (get-buffer org-gtd-review--buffer-name)
     (kill-buffer org-gtd-review--buffer-name)))
 
+(defun org-gtd-review--reminder-exists-p ()
+  "Non-nil when a habit named after a review profile already exists.
+Walks the headings of the default tasks file looking for one whose
+title matches a profile name in `org-gtd-review-profiles' and whose
+ORG_GTD property marks it as a habit — the shape
+`org-gtd-review-schedule' creates."
+  (let ((habit-marker (plist-get (cdr (org-gtd-type-get 'habit)) :org-gtd)))
+    (with-current-buffer (org-gtd--default-file)
+      (org-with-wide-buffer
+       (goto-char (point-min))
+       (catch 'found
+         (while (re-search-forward org-heading-regexp nil t)
+           (when (and (equal (org-entry-get (point) "ORG_GTD") habit-marker)
+                      (assoc (org-get-heading t t t t)
+                             org-gtd-review-profiles))
+             (throw 'found t)))
+         nil)))))
+
 (defun org-gtd-review--finish ()
   "Complete the session: report, clean up.
 Every completion path funnels through here, so this is where the
-checkpoint file is removed."
+checkpoint file is removed.  The scheduling tip is one-time
+teaching: it only appears while no review reminder exists yet."
   (org-gtd-review--delete-state-file)
   (let ((done (plist-get org-gtd-review--state :done))
         (skipped (plist-get org-gtd-review--state :skipped)))
     (org-gtd-review--teardown)
-    (message (concat "Review complete: %d steps done, %d skipped.  "
-                     "Tip: M-x org-gtd-review-schedule puts this on your calendar.")
+    (message (concat "Review complete: %d steps done, %d skipped."
+                     (unless (org-gtd-review--reminder-exists-p)
+                       "  Tip: M-x org-gtd-review-schedule puts this on your calendar."))
              done skipped)))
 
 ;;;; Commands
@@ -543,6 +564,34 @@ the single save slot as soon as it successfully boots."
      (org-gtd-review--teardown)
      (signal (car err) (cdr err))))
   (org-gtd-review--save-state))
+
+;;;###autoload
+(defun org-gtd-review-schedule (&optional profile-name date repeater)
+  "Create a recurring habit reminding you to run a review.
+PROFILE-NAME, DATE (YYYY-MM-DD) and REPEATER (org repeater like
+\".+1w\") are prompted for interactively."
+  (interactive)
+  (let* ((names (mapcar #'car org-gtd-review-profiles))
+         (profile (or profile-name
+                      (if (cdr names)
+                          (completing-read "Review profile: " names nil t)
+                        (car names))))
+         (date (or date (org-read-date nil nil nil "First review: ")))
+         (repeater (or repeater
+                       (read-string "How often? (org repeater, e.g. .+1w): "
+                                    nil nil ".+1w"))))
+    (org-gtd-create-item 'habit profile
+                         `((:when . ,(format "<%s %s>" date repeater))))
+    (with-current-buffer (org-gtd--default-file)
+      (org-with-wide-buffer
+       (goto-char (point-min))
+       (when (re-search-forward
+              (format "^\\*+ +.*%s[ \t]*$" (regexp-quote profile)) nil t)
+         (org-end-of-meta-data t)
+         (insert "Run M-x org-gtd-review when you sit down for this.\n")
+         (basic-save-buffer))))
+    (message "'%s' reminder created — it will show up in your engage view."
+             profile)))
 
 ;;;; Footer
 

--- a/org-gtd-review.el
+++ b/org-gtd-review.el
@@ -119,7 +119,7 @@ interval (e.g. \".+2d/4d\").")
               org-gtd-review-profiles)))
 
 (defun org-gtd-review--current-phase ()
-  "Return the (NAME . STEPS) phase the session is in."
+  "Return the phase the session is in, a cons of name and step list."
   (nth (plist-get org-gtd-review--state :phase) (org-gtd-review--phases)))
 
 (defun org-gtd-review--current-step ()

--- a/org-gtd-review.el
+++ b/org-gtd-review.el
@@ -33,6 +33,13 @@
 (require 'org-gtd-files)
 (require 'org-gtd-checklist)
 (require 'org-gtd-create)
+(require 'org-gtd-capture)
+
+;;;; External Function Declarations
+
+;; Evil functions (only called inside with-eval-after-load 'evil)
+(declare-function evil-set-initial-state "evil-core")
+(declare-function evil-emacs-state "evil-states")
 
 ;;;; Customization
 
@@ -111,6 +118,178 @@ Keys: :profile (name string), :phase (index), :step (index),
   "Return the step plist the session is on."
   (nth (plist-get org-gtd-review--state :step)
        (cdr (org-gtd-review--current-phase))))
+
+;;;; Keymap and Mode
+
+(defvar org-gtd-review-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "n") #'org-gtd-review-next)
+    (define-key map (kbd "s") #'org-gtd-review-skip)
+    (define-key map (kbd "c") #'org-gtd-review-capture)
+    (define-key map (kbd "p") #'org-gtd-review-pause)
+    (define-key map (kbd "q") #'org-gtd-review-quit)
+    map)
+  "Keymap for `org-gtd-review-mode'.")
+
+(define-derived-mode org-gtd-review-mode special-mode "GTD-Review"
+  "Major mode for the guided review session console.
+
+\\{org-gtd-review-mode-map}"
+  :group 'org-gtd)
+
+;; When evil-mode is loaded, start review-mode in emacs state.
+;; We use both evil-set-initial-state AND a mode hook for robustness:
+;; - evil-set-initial-state: handles new buffers entering this mode
+;; - mode hook: forces emacs state even if evil-collection or user config
+;;   has set a different state
+(with-eval-after-load 'evil
+  (evil-set-initial-state 'org-gtd-review-mode 'emacs)
+  (add-hook 'org-gtd-review-mode-hook #'evil-emacs-state))
+
+;;;; Rendering
+
+(defun org-gtd-review--header-line (step)
+  "Compute the header line advertising keys for STEP."
+  (concat "[n] Do/advance  [s] Skip  [p] Pause  [q] Quit"
+          (when (eq (plist-get step :type) 'checklist)
+            "  [c] Capture")))
+
+(defun org-gtd-review--phase-tracker ()
+  "Render the phase tracker line."
+  (let ((current (plist-get org-gtd-review--state :phase)))
+    (mapconcat
+     (lambda (pair)
+       (let ((i (car pair)) (name (car (cdr pair))))
+         (cond ((< i current) (format "[✓ %s]" name))
+               ((= i current) (format "▸ %s ◂" name))
+               (t (format "[ %s ]" name)))))
+     (seq-map-indexed (lambda (ph i) (cons i ph)) (org-gtd-review--phases))
+     "  ")))
+
+(defun org-gtd-review--render ()
+  "Render the session buffer from `org-gtd-review--state'."
+  (let* ((state org-gtd-review--state)
+         (phase (org-gtd-review--current-phase))
+         (steps (cdr phase))
+         (step (org-gtd-review--current-step)))
+    (with-current-buffer (get-buffer-create org-gtd-review--buffer-name)
+      (unless (derived-mode-p 'org-gtd-review-mode) (org-gtd-review-mode))
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert (format "%s\n\n" (plist-get state :profile)))
+        (insert (org-gtd-review--phase-tracker) "\n\n")
+        (insert (format "%s — step %d/%d\n\n"
+                        (car phase)
+                        (1+ (plist-get state :step))
+                        (length steps)))
+        (insert (format "  %s\n" (plist-get step :title)))
+        (when-let ((instr (plist-get step :instruction)))
+          (insert (format "\n  %s\n" instr)))
+        (when (and (eq (plist-get step :type) 'checklist)
+                   (plist-get state :walk-items))
+          (let ((items (plist-get state :walk-items))
+                (pos (plist-get state :walk-pos)))
+            (insert (format "\n    → %s   (%d/%d)\n"
+                            (nth pos items) (1+ pos) (length items)))))
+        (goto-char (point-min)))
+      (setq header-line-format (org-gtd-review--header-line step))
+      (pop-to-buffer (current-buffer)))))
+
+;;;; Step Advancement
+
+(defun org-gtd-review--complete-step (&optional skipped)
+  "Advance past the current step, tallying SKIPPED or done."
+  (let ((state org-gtd-review--state)
+        (counter (if skipped :skipped :done)))
+    (plist-put state counter (1+ (plist-get state counter)))
+    (plist-put state :acted nil)
+    (plist-put state :walk-items nil)
+    (plist-put state :walk-pos 0)
+    (let ((steps (cdr (org-gtd-review--current-phase)))
+          (next-step (1+ (plist-get state :step))))
+      (if (< next-step (length steps))
+          (progn (plist-put state :step next-step)
+                 (org-gtd-review--render))
+        (let ((phases (org-gtd-review--phases))
+              (next-phase (1+ (plist-get state :phase))))
+          (if (< next-phase (length phases))
+              (progn
+                (message "%s complete — on to %s."
+                         (car (nth (plist-get state :phase) phases))
+                         (car (nth next-phase phases)))
+                (plist-put state :phase next-phase)
+                (plist-put state :step 0)
+                (org-gtd-review--render))
+            (org-gtd-review--finish)))))))
+
+(defun org-gtd-review--teardown ()
+  "Kill the session buffer, clear state, restore windows."
+  (setq org-gtd-review--state nil)
+  (when (get-buffer org-gtd-review--buffer-name)
+    (kill-buffer org-gtd-review--buffer-name))
+  (when org-gtd-review--window-config
+    (set-window-configuration org-gtd-review--window-config)
+    (setq org-gtd-review--window-config nil)))
+
+(defun org-gtd-review--finish ()
+  "Complete the session: report, clean up."
+  (let ((done (plist-get org-gtd-review--state :done))
+        (skipped (plist-get org-gtd-review--state :skipped)))
+    (org-gtd-review--teardown)
+    (message (concat "Review complete: %d steps done, %d skipped.  "
+                     "Tip: M-x org-gtd-review-schedule puts this on your calendar.")
+             done skipped)))
+
+;;;; Commands
+
+(defun org-gtd-review-next ()
+  "Do the current step, or advance past it."
+  (interactive)
+  (let* ((step (org-gtd-review--current-step))
+         (type (plist-get step :type)))
+    (pcase type
+      ('prompt (org-gtd-review--complete-step))
+      (_ (message "Step type %s not implemented yet" type)))))
+
+(defun org-gtd-review-skip ()
+  "Skip the current step for this run only."
+  (interactive)
+  (org-gtd-review--complete-step t))
+
+(defun org-gtd-review-capture ()
+  "Capture something to the inbox mid-review."
+  (interactive)
+  (call-interactively #'org-gtd-capture))
+
+(defun org-gtd-review-pause ()
+  "Pause the session; placeholder until persistence lands."
+  (interactive))
+
+(defun org-gtd-review-quit ()
+  "Quit the session, tearing it down."
+  (interactive)
+  (org-gtd-review--teardown))
+
+;;;; Entry Point
+
+;;;###autoload
+(defun org-gtd-review (&optional profile-name)
+  "Run a guided review session.
+With more than one profile in `org-gtd-review-profiles', prompt;
+PROFILE-NAME selects one non-interactively."
+  (interactive)
+  (let* ((names (mapcar #'car org-gtd-review-profiles))
+         (name (or profile-name
+                   (if (cdr names)
+                       (completing-read "Review profile: " names nil t)
+                     (car names)))))
+    (unless (assoc name org-gtd-review-profiles)
+      (user-error "No review profile named '%s'" name))
+    (setq org-gtd-review--window-config (current-window-configuration))
+    (setq org-gtd-review--state
+          (list :profile name :phase 0 :step 0 :acted nil
+                :walk-items nil :walk-pos 0 :done 0 :skipped 0))
+    (org-gtd-review--render)))
 
 ;;;; Footer
 

--- a/org-gtd-review.el
+++ b/org-gtd-review.el
@@ -133,10 +133,14 @@ step looks like so the error teaches the fix."
        "Review profile '%s' has no phases — give it at least one (PHASE-NAME STEP...) list"
        name))
     (dolist (phase phases)
-      (unless (and (consp phase) (stringp (car phase)))
+      (unless (and (proper-list-p phase) (stringp (car phase)))
         (user-error
          "Review profile '%s': phase %S should be a list starting with a name string, like (\"Get Clear\" STEP...)"
          name phase))
+      (unless (cdr phase)
+        (user-error
+         "Review profile '%s': phase '%s' has no steps — give it at least one step plist"
+         name (car phase)))
       (dolist (step (cdr phase))
         (unless (and (listp step) (keywordp (car-safe step)))
           (user-error

--- a/org-gtd-review.el
+++ b/org-gtd-review.el
@@ -119,6 +119,38 @@ Keys: :profile (name string), :phase (index), :step (index),
   (nth (plist-get org-gtd-review--state :step)
        (cdr (org-gtd-review--current-phase))))
 
+;;;; Profile Validation
+
+(defun org-gtd-review--check-profile (profile)
+  "Signal a `user-error' when PROFILE is malformed.
+PROFILE is an entry of `org-gtd-review-profiles', that is
+\(PROFILE-NAME . PHASES).  Explain what a well-formed phase or
+step looks like so the error teaches the fix."
+  (let ((name (car profile))
+        (phases (cdr profile)))
+    (unless phases
+      (user-error
+       "Review profile '%s' has no phases — give it at least one (PHASE-NAME STEP...) list"
+       name))
+    (dolist (phase phases)
+      (unless (and (consp phase) (stringp (car phase)))
+        (user-error
+         "Review profile '%s': phase %S should be a list starting with a name string, like (\"Get Clear\" STEP...)"
+         name phase))
+      (dolist (step (cdr phase))
+        (unless (and (listp step) (keywordp (car-safe step)))
+          (user-error
+           "Review profile '%s', phase '%s': step %S should be a plist like (:title \"...\" :type prompt)"
+           name (car phase) step))
+        (unless (plist-get step :title)
+          (user-error
+           "Review profile '%s', phase '%s': a step is missing :title — every step needs one"
+           name (car phase)))
+        (unless (plist-get step :type)
+          (user-error
+           "Review profile '%s', phase '%s': step \"%s\" is missing :type — one of prompt, command, view, or checklist"
+           name (car phase) (plist-get step :title)))))))
+
 ;;;; Keymap and Mode
 
 (defvar org-gtd-review-mode-map
@@ -135,7 +167,8 @@ Keys: :profile (name string), :phase (index), :step (index),
   "Major mode for the guided review session console.
 
 \\{org-gtd-review-mode-map}"
-  :group 'org-gtd)
+  :group 'org-gtd
+  (add-hook 'kill-buffer-hook #'org-gtd-review--on-buffer-kill nil t))
 
 ;; When evil-mode is loaded, start review-mode in emacs state.
 ;; We use both evil-set-initial-state AND a mode hook for robustness:
@@ -148,11 +181,10 @@ Keys: :profile (name string), :phase (index), :step (index),
 
 ;;;; Rendering
 
-(defun org-gtd-review--header-line (step)
-  "Compute the header line advertising keys for STEP."
-  (concat "[n] Do/advance  [s] Skip  [p] Pause  [q] Quit"
-          (when (eq (plist-get step :type) 'checklist)
-            "  [c] Capture")))
+(defun org-gtd-review--header-line ()
+  "Compute the header line advertising the session keys.
+Capture is always available: any step can shake something loose."
+  "[n] Do/advance  [s] Skip  [c] Capture  [p] Pause  [q] Quit")
 
 (defun org-gtd-review--phase-tracker ()
   "Render the phase tracker line."
@@ -192,7 +224,7 @@ Keys: :profile (name string), :phase (index), :step (index),
             (insert (format "\n    → %s   (%d/%d)\n"
                             (nth pos items) (1+ pos) (length items)))))
         (goto-char (point-min)))
-      (setq header-line-format (org-gtd-review--header-line step))
+      (setq header-line-format (org-gtd-review--header-line))
       (pop-to-buffer (current-buffer)))))
 
 ;;;; Step Advancement
@@ -222,14 +254,26 @@ Keys: :profile (name string), :phase (index), :step (index),
                 (org-gtd-review--render))
             (org-gtd-review--finish)))))))
 
-(defun org-gtd-review--teardown ()
-  "Kill the session buffer, clear state, restore windows."
+(defun org-gtd-review--reset-session ()
+  "Clear the session state and restore the saved window configuration."
   (setq org-gtd-review--state nil)
-  (when (get-buffer org-gtd-review--buffer-name)
-    (kill-buffer org-gtd-review--buffer-name))
   (when org-gtd-review--window-config
     (set-window-configuration org-gtd-review--window-config)
     (setq org-gtd-review--window-config nil)))
+
+(defun org-gtd-review--on-buffer-kill ()
+  "End the session when its buffer is killed out from under it.
+Buffer-local `kill-buffer-hook' for `org-gtd-review-mode'.  No-op
+when the session already ended, so `org-gtd-review--teardown' does
+not recurse through the kill it performs itself."
+  (when org-gtd-review--state
+    (org-gtd-review--reset-session)))
+
+(defun org-gtd-review--teardown ()
+  "Kill the session buffer, clear state, restore windows."
+  (org-gtd-review--reset-session)
+  (when (get-buffer org-gtd-review--buffer-name)
+    (kill-buffer org-gtd-review--buffer-name)))
 
 (defun org-gtd-review--finish ()
   "Complete the session: report, clean up."
@@ -278,6 +322,13 @@ Keys: :profile (name string), :phase (index), :step (index),
 With more than one profile in `org-gtd-review-profiles', prompt;
 PROFILE-NAME selects one non-interactively."
   (interactive)
+  (when org-gtd-review--state
+    (user-error
+     "A review session is already active — finish it or press q in %s first"
+     org-gtd-review--buffer-name))
+  (unless org-gtd-review-profiles
+    (user-error
+     "No review profiles configured — see `org-gtd-review-profiles'"))
   (let* ((names (mapcar #'car org-gtd-review-profiles))
          (name (or profile-name
                    (if (cdr names)
@@ -285,11 +336,16 @@ PROFILE-NAME selects one non-interactively."
                      (car names)))))
     (unless (assoc name org-gtd-review-profiles)
       (user-error "No review profile named '%s'" name))
+    (org-gtd-review--check-profile (assoc name org-gtd-review-profiles))
     (setq org-gtd-review--window-config (current-window-configuration))
     (setq org-gtd-review--state
           (list :profile name :phase 0 :step 0 :acted nil
                 :walk-items nil :walk-pos 0 :done 0 :skipped 0))
-    (org-gtd-review--render)))
+    (condition-case err
+        (org-gtd-review--render)
+      (error
+       (org-gtd-review--teardown)
+       (signal (car err) (cdr err))))))
 
 ;;;; Footer
 

--- a/org-gtd-review.el
+++ b/org-gtd-review.el
@@ -105,11 +105,13 @@ Keys: :profile (name string), :phase (index), :step (index),
 (defconst org-gtd-review--buffer-name "*GTD Review*")
 
 (defconst org-gtd-review--repeater-re
-  "\\`[.+]?\\+[0-9]+[hdwmy]\\(?:/[0-9]+[hdwmy]\\)?\\'"
+  "\\`[.+]?\\+0*[1-9][0-9]*[hdwmy]\\(?:/0*[1-9][0-9]*[hdwmy]\\)?\\'"
   "Regexp matching a standalone org repeater.
 The repeater core of `org-repeat-re': +N, ++N, or .+N with an
 h/d/w/m/y unit, optionally followed by a /N[hdwmy] habit maximum
-interval (e.g. \".+2d/4d\").")
+interval (e.g. \".+2d/4d\").  N must be nonzero: org treats a
+zero-interval repeater as cancelled, so a \".+0w\" reminder would
+never re-arm.")
 
 ;;;; Accessors
 
@@ -425,6 +427,8 @@ lands on the item the user was looking at."
 (defun org-gtd-review-next ()
   "Do the current step, or advance past it."
   (interactive)
+  (unless org-gtd-review--state
+    (user-error "No review session is active — start one with M-x org-gtd-review"))
   (let* ((step (org-gtd-review--current-step))
          (type (plist-get step :type)))
     (pcase type
@@ -452,6 +456,8 @@ lands on the item the user was looking at."
 (defun org-gtd-review-skip ()
   "Skip the current step for this run only."
   (interactive)
+  (unless org-gtd-review--state
+    (user-error "No review session is active — start one with M-x org-gtd-review"))
   (org-gtd-review--complete-step t))
 
 (defun org-gtd-review-capture ()

--- a/org-gtd-review.el
+++ b/org-gtd-review.el
@@ -170,10 +170,12 @@ step looks like so the error teaches the fix."
            "Review profile '%s', phase '%s': checklist step \"%s\" is missing :checklist — name a template from your checklists file, like :checklist \"Weekly Review triggers\""
            name (car phase) (plist-get step :title)))))))
 
-;;;; Pause and Resume Persistence
+;;;; Checkpoint and Resume Persistence
 
 (defun org-gtd-review--state-file ()
-  "Return the path of the paused-session state file."
+  "Return the path of the session checkpoint file.
+A single slot with no locking: concurrent Emacs sessions writing
+checkpoints race, and the last write wins."
   (f-join org-gtd-directory "review-state.eld"))
 
 (defun org-gtd-review--save-state ()
@@ -197,15 +199,27 @@ step looks like so the error teaches the fix."
     (when (file-exists-p file) (delete-file file))))
 
 (defun org-gtd-review--state-valid-p (state)
-  "Non-nil when STATE still fits `org-gtd-review-profiles'."
+  "Non-nil when STATE still fits `org-gtd-review-profiles'.
+Also rejects internally incoherent states — negative indices,
+non-integer tallies, a walk position outside the walk items — so a
+corrupted checkpoint falls back to a fresh session instead of
+crashing mid-render."
   (when-let* ((profile (assoc (plist-get state :profile)
                               org-gtd-review-profiles))
               (phases (cdr profile))
               (p (plist-get state :phase))
               (s (plist-get state :step)))
-    (and (integerp p) (integerp s)
-         (< p (length phases))
-         (< s (length (cdr (nth p phases)))))))
+    (let ((walk-items (plist-get state :walk-items))
+          (walk-pos (plist-get state :walk-pos)))
+      (and (integerp p) (>= p 0) (< p (length phases))
+           (integerp s) (>= s 0) (< s (length (cdr (nth p phases))))
+           (integerp (plist-get state :done))
+           (integerp (plist-get state :skipped))
+           (listp walk-items)
+           (or (null walk-items)
+               (and (integerp walk-pos)
+                    (>= walk-pos 0)
+                    (< walk-pos (length walk-items))))))))
 
 ;;;; Keymap and Mode
 
@@ -286,7 +300,9 @@ Capture is always available: any step can shake something loose."
 ;;;; Step Advancement
 
 (defun org-gtd-review--complete-step (&optional skipped)
-  "Advance past the current step, tallying SKIPPED or done."
+  "Advance past the current step, tallying SKIPPED or done.
+Checkpoints the new position to disk at every step boundary, so a
+crash or killed buffer resumes where the user left off."
   (let ((state org-gtd-review--state)
         (counter (if skipped :skipped :done)))
     (plist-put state counter (1+ (plist-get state counter)))
@@ -297,6 +313,7 @@ Capture is always available: any step can shake something loose."
           (next-step (1+ (plist-get state :step))))
       (if (< next-step (length steps))
           (progn (plist-put state :step next-step)
+                 (org-gtd-review--save-state)
                  (org-gtd-review--render))
         (let ((phases (org-gtd-review--phases))
               (next-phase (1+ (plist-get state :phase))))
@@ -307,6 +324,7 @@ Capture is always available: any step can shake something loose."
                          (car (nth next-phase phases)))
                 (plist-put state :phase next-phase)
                 (plist-put state :step 0)
+                (org-gtd-review--save-state)
                 (org-gtd-review--render))
             (org-gtd-review--finish)))))))
 
@@ -323,10 +341,11 @@ Buffer-local `kill-buffer-hook' for `org-gtd-review-mode'.  No-op
 when the session already ended, so `org-gtd-review--teardown' does
 not recurse through the kill it performs itself.
 
-Deliberately leaves the state file alone: killing the buffer ends
-the session without saving — the state file only exists when the
-user paused, and a stray \\[kill-buffer] must not destroy that
-earlier pause."
+Deliberately leaves the checkpoint file alone: the session saves at
+every step boundary and walk advance, so the file already holds the
+latest position.  A stray \\[kill-buffer] — or a crash — therefore
+loses nothing: the next `org-gtd-review' offers to resume right
+where the user was."
   (when org-gtd-review--state
     (org-gtd-review--reset-session)))
 
@@ -339,7 +358,7 @@ earlier pause."
 (defun org-gtd-review--finish ()
   "Complete the session: report, clean up.
 Every completion path funnels through here, so this is where the
-paused-session state file (if any survived a resume) is removed."
+checkpoint file is removed."
   (org-gtd-review--delete-state-file)
   (let ((done (plist-get org-gtd-review--state :done))
         (skipped (plist-get org-gtd-review--state :skipped)))
@@ -351,7 +370,9 @@ paused-session state file (if any survived a resume) is removed."
 ;;;; Commands
 
 (defun org-gtd-review--walk-next (step)
-  "Advance the checklist walk for STEP, loading it on first call."
+  "Advance the checklist walk for STEP, loading it on first call.
+Every walk-position change is checkpointed to disk, so resuming
+lands on the item the user was looking at."
   (let ((state org-gtd-review--state))
     (if (not (plist-get state :acted))
         (let ((items (org-gtd-checklist--items (plist-get step :checklist))))
@@ -364,10 +385,12 @@ paused-session state file (if any survived a resume) is removed."
             (plist-put state :acted t)
             (plist-put state :walk-items items)
             (plist-put state :walk-pos 0)
+            (org-gtd-review--save-state)
             (org-gtd-review--render)))
       (let ((next (1+ (plist-get state :walk-pos))))
         (if (< next (length (plist-get state :walk-items)))
             (progn (plist-put state :walk-pos next)
+                   (org-gtd-review--save-state)
                    (org-gtd-review--render))
           (org-gtd-review--complete-step))))))
 
@@ -409,15 +432,23 @@ paused-session state file (if any survived a resume) is removed."
   (call-interactively #'org-gtd-capture))
 
 (defun org-gtd-review-pause ()
-  "Pause the session; `org-gtd-review' resumes it later."
+  "Pause the session; `org-gtd-review' resumes it later.
+Guarded against running with no active session: saving then would
+write an empty state over an existing checkpoint."
   (interactive)
+  (unless org-gtd-review--state
+    (user-error "No review session is active"))
   (org-gtd-review--save-state)
   (org-gtd-review--teardown)
   (message "Review paused — run M-x org-gtd-review to resume."))
 
 (defun org-gtd-review-quit ()
-  "Quit the session, offering to keep or abandon progress."
+  "Quit the session, offering to keep or abandon progress.
+Guarded against running with no active session: abandoning then
+would delete an existing checkpoint."
   (interactive)
+  (unless org-gtd-review--state
+    (user-error "No review session is active"))
   (if (y-or-n-p "Keep progress to resume later? ")
       (org-gtd-review-pause)
     (org-gtd-review--delete-state-file)
@@ -428,9 +459,11 @@ paused-session state file (if any survived a resume) is removed."
 
 ;;;###autoload
 (defun org-gtd-review (&optional profile-name)
-  "Run a guided review session, resuming a paused one when offered.
+  "Run a guided review session, resuming a checkpointed one when offered.
 With more than one profile in `org-gtd-review-profiles', prompt;
-PROFILE-NAME selects one non-interactively."
+PROFILE-NAME selects one non-interactively.  An explicit
+PROFILE-NAME that differs from the checkpointed profile skips the
+resume offer and starts that profile fresh."
   (interactive)
   (when org-gtd-review--state
     (user-error
@@ -441,17 +474,45 @@ PROFILE-NAME selects one non-interactively."
      "No review profiles configured — see `org-gtd-review-profiles'"))
   (let ((saved (org-gtd-review--load-state)))
     (cond
-     ((and saved (not (org-gtd-review--state-valid-p saved)))
+     ((null saved)
+      (org-gtd-review--start-fresh profile-name))
+     ((not (org-gtd-review--state-valid-p saved))
       (org-gtd-review--delete-state-file)
       (message "Saved review no longer matches your profiles — starting over.")
       (org-gtd-review--start-fresh profile-name))
-     ((and saved
-           (y-or-n-p (format "Resume paused '%s' review? "
-                             (plist-get saved :profile))))
-      (org-gtd-review--begin-session saved))
+     ((and profile-name
+           (not (equal profile-name (plist-get saved :profile))))
+      ;; Asked for a different profile by name: no resume offer.  No
+      ;; eager delete either — the new session's first checkpoint
+      ;; claims the slot, so aborting the start keeps the old save.
+      (org-gtd-review--start-fresh profile-name))
+     ((y-or-n-p (format "Resume paused '%s' review? "
+                        (plist-get saved :profile)))
+      (org-gtd-review--resume saved profile-name))
      (t
-      (org-gtd-review--delete-state-file)
+      ;; Declined.  Deleting here would destroy the save if the user
+      ;; then quits the profile picker; the fresh session's first
+      ;; checkpoint overwrites it instead, and nothing between the
+      ;; decline and that overwrite reads the file.
       (org-gtd-review--start-fresh profile-name)))))
+
+(defun org-gtd-review--resume (saved profile-name)
+  "Resume the SAVED session after re-validating its profile.
+The profile may have been edited into an invalid shape while the
+session was paused; in that case surface the teaching error, drop
+the checkpoint, and start over — PROFILE-NAME seeds the fresh
+start, as in the invalid-state branch of `org-gtd-review'."
+  (let ((problem
+         (condition-case err
+             (prog1 nil
+               (org-gtd-review--check-profile
+                (assoc (plist-get saved :profile) org-gtd-review-profiles)))
+           (user-error err))))
+    (if (null problem)
+        (org-gtd-review--begin-session saved)
+      (org-gtd-review--delete-state-file)
+      (message "Saved review's profile is no longer valid — starting over.")
+      (org-gtd-review--start-fresh profile-name))))
 
 (defun org-gtd-review--start-fresh (profile-name)
   "Start a new session for PROFILE-NAME (prompting when nil)."
@@ -468,18 +529,20 @@ PROFILE-NAME selects one non-interactively."
            :walk-items nil :walk-pos 0 :done 0 :skipped 0))))
 
 (defun org-gtd-review--begin-session (state)
-  "Install STATE as the live session and render, tearing down on error.
+  "Install STATE as the live session, render, and checkpoint it.
 Snapshots the current window configuration for restore at session
 end.  A resumed session re-snapshots here rather than restoring a
 saved one: a live window configuration cannot be serialized to the
-state file."
+state file.  The immediate checkpoint means a fresh session claims
+the single save slot as soon as it successfully boots."
   (setq org-gtd-review--window-config (current-window-configuration))
   (setq org-gtd-review--state state)
   (condition-case err
       (org-gtd-review--render)
     (error
      (org-gtd-review--teardown)
-     (signal (car err) (cdr err)))))
+     (signal (car err) (cdr err))))
+  (org-gtd-review--save-state))
 
 ;;;; Footer
 

--- a/org-gtd-review.el
+++ b/org-gtd-review.el
@@ -267,16 +267,34 @@ Capture is always available: any step can shake something loose."
   "[n] Do/advance  [s] Skip  [c] Capture  [p] Pause  [q] Quit")
 
 (defun org-gtd-review--phase-tracker ()
-  "Render the phase tracker line."
+  "Render the phase tracker line.
+Every phase is bracketed for a stable, scannable shape; the marker
+inside distinguishes state: check for done, arrow for the current
+phase, dot for pending."
   (let ((current (plist-get org-gtd-review--state :phase)))
     (mapconcat
      (lambda (pair)
        (let ((i (car pair)) (name (car (cdr pair))))
          (cond ((< i current) (format "[✓ %s]" name))
-               ((= i current) (format "▸ %s ◂" name))
-               (t (format "[ %s ]" name)))))
+               ((= i current) (format "[→ %s]" name))
+               (t (format "[· %s]" name)))))
      (seq-map-indexed (lambda (ph i) (cons i ph)) (org-gtd-review--phases))
      "  ")))
+
+(defun org-gtd-review--step-guidance (step)
+  "Return a one-line guidance string for STEP, or nil for a type with none.
+Command and view steps use a two-press flow: the first advance hands
+off to the action (the buffer switches to it), and a second advance —
+after you return — continues the review.  Spell that out so advancing
+never reads as a stuck key, and so it is clear org-gtd does the work
+rather than the prose being an instruction to act by hand."
+  (pcase (plist-get step :type)
+    ('command
+     "Press n and org-gtd runs this now — you'll switch to it.  \
+Come back, then press n again to continue.")
+    ('view
+     "Press n and org-gtd opens this view — you'll switch to it.  \
+Come back, then press n again to continue.")))
 
 (defun org-gtd-review--render ()
   "Render the session buffer from `org-gtd-review--state'."
@@ -297,6 +315,8 @@ Capture is always available: any step can shake something loose."
         (insert (format "  %s\n" (plist-get step :title)))
         (when-let ((instr (plist-get step :instruction)))
           (insert (format "\n  %s\n" instr)))
+        (when-let ((guide (org-gtd-review--step-guidance step)))
+          (insert (format "\n  %s\n" guide)))
         (when (and (eq (plist-get step :type) 'checklist)
                    (plist-get state :walk-items))
           (let ((items (plist-get state :walk-items))

--- a/org-gtd-review.el
+++ b/org-gtd-review.el
@@ -104,6 +104,13 @@ Keys: :profile (name string), :phase (index), :step (index),
 
 (defconst org-gtd-review--buffer-name "*GTD Review*")
 
+(defconst org-gtd-review--repeater-re
+  "\\`[.+]?\\+[0-9]+[hdwmy]\\(?:/[0-9]+[hdwmy]\\)?\\'"
+  "Regexp matching a standalone org repeater.
+The repeater core of `org-repeat-re': +N, ++N, or .+N with an
+h/d/w/m/y unit, optionally followed by a /N[hdwmy] habit maximum
+interval (e.g. \".+2d/4d\").")
+
 ;;;; Accessors
 
 (defun org-gtd-review--phases ()
@@ -362,7 +369,7 @@ Walks the headings of the default tasks file looking for one whose
 title matches a profile name in `org-gtd-review-profiles' and whose
 ORG_GTD property marks it as a habit — the shape
 `org-gtd-review-schedule' creates."
-  (let ((habit-marker (plist-get (cdr (org-gtd-type-get 'habit)) :org-gtd)))
+  (let ((habit-marker (org-gtd-type-org-gtd-value 'habit)))
     (with-current-buffer (org-gtd--default-file)
       (org-with-wide-buffer
        (goto-char (point-min))
@@ -565,33 +572,57 @@ the single save slot as soon as it successfully boots."
      (signal (car err) (cdr err))))
   (org-gtd-review--save-state))
 
+(defun org-gtd-review--insert-reminder-body (profile)
+  "Add the reminder body line under the habit heading titled PROFILE.
+Targets the last habit heading in the default tasks file whose title
+equals PROFILE — the one `org-gtd-review-schedule' just created — so
+pre-existing headings that merely mention PROFILE, or carry tags,
+are never mistaken for it."
+  (let ((habit-marker (org-gtd-type-org-gtd-value 'habit)))
+    (with-current-buffer (org-gtd--default-file)
+      (org-with-wide-buffer
+       (goto-char (point-min))
+       (let (target)
+         (while (re-search-forward org-heading-regexp nil t)
+           (when (and (equal (org-get-heading t t t t) profile)
+                      (equal (org-entry-get (point) "ORG_GTD") habit-marker))
+             (setq target (point))))
+         (when target
+           (goto-char target)
+           (org-end-of-meta-data t)
+           (insert "Run M-x org-gtd-review when you sit down for this.\n")
+           (basic-save-buffer)))))))
+
 ;;;###autoload
 (defun org-gtd-review-schedule (&optional profile-name date repeater)
   "Create a recurring habit reminding you to run a review.
 PROFILE-NAME, DATE (YYYY-MM-DD) and REPEATER (org repeater like
-\".+1w\") are prompted for interactively."
+\".+1w\") are prompted for interactively.  When a reminder already
+exists, ask before scheduling another."
   (interactive)
-  (let* ((names (mapcar #'car org-gtd-review-profiles))
-         (profile (or profile-name
-                      (if (cdr names)
-                          (completing-read "Review profile: " names nil t)
-                        (car names))))
-         (date (or date (org-read-date nil nil nil "First review: ")))
-         (repeater (or repeater
-                       (read-string "How often? (org repeater, e.g. .+1w): "
-                                    nil nil ".+1w"))))
-    (org-gtd-create-item 'habit profile
-                         `((:when . ,(format "<%s %s>" date repeater))))
-    (with-current-buffer (org-gtd--default-file)
-      (org-with-wide-buffer
-       (goto-char (point-min))
-       (when (re-search-forward
-              (format "^\\*+ +.*%s[ \t]*$" (regexp-quote profile)) nil t)
-         (org-end-of-meta-data t)
-         (insert "Run M-x org-gtd-review when you sit down for this.\n")
-         (basic-save-buffer))))
-    (message "'%s' reminder created — it will show up in your engage view."
-             profile)))
+  (unless org-gtd-review-profiles
+    (user-error
+     "No review profiles configured — see `org-gtd-review-profiles'"))
+  (if (and (org-gtd-review--reminder-exists-p)
+           (not (y-or-n-p "A review reminder already exists — schedule another? ")))
+      (message "Keeping the existing reminder.")
+    (let* ((names (mapcar #'car org-gtd-review-profiles))
+           (profile (or profile-name
+                        (if (cdr names)
+                            (completing-read "Review profile: " names nil t)
+                          (car names))))
+           (date (or date (org-read-date nil nil nil "First review: ")))
+           (repeater (or repeater
+                         (read-string "How often? (org repeater, e.g. .+1w): "
+                                      nil nil ".+1w"))))
+      (unless (string-match-p org-gtd-review--repeater-re repeater)
+        (user-error
+         "Org repeaters look like .+1w (dot-plus means 'a week after I actually do it'), +1w, or ++1w"))
+      (org-gtd-create-item 'habit profile
+                           `((:when . ,(format "<%s %s>" date repeater))))
+      (org-gtd-review--insert-reminder-body profile)
+      (message "'%s' reminder created — it will show up in your engage view."
+               profile))))
 
 ;;;; Footer
 

--- a/org-gtd-review.el
+++ b/org-gtd-review.el
@@ -153,6 +153,16 @@ step looks like so the error teaches the fix."
         (unless (plist-get step :type)
           (user-error
            "Review profile '%s', phase '%s': step \"%s\" is missing :type — one of prompt, command, view, or checklist"
+           name (car phase) (plist-get step :title)))
+        (when (and (eq (plist-get step :type) 'command)
+                   (not (plist-get step :command)))
+          (user-error
+           "Review profile '%s', phase '%s': command step \"%s\" is missing :command — name the command to run, like :command org-gtd-process-inbox"
+           name (car phase) (plist-get step :title)))
+        (when (and (eq (plist-get step :type) 'view)
+                   (not (plist-get step :view)))
+          (user-error
+           "Review profile '%s', phase '%s': view step \"%s\" is missing :view — name the command that shows the view, like :view org-gtd-engage"
            name (car phase) (plist-get step :title)))))))
 
 ;;;; Keymap and Mode
@@ -318,17 +328,21 @@ not recurse through the kill it performs itself."
          (type (plist-get step :type)))
     (pcase type
       ('prompt (org-gtd-review--complete-step))
+      ;; Command/view steps set :acted only AFTER the call returns, so a
+      ;; signaling command leaves the step un-acted and n retries it.
+      ;; Deliberate: s after the first n tallies :skipped — the user
+      ;; declined to confirm completion.
       ('command
        (if (plist-get org-gtd-review--state :acted)
            (org-gtd-review--complete-step)
-         (plist-put org-gtd-review--state :acted t)
-         (call-interactively (plist-get step :command))))
+         (call-interactively (plist-get step :command))
+         (plist-put org-gtd-review--state :acted t)))
       ('view
        (if (plist-get org-gtd-review--state :acted)
            (org-gtd-review--complete-step)
-         (plist-put org-gtd-review--state :acted t)
          (save-selected-window
-           (call-interactively (plist-get step :view)))))
+           (call-interactively (plist-get step :view)))
+         (plist-put org-gtd-review--state :acted t)))
       ('checklist (org-gtd-review--walk-next step))
       (_
        (message "Step type '%s' is unknown — check org-gtd-review-profiles; skipping this step" type)

--- a/org-gtd-review.el
+++ b/org-gtd-review.el
@@ -290,9 +290,26 @@ not recurse through the kill it performs itself."
 
 ;;;; Commands
 
-(defun org-gtd-review--walk-next (_step)
-  "Placeholder."
-  nil)
+(defun org-gtd-review--walk-next (step)
+  "Advance the checklist walk for STEP, loading it on first call."
+  (let ((state org-gtd-review--state))
+    (if (not (plist-get state :acted))
+        (let ((items (org-gtd-checklist--items (plist-get step :checklist))))
+          (if (null items)
+              (progn
+                (message "Nothing in checklist '%s' — moving on.  (Edit %s to add items.)"
+                         (plist-get step :checklist)
+                         (org-gtd-checklist--file-path))
+                (org-gtd-review--complete-step))
+            (plist-put state :acted t)
+            (plist-put state :walk-items items)
+            (plist-put state :walk-pos 0)
+            (org-gtd-review--render)))
+      (let ((next (1+ (plist-get state :walk-pos))))
+        (if (< next (length (plist-get state :walk-items)))
+            (progn (plist-put state :walk-pos next)
+                   (org-gtd-review--render))
+          (org-gtd-review--complete-step))))))
 
 (defun org-gtd-review-next ()
   "Do the current step, or advance past it."

--- a/org-gtd-review.el
+++ b/org-gtd-review.el
@@ -1,0 +1,119 @@
+;;; org-gtd-review.el --- Guided review sessions for org-gtd -*- lexical-binding: t; coding: utf-8 -*-
+;;
+;; Copyright © 2026 Aldric Giacomoni
+
+;; Author: Aldric Giacomoni <trevoke@gmail.com>
+;; This file is not part of GNU Emacs.
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; Guided, profile-driven review sessions — Weekly Review by default.
+;;
+;;; Code:
+
+;;;; Requirements
+
+(require 'org)
+(require 'f)
+(require 'seq)
+(require 'org-gtd-core)
+(require 'org-gtd-files)
+(require 'org-gtd-checklist)
+(require 'org-gtd-create)
+
+;;;; Customization
+
+(defcustom org-gtd-review-profiles
+  '(("Weekly Review"
+     ("Get Clear"
+      (:title "Gather loose materials"
+       :type prompt
+       :instruction "Collect loose papers, receipts, and notes.  Capture each one into the inbox.")
+      (:title "Mind sweep"
+       :type checklist
+       :checklist "Weekly Review triggers"
+       :instruction "Walk each trigger.  Press c to capture whatever it shakes loose.")
+      (:title "Inbox to zero"
+       :type command
+       :command org-gtd-process-inbox
+       :instruction "Process every inbox item.  Come back here and press n when the inbox is empty."))
+     ("Get Current"
+      (:title "Review missed items"
+       :type view
+       :view org-gtd-reflect-missed-items
+       :instruction "Reschedule, complete, or cancel anything that slipped.")
+      (:title "Review Waiting-For"
+       :type view
+       :view org-gtd-reflect-upcoming-delegated
+       :instruction "Nudge, close, or re-delegate each delegated item.")
+      (:title "Review next actions"
+       :type view
+       :view org-gtd-show-all-next
+       :instruction "Mark done what is done; check these still feel current.")
+      (:title "Review stuck projects"
+       :type view
+       :view org-gtd-reflect-stuck-projects
+       :instruction "Give every active project a next action."))
+     ("Get Creative"
+      (:title "Review Someday/Maybe"
+       :type view
+       :view org-gtd-reflect-someday-maybe
+       :instruction "Reactivate anything whose time has come.")
+      (:title "Capture new ideas"
+       :type prompt
+       :instruction "Any creative, risky, or fun ideas?  Capture them."))))
+  "Alist of guided review profiles.
+Each entry is (PROFILE-NAME . PHASES); each phase is
+\(PHASE-NAME . STEPS); each step is a plist with :title, :type
+\(one of `prompt', `command', `view', `checklist'), an optional
+:instruction, and the type-specific key :command, :view, or
+:checklist (a template name in the checklists file)."
+  :group 'org-gtd
+  :type 'sexp)
+
+;;;; Variables
+
+(defvar org-gtd-review--state nil
+  "State plist of the active review session.
+Keys: :profile (name string), :phase (index), :step (index),
+:acted (step-local flag), :walk-items, :walk-pos, :done, :skipped.")
+
+(defvar org-gtd-review--window-config nil
+  "Window configuration to restore when the session ends.")
+
+(defconst org-gtd-review--buffer-name "*GTD Review*")
+
+;;;; Accessors
+
+(defun org-gtd-review--phases ()
+  "Return the phases of the active profile."
+  (cdr (assoc (plist-get org-gtd-review--state :profile)
+              org-gtd-review-profiles)))
+
+(defun org-gtd-review--current-phase ()
+  "Return the (NAME . STEPS) phase the session is in."
+  (nth (plist-get org-gtd-review--state :phase) (org-gtd-review--phases)))
+
+(defun org-gtd-review--current-step ()
+  "Return the step plist the session is on."
+  (nth (plist-get org-gtd-review--state :step)
+       (cdr (org-gtd-review--current-phase))))
+
+;;;; Footer
+
+(provide 'org-gtd-review)
+
+;;; org-gtd-review.el ends here

--- a/org-gtd-review.el
+++ b/org-gtd-review.el
@@ -290,6 +290,10 @@ not recurse through the kill it performs itself."
 
 ;;;; Commands
 
+(defun org-gtd-review--walk-next (_step)
+  "Placeholder."
+  nil)
+
 (defun org-gtd-review-next ()
   "Do the current step, or advance past it."
   (interactive)
@@ -297,7 +301,21 @@ not recurse through the kill it performs itself."
          (type (plist-get step :type)))
     (pcase type
       ('prompt (org-gtd-review--complete-step))
-      (_ (message "Step type %s not implemented yet" type)))))
+      ('command
+       (if (plist-get org-gtd-review--state :acted)
+           (org-gtd-review--complete-step)
+         (plist-put org-gtd-review--state :acted t)
+         (call-interactively (plist-get step :command))))
+      ('view
+       (if (plist-get org-gtd-review--state :acted)
+           (org-gtd-review--complete-step)
+         (plist-put org-gtd-review--state :acted t)
+         (save-selected-window
+           (call-interactively (plist-get step :view)))))
+      ('checklist (org-gtd-review--walk-next step))
+      (_
+       (message "Step type '%s' is unknown — check org-gtd-review-profiles; skipping this step" type)
+       (org-gtd-review--complete-step t)))))
 
 (defun org-gtd-review-skip ()
   "Skip the current step for this run only."

--- a/org-gtd-upgrades.el
+++ b/org-gtd-upgrades.el
@@ -233,6 +233,64 @@ Make a backup before running!"
 
     (message "Migration complete! Your projects now use the dependency system.")))
 
+(defun org-gtd-upgrade-v4-to-v5 ()
+  "Report repeating headings whose checkboxes will auto-reset in v5.
+org-gtd v5 clears the checkbox state in a repeating heading's subtree
+each time the heading re-arms its repeater (see
+`org-gtd-checklist--maybe-reset-checkboxes').  This command scans your
+agenda files and lists every existing repeating heading that already
+contains checkboxes, so you can confirm the new behavior suits them
+before relying on it.  It changes nothing."
+  (interactive)
+  (let ((headings (org-gtd-upgrade--repeating-checkbox-headings)))
+    (if (null headings)
+        (message
+         "org-gtd v5: no existing repeating headings contain checkboxes — nothing changes")
+      (with-current-buffer (get-buffer-create "*org-gtd v5 upgrade*")
+        (let ((inhibit-read-only t))
+          (erase-buffer)
+          (insert "org-gtd v5 — checkbox auto-reset on repeat\n"
+                  "==========================================\n\n"
+                  "Completing a repeating heading now clears the checkboxes in its\n"
+                  "subtree, so the next occurrence starts fresh.  These existing\n"
+                  "repeating headings contain checkboxes and will behave this way.\n"
+                  "Nothing has been changed; review them at your leisure.\n\n")
+          (dolist (heading headings)
+            (insert (format "  - %s\n      %s\n"
+                            (plist-get heading :heading)
+                            (plist-get heading :file))))
+          (goto-char (point-min))
+          (special-mode))
+        (display-buffer (current-buffer)))
+      (message
+       "org-gtd v5: %d repeating heading(s) with checkboxes — see *org-gtd v5 upgrade*"
+       (length headings)))))
+
+(defun org-gtd-upgrade--repeating-checkbox-headings ()
+  "Return existing repeating headings with checkbox items in their subtree.
+Each element is a plist (:file FILE :heading TITLE).  A heading matches
+when it carries a live, non-zero-interval repeater — the same condition
+under which `org-gtd-checklist--maybe-reset-checkboxes' fires — and its
+subtree contains at least one checkbox list item.  Read-only; scans
+`org-agenda-files'."
+  (let ((org-agenda-files (org-gtd-core--agenda-files))
+        (results '()))
+    (org-map-entries
+     (lambda ()
+       (let ((repeat (org-get-repeat)))
+         (when (and repeat
+                    (/= 0 (string-to-number (substring repeat 1)))
+                    (save-excursion
+                      (re-search-forward
+                       "^[ \t]*\\(?:[-+*]\\|[0-9]+[.)]\\)[ \t]+\\[[ Xx-]\\]"
+                       (save-excursion (org-end-of-subtree t t) (point))
+                       t)))
+           (push (list :file (buffer-file-name)
+                       :heading (org-get-heading t t t t))
+                 results))))
+     nil 'agenda)
+    (nreverse results)))
+
 (defun org-gtd-upgrade--migrate-delegated-items ()
   "Migrate delegated items to use ORG_GTD=Delegated (Step 2 of migration).
 

--- a/org-gtd.el
+++ b/org-gtd.el
@@ -82,8 +82,10 @@
 (require 'org-gtd-mode)
 (require 'org-gtd-reflect)
 (require 'org-gtd-someday-review)
+(require 'org-gtd-review)
 (require 'org-gtd-view-language)
 (require 'org-gtd-upgrades)
+(require 'org-gtd-init)
 (require 'org-gtd-command-center)
 
 ;;;; Constants

--- a/org-gtd.el
+++ b/org-gtd.el
@@ -56,6 +56,7 @@
 (require 'org-gtd-context)
 (require 'org-gtd-id)
 (require 'org-gtd-files)
+(require 'org-gtd-checklist)
 (require 'org-gtd-horizons)
 (require 'org-gtd-areas-of-focus)
 (require 'org-gtd-hooks)

--- a/org-gtd.info
+++ b/org-gtd.info
@@ -1382,7 +1382,7 @@ File: org-gtd.info,  Node: Configuring,  Prev: Installing,  Up: Setting up Org G
                Add items and process inbox
           *Reflect* (‘w’, ‘a’, ‘y’, ‘d’, ‘r’, ‘R’, ‘l’)
                Guided Weekly Review, review areas, someday items,
-               completed work, checklists
+               completed work, checklist templates
           *Review System* (‘S’, ‘M’)
                Sub-menus for stuck and missed items
           *Archive* (‘A’)
@@ -2129,7 +2129,7 @@ part.
      ‘org-gtd-engage’                           See actionable items                   Daily (your "work from" view)
      ‘org-gtd-show-all-next’                    See only NEXT actions                  When you want to focus on actions
      ‘org-gtd-review’                           Guided Weekly Review session           Weekly
-     ‘org-gtd-checklist-insert’                 Insert a reusable checklist at point   Packing lists, release steps, mind sweeps
+     ‘org-gtd-checklist-template-insert’        Insert a reusable checklist at point   Packing lists, release steps, mind sweeps
      ‘org-gtd-reflect-stuck-projects’           Find stuck projects                    Weekly review
      ‘org-gtd-reflect-someday-review’           Review someday items one-by-one        Weekly/monthly review
      ‘org-gtd-projects-fix-all-todo-keywords’   Fix task states after external edits   After mobile/web edits
@@ -2744,7 +2744,7 @@ File: org-gtd.info,  Node: Checklists,  Next: Weekly Review (guided),  Prev: The
 
 Some lists you use over and over: packing for a trip, releasing
 software, the trigger list of a Weekly Review mind sweep.  org-gtd
-stores these as templates in a file called ‘checklists.org’ in
+stores these as templates in a file called ‘checklist-templates.org’ in
 ‘org-gtd-directory’, and lets you stamp out a fresh copy whenever you
 need one.
 
@@ -2754,8 +2754,8 @@ prompts".  They're yours — edit or delete them freely.
 
    • The template file
 
-     Each top-level heading in ‘checklists.org’ is a template; its
-     checkbox items are the checklist:
+     Each top-level heading in ‘checklist-templates.org’ is a template;
+     its checkbox items are the checklist:
 
           * Beach packing
           - [ ] Sunscreen
@@ -2772,19 +2772,19 @@ prompts".  They're yours — edit or delete them freely.
 
      That's the whole format: no TODO keywords, no properties, nothing
      org-gtd-specific.  *Editing this file is how you customize your
-     checklists.*  Open it with ‘M-x org-gtd-checklist-visit’ (or ‘l’
-     from the command center) and use ordinary org editing.  A heading
-     marked with org's ‘COMMENT’ keyword is ignored — a handy way to
-     retire a template without deleting it.
+     checklists.*  Open it with ‘M-x org-gtd-checklist-template-visit’
+     (or ‘l’ from the command center) and use ordinary org editing.  A
+     heading marked with org's ‘COMMENT’ keyword is ignored — a handy
+     way to retire a template without deleting it.
 
      The file is not part of your agenda: templates are content, not
      tasks.
 
    • Spawning a checklist
 
-     Call ‘M-x org-gtd-checklist-insert’ in any org buffer.  It offers
-     your template names for completion, then inserts a fresh copy of
-     the chosen template as a subtree:
+     Call ‘M-x org-gtd-checklist-template-insert’ in any org buffer.  It
+     offers your template names for completion, then inserts a fresh
+     copy of the chosen template as a subtree:
 
         • On a heading line, the copy becomes the *first child* of that
           heading.
@@ -2802,7 +2802,7 @@ prompts".  They're yours — edit or delete them freely.
      have:
 
        1. In your inbox (or any org file), ‘M-x
-          org-gtd-checklist-insert’ and pick the template.
+          org-gtd-checklist-template-insert’ and pick the template.
        2. ‘M-x org-gtd-clarify-item’ on the new heading; rename it if
           you like.
        3. Organize it as a *Habit* with a repeater (say, ‘.+1w’).
@@ -2835,7 +2835,8 @@ prompts".  They're yours — edit or delete them freely.
      ‘org-gtd-mode’.
 
      *See also*: *note Commands Reference:: for
-     ‘org-gtd-checklist-insert’ and ‘org-gtd-checklist-visit’.
+     ‘org-gtd-checklist-template-insert’ and
+     ‘org-gtd-checklist-template-visit’.
 
 
 File: org-gtd.info,  Node: Weekly Review (guided),  Next: Understanding GTD Item Types,  Prev: Checklists,  Up: Using Org GTD
@@ -2895,12 +2896,12 @@ it one step at a time, so you don't have to hold the ritual in your head
           agenda view in another window; browse it and act on what needs
           acting.  The second ‘n’ advances.
      checklist
-          Walks the items of a named template from your *note checklists
-          file: Checklists, one item at a time.  The first ‘n’ shows the
-          first item; each further ‘n’ shows the next; press ‘c’
-          whenever an item shakes something loose.  The template file
-          itself is never modified.  An empty or missing checklist just
-          says so and moves on.
+          Walks the items of a named template from your *note checklist
+          templates file: Checklists, one item at a time.  The first ‘n’
+          shows the first item; each further ‘n’ shows the next; press
+          ‘c’ whenever an item shakes something loose.  The template
+          file itself is never modified.  An empty or missing checklist
+          just says so and moves on.
 
    • Pause, resume, and crash recovery
 
@@ -2926,7 +2927,7 @@ it one step at a time, so you don't have to hold the ritual in your head
      list of steps; each step is a plist with a ‘:title’, a ‘:type’ (one
      of ‘prompt’, ‘command’, ‘view’, ‘checklist’), an optional
      ‘:instruction’, and the type-specific key ‘:command’, ‘:view’, or
-     ‘:checklist’ (a template name from your checklists file).
+     ‘:checklist’ (a template name from your checklist templates file).
 
      The Weekly Review ships as the default value, so customizing means
      editing this variable — reorder steps, delete what you don't use,
@@ -3009,11 +3010,11 @@ it one step at a time, so you don't have to hold the ritual in your head
 
      ‘M-x org-gtd-init-system’ is a small first-run concierge.  It
      ensures ‘org-gtd-directory’ and the GTD files exist — the tasks
-     file, the inbox, and ‘checklists.org’ with its starter templates —
-     and then offers to schedule a recurring Weekly Review (skipping the
-     offer when a reminder already exists).  It is idempotent: run it
-     again anytime, and anything already in place is simply reported as
-     ready.
+     file, the inbox, and ‘checklist-templates.org’ with its starter
+     templates — and then offers to schedule a recurring Weekly Review
+     (skipping the offer when a reminder already exists).  It is
+     idempotent: run it again anytime, and anything already in place is
+     simply reported as ready.
 
      Two things it deliberately does *not* do, because they belong in
      your Emacs configuration: adding your GTD files to
@@ -5983,7 +5984,7 @@ These variables control how org-gtd behaves.  All can be customized via
           plist with ‘:title’, ‘:type’ (one of ‘prompt’, ‘command’,
           ‘view’, ‘checklist’), an optional ‘:instruction’, and the
           type-specific key ‘:command’, ‘:view’, or ‘:checklist’ (a
-          template name from your checklists file).
+          template name from your checklist templates file).
 
           *When to customize*: To reorder or trim the Weekly Review,
           point ‘:view’ steps at your own views, or add profiles of your
@@ -6373,7 +6374,7 @@ organized by workflow step.
           d     Reflect: upcoming delegated
           r     Reflect: completed items
           R     Reflect: completed projects
-          l     Reflect: checklists
+          l     Reflect: checklist templates
           A     Archive completed items
           S     Stuck items sub-menu
           M     Missed items sub-menu
@@ -7030,28 +7031,29 @@ organized by workflow step.
 
    • Checklist Commands
 
-        • ‘org-gtd-checklist-insert’
+        • ‘org-gtd-checklist-template-insert’
 
           *When to use*: Whenever you need a fresh copy of a reusable
           checklist (a packing list, release steps, mind-sweep triggers)
 
           *What it does*:
-             • Offers the template names from ‘checklists.org’ for
-               completion
+             • Offers the template names from ‘checklist-templates.org’
+               for completion
              • Inserts a fresh copy of the chosen template as a subtree
                at point (on a heading line, as that heading's first
                child)
              • The copy is plain org; org-gtd does not track it
 
-        • ‘org-gtd-checklist-visit’
+        • ‘org-gtd-checklist-template-visit’
 
           *Binding*: ‘l’ from the command center
 
           *When to use*: To add, edit, or retire checklist templates
 
           *What it does*:
-             • Opens ‘checklists.org’ in ‘org-gtd-directory’, creating
-               and seeding it with starter templates on first use
+             • Opens ‘checklist-templates.org’ in ‘org-gtd-directory’,
+               creating and seeding it with starter templates on first
+               use
              • Each top-level heading is a template; editing this file
                is how you customize your checklists
 
@@ -8201,8 +8203,8 @@ organized by workflow step.
 
           *What it does*:
              • Ensures ‘org-gtd-directory’ and the GTD files exist: the
-               tasks file, the inbox, and ‘checklists.org’ with its
-               starter templates
+               tasks file, the inbox, and ‘checklist-templates.org’ with
+               its starter templates
              • Offers to schedule a recurring Weekly Review via
                ‘org-gtd-review-schedule’ (skips the offer when a
                reminder already exists)
@@ -10806,533 +10808,533 @@ Ref: Required keyword configuration49823
 Ref: Optional configuration52659
 Ref: Recommended key bindings58156
 Ref: Command Center58806
-Ref: Sample Doom Emacs Config59765
-Node: Getting Started with Org GTD61194
-Node: Quick Start Reference61658
-Node: Tutorial Your First Project62200
-Ref: What You'll Learn62657
-Ref: The Project62962
-Ref: Step 1 Capture the Project63269
-Ref: Step 2 Process the Inbox63759
-Ref: Step 3 Organize as a Project64178
-Ref: Step 4 View in Engage64759
-Ref: Step 5 Complete the First Task65278
-Ref: Step 6 Refresh and See the Change65628
-Ref: What Just Happened?66014
-Ref: Continue the Project67001
-Ref: Key Takeaways67444
-Ref: What's Next?67971
-Node: Tutorial Creating Your First Custom View68652
-Ref: What You'll Learn (1)69173
-Ref: Why This View?69405
-Ref: Understanding the View DSL69794
-Ref: Creating the View Function70323
-Ref: Using Your View70800
-Ref: Binding to a Key70946
-Ref: What You'll See71565
-Ref: Experiment Modify the View71981
-Ref: Available Filters72972
-Ref: Key Takeaways (1)75170
-Ref: What's Next? (1)75635
-Node: Tutorial Quick Wins and Focus Work Views76134
-Ref: Why This Matters76579
-Ref: Your First Quick Wins View (30 seconds)77058
-Ref: The Effort Filter Explained77584
-Ref: Building a Focus Work View78283
-Ref: The Priority Filter Explained78824
-Ref: Finding Tasks to Triage79494
-Ref: Bonus The Clocked Filter80097
-Ref: Putting It All Together80806
-Ref: Key Takeaways (2)81977
-Ref: Where to Go From Here82398
-Node: Using Org GTD83575
-Node: Your Daily Workflow84368
-Ref: Quick command reference85228
-Node: The GTD Flow in Depth86997
-Ref: Adding things to the inbox87233
-Ref: Processing the inbox88562
-Ref: Clarifying each item89286
-Ref: How to start clarifying89655
-Ref: data shape requirements90208
-Ref: Options and commands related to clarification90835
-Ref: Duplicating items during clarification93283
-Ref: Your first duplicate in 30 seconds93774
-Ref: Understanding the workflow94215
-Ref: The queue window95022
-Ref: Two ways to duplicate95579
-Ref: What happens if you cancel?96270
-Ref: Nested duplicates96943
-Ref: Data safety97180
-Ref: Configuration97665
-Ref: Organizing an item into the system98059
-Ref: Refiling to the appropriate area98847
-Ref: Understanding Refiling in V498898
-Ref: Refile Target System99349
-Ref: Controlling Refile Prompts by Item Type100555
-Ref: Creating New Refile Targets103060
-Ref: Multiple Types Per Heading103853
-Ref: Using Your Own Refile Targets104576
-Ref: Migration from V3105319
-Ref: Engaging with your GTD items105993
-Ref: Quick Task Actions from the Agenda106623
-Ref: First Contact Why This Feature?106676
-Ref: Black Triangle Your First Quick Action107412
-Ref: Understanding the Actions108251
-Ref: State Changes108410
-Ref: Time Adjustments (Conditional)108960
-Ref: Clocking110050
-Ref: Metadata110263
-Ref: Clarify110816
-Ref: Command Reference111167
-Ref: Suggested Keybinding112507
-Node: Checklists112877
-Ref: The template file113517
-Ref: Spawning a checklist114606
-Ref: Recurring checklists compose with habits115217
-Ref: Checkbox reset on repeat115904
-Node: Weekly Review (guided)117074
-Ref: Running a session117598
-Ref: Step types118818
-Ref: Pause resume and crash recovery120064
-Ref: Customizing the ritual org-gtd-review-profiles121025
-Ref: Scheduling the review org-gtd-review-schedule124305
-Ref: First-time setup org-gtd-init-system125463
-Node: Understanding GTD Item Types126538
-Ref: Single Action [S]127056
-Ref: Project [P]127631
-Ref: Add to existing project [A]128543
-Ref: Calendar [C]129308
-Ref: Delegate [D]130067
-Ref: Quick Action [Q]131325
-Ref: Tickler [I]131867
-Ref: Someday/Maybe [y]133402
-Ref: Habit [H]136195
-Ref: Knowledge [K]136981
-Ref: Trash [T]137645
-Ref: Working with the GTD Horizons138419
-Ref: Areas of focus139043
-Ref: Longer-term horizons140444
-Node: Working with Projects (Advanced)142244
-Ref: Quick Navigation142737
-Ref: First Contact Why Visual Project Management?143956
-Ref: Black Triangle Your First Project Graph View144791
-Ref: Step 1 Find a project144892
-Ref: Step 2 Open the graph view145090
-Ref: Step 3 Explore145273
-Ref: Understanding Project Dependencies145897
-Ref: The Dependency Graph (DAG)146039
-Ref: What You See in Graph View146646
-Ref: Sequential vs Parallel vs Mixed147373
-Ref: Tutorial Parallel Tasks with Graph View148376
-Ref: The Scenario148498
-Ref: Step 1 Capture and Organize148954
-Ref: Step 2 Open Graph View149357
-Ref: Step 3 Modify Dependencies to Create Parallel Tasks150003
-Ref: What Graph View CAN Do150679
-Ref: Building Our Parallel Structure151332
-Ref: The Diamond Pattern in Action152210
-Ref: Alternative Approach Add Blockers152760
-Ref: Tutorial Complex Dependencies with Graph View153355
-Ref: The Scenario (1)153415
-Ref: The Dependency Graph154041
-Ref: Building with Graph View154634
-Ref: Creating the Convergence Point155133
-Ref: Building the Rest155614
-Ref: The Complete Graph156164
-Ref: Key Patterns This Example Shows156845
-Ref: Common Dependency Patterns (Visual Reference)157306
-Ref: Sequential Chain (A → B → C)157427
-Ref: Parallel Independent (A B C all start together)157897
-Ref: Fan-out (A → B A → C A → D)158286
-Ref: Fan-in / Convergence (A → C B → C)158795
-Ref: Diamond (A → B → D A → C → D)159254
-Ref: Graph View Command Reference159922
-Ref: Opening Graph View160122
-Ref: Tier 1 Single-Key Commands (Always Available)160420
-Ref: Tier 2 Prefixed Commands163770
-Ref: Visual Indicators165323
-Ref: Operations Not Available in Graph View165629
-Ref: Text-Based Alternatives166452
-Ref: Graph Rendering Modes167787
-Ref: SVG Mode (Default)167989
-Ref: ASCII Mode168350
-Ref: Toggling Modes168735
-Ref: Troubleshooting ASCII Rendering168861
-Ref: Complete Keyboard Reference169224
-Ref: Tier 1 Single Keys169348
-Ref: Tier 2 Task Operations (t prefix)170293
-Ref: Tier 2 Project and View Operations170670
-Ref: Auto-Refresh on File Changes171121
-Ref: Technical Details171616
-Ref: Graph Data Structure171647
-Ref: Layout Algorithm172047
-Ref: Properties Used172403
-Ref: Undo/Redo Support173349
-Ref: Practical Tips for Project Management173728
-Ref: When to Use Graph View173779
-Ref: When to Use Sequential (Default)174186
-Ref: When to Create Parallel Structures174602
-Ref: Managing Complexity174970
-Ref: Growing Projects Over Time175414
-Ref: Canceling Projects175853
-Ref: Exporting Project Graphs176869
-Ref: First Contact What is Graph Export?176907
-Ref: Tutorial Export Your First Graph177649
-Ref: Progressive Learning Choosing Export Formats178211
-Ref: When Exports Differ from Display180052
-Ref: Reference Export Commands180666
-Ref: Troubleshooting Exports181356
-Ref: Troubleshooting Projects with Graph View182144
-Ref: Project is Stuck (has TODO tasks but no NEXT)182198
-Ref: Task Should Be NEXT But Shows as TODO183132
-Ref: Too Many Tasks Are NEXT183782
-Ref: Graph Won't Open184282
-Ref: Graph Shows No Tasks184682
-Ref: Task Shows Wrong State (NEXT vs TODO)185117
-Ref: Can't Modify Dependencies185620
-Ref: See Also186072
-Ref: Tickler Projects Pausing Work You're Not Ready For186569
-Ref: First Contact Why Tickler Projects?186634
-Ref: Black Triangle Tickler Your First Project in 30 Seconds187702
-Ref: Understanding Tickler What Actually Happens188615
-Ref: Tutorial Managing Seasonal Projects190865
-Ref: Common Patterns and Scenarios193329
-Ref: Advanced External Dependencies and Warnings195610
-Ref: Technical Details How Tickler Works Under the Hood197926
-Ref: Troubleshooting Tickler201787
-Ref: See Also (1)205074
-Ref: Project Progress Cookies See Your Progress at a Glance205704
-Ref: First Contact What Are Progress Cookies?205773
-Ref: Black Triangle See Progress in 30 Seconds206334
-Ref: Tutorial Watch Cookies Update Automatically206821
-Ref: Understanding How Cookies Work207635
-Ref: Configuring Cookie Position208707
-Ref: Common Scenarios209541
-Ref: Technical Reference210378
-Ref: Cleaning up / archiving completed work211307
-Ref: Commands you can call on org-agenda212001
-Ref: Defining your own agenda views212799
-Ref: Adding your own hooks when organizing213499
-Node: Automating through emacs214769
-Node: Reference216072
-Node: Configuration Variables Reference217518
-Ref: Required Configuration217825
-Ref: org-todo-keywords (org-mode variable)217861
-Ref: org-gtd-keyword-mapping218948
-Ref: Directory and File Configuration220112
-Ref: org-gtd-directory220158
-Ref: org-gtd-additional-inbox-files221257
-Ref: org-gtd-horizons-file222230
-Ref: Capture Configuration222663
-Ref: org-gtd-capture-templates222698
-Ref: Organize and Process Configuration223978
-Ref: org-gtd-organize-hooks224026
-Ref: org-gtd-save-after-organize225570
-Ref: org-gtd-refile-to-any-target (deprecated)225921
-Ref: org-gtd-refile-prompt-for-types227223
-Ref: Mode-Line Configuration228658
-Ref: org-gtd-mode-update-interval228695
-Ref: org-gtd-mode-lighter-display229586
-Ref: Clarification Configuration230160
-Ref: org-gtd-clarify-show-horizons230201
-Ref: org-gtd-clarify-show-organize-help230965
-Ref: org-gtd-clarify-display-helper-buffer232089
-Ref: org-gtd-clarify-project-templates232738
-Ref: org-gtd-clarify-duplicate-queue-position233939
-Ref: Areas of Focus Configuration234772
-Ref: org-gtd-areas-of-focus234814
-Ref: View Prefix Configuration235466
-Ref: org-gtd-prefix-width235505
-Ref: org-gtd-agenda-truncate-ellipsis236508
-Ref: Archive Configuration237289
-Ref: org-gtd-archive-location237324
-Ref: Missed Engagements Review Configuration238967
-Ref: org-gtd-reflect-missed-custom-views239020
-Ref: Guided Review Configuration240395
-Ref: org-gtd-review-profiles240436
-Ref: Advanced Item Configuration241525
-Ref: org-gtd-user-types241566
-Ref: Agenda Display Configuration244955
-Ref: org-gtd-agenda-property-list245235
-Ref: org-gtd-agenda-property-position245785
-Ref: org-gtd-agenda-property-column246422
-Ref: org-gtd-agenda-property-separator246873
-Ref: Graph View Configuration247233
-Ref: org-gtd-graph-render-mode247342
-Ref: org-gtd-graph-ui-split-ratio248094
-Ref: org-gtd-graph-sibling-mode248867
-Ref: Projects Configuration251315
-Ref: org-gtd-project-progress-cookie-position251351
-Ref: Obsolete Variables (Do Not Use)253531
-Ref: org-gtd-todo-keyword (obsolete)253677
-Ref: org-gtd-next-keyword (obsolete)253805
-Ref: org-gtd-wait-keyword (obsolete)253933
-Ref: org-gtd-canceled-keyword (obsolete)254061
-Node: Commands Reference254185
-Ref: Core GTD Workflow Commands254500
-Ref: org-gtd-command-center254540
-Ref: org-gtd-capture255921
-Ref: org-gtd-process-inbox256565
-Ref: org-gtd-organize257410
-Ref: org-gtd-engage258381
-Ref: org-gtd-show-all-next259187
-Ref: Reflect Commands259580
-Ref: org-gtd-review259610
-Ref: org-gtd-review-schedule260571
-Ref: org-gtd-reflect-stuck-projects261221
-Ref: org-gtd-reflect-area-of-focus261789
-Ref: org-gtd-reflect-completed-items262400
-Ref: org-gtd-reflect-completed-projects262950
-Ref: org-gtd-reflect-missed-items263199
-Ref: Stuck Item Review Commands263488
-Ref: org-gtd-reflect-stuck-calendar-items263612
-Ref: org-gtd-reflect-stuck-tickler-items263736
-Ref: org-gtd-reflect-stuck-habit-items263860
-Ref: org-gtd-reflect-stuck-delegated-items263972
-Ref: org-gtd-reflect-stuck-next-action-items264115
-Ref: Reviewing Someday/Maybe Items264229
-Ref: Your First Review in 60 Seconds264853
-Ref: Understanding the Review Workflow265330
-Ref: Tutorial Weekly Someday Review266044
-Ref: Organizing Your Someday Items (Optional)266953
-Ref: Common Patterns267744
-Ref: Command Reference (1)268501
-Ref: org-gtd-reflect-someday-review268960
-Ref: Reflect Commands (Missed Engagements)269975
-Ref: What Are Missed Engagements?270026
-Ref: Your First Review in 30 Seconds270843
-Ref: Understanding the Review Workflow (1)271310
-Ref: Tutorial Daily Review Workflow272058
-Ref: Common Patterns (1)272891
-Ref: Command Reference (2)273403
-Ref: Backward Compatibility Note274163
-Ref: Reflect Commands (Upcoming Delegated)274855
-Ref: What Are Upcoming Delegated Check-ins?274906
-Ref: Your First Review in 30 Seconds (1)275734
-Ref: Understanding Proactive Delegation Management276242
-Ref: Tutorial Weekly Planning Workflow276901
-Ref: Common Patterns (2)278035
-Ref: Understanding What You See278816
-Ref: Comparison Missed vs Upcoming279602
-Ref: Command Reference (3)280112
-Ref: Checklist Commands280537
-Ref: org-gtd-checklist-insert280569
-Ref: org-gtd-checklist-visit281113
-Ref: Custom View Commands281706
-Ref: org-gtd-view-show281740
-Ref: Clarification Commands292053
-Ref: org-gtd-clarify-item292089
-Ref: org-gtd-clarify-agenda-item292575
-Ref: org-gtd-clarify-toggle-horizons-window292868
-Ref: org-gtd-clarify-toggle-organize-help293234
-Ref: org-gtd-clarify-project-insert-template293827
-Ref: org-gtd-clarify-duplicate294170
-Ref: org-gtd-clarify-duplicate-exact295022
-Ref: org-gtd-clarify-stop295515
-Ref: Updating Items Without Refiling295906
-Ref: Archive Commands300987
-Ref: org-gtd-archive-completed-items301017
-Ref: Agenda-Specific Commands301542
-Ref: org-gtd-delegate-agenda-item301644
-Ref: org-gtd-project-cancel-from-agenda302007
-Ref: Timestamp Commands (DWIM)302449
-Ref: org-gtd-set-timestamp302605
-Ref: Project Task Commands (DWIM)303292
-Ref: org-gtd-project-add-successor303493
-Ref: org-gtd-project-add-blocker303972
-Ref: org-gtd-project-add-root-task304464
-Ref: org-gtd-project-remove-task304862
-Ref: org-gtd-project-trash-task305274
-Ref: org-gtd-project-change-state305646
-Ref: Project Management Commands305934
-Ref: org-gtd-projects-fix-todo-keywords-for-project-at-point305975
-Ref: org-gtd-projects-fix-all-todo-keywords306625
-Ref: org-gtd-project-update-all-cookies309667
-Ref: org-gtd-tickler311293
-Ref: org-gtd-someday313135
-Ref: org-gtd-reactivate314842
-Ref: Task Dependency Commands316959
-Ref: org-gtd-task-add-blockers317737
-Ref: org-gtd-task-remove-blockers318558
-Ref: org-gtd-task-add-dependent318864
-Ref: org-gtd-task-add-dependents319597
-Ref: org-gtd-task-clear-relationships319869
-Ref: org-gtd-task-show-relationships320242
-Ref: org-gtd-validate-project-dependencies320632
-Ref: org-gtd-remove-task-from-project321106
-Ref: Area of Focus Commands321480
-Ref: org-gtd-area-of-focus-set-on-item-at-point321516
-Ref: org-gtd-area-of-focus-set-on-agenda-item321923
-Ref: Programmatic Creation Commands322298
-Ref: org-gtd-habit-create322447
-Ref: org-gtd-calendar-create322708
-Ref: org-gtd-delegate-create322972
-Ref: org-gtd-tickler-create323696
-Ref: org-gtd-someday-create323989
-Ref: org-gtd-single-action-create324238
-Ref: Utility Commands324459
-Ref: org-gtd-init-system324489
-Ref: org-gtd-setup-keywords-wizard325298
-Ref: org-gtd-inbox-path325650
-Ref: Migration and Upgrade Commands326064
-Ref: org-gtd-upgrade-v3-to-v4326108
-Ref: Mode-Line Integration326720
-Ref: org-gtd-mode326755
-Ref: org-gtd-inbox-count327498
-Ref: Obsolete Commands327782
-Ref: org-gtd-delegate-item-at-point (removed in 40)327813
-Node: Properties Reference (Internal Implementation)328675
-Ref: Core GTD Properties329564
-Ref: ORG_GTD329597
-Ref: ORG_GTD_REFILE330675
-Ref: Project Properties333026
-Ref: ORG_GTD_FIRST_TASKS333058
-Ref: Task Dependency Properties333997
-Ref: ORG_GTD_DEPENDS_ON334037
-Ref: ORG_GTD_BLOCKS335955
-Ref: ORG_GTD_PROJECT_IDS336792
-Ref: Calendar and Time Properties337142
-Ref: ORG_GTD_TIMESTAMP337184
-Ref: Delegation Properties338126
-Ref: DELEGATED_TO338161
-Ref: Habit Properties339113
-Ref: STYLE339143
-Ref: Area of Focus Properties339614
-Ref: CATEGORY339652
-Ref: Standard Org Properties Used by org-gtd340523
-Ref: ID340576
-Ref: keyword340853
-Ref: SCHEDULED (org-mode standard)341508
-Ref: DEADLINE (org-mode standard)341783
-Node: Troubleshooting Projects342026
-Ref: Fixing Broken Dependencies342547
-Ref: When Manual Property Editing is Needed343834
-Ref: Common Problems and Solutions345630
-Ref: Project Shows No NEXT Tasks (Stuck Project)345673
-Ref: Too Many NEXT Tasks346507
-Ref: Task Won't Advance to NEXT346981
-Ref: Task States Inconsistent After External Edits347683
-Node: View DSL Filter Reference348891
-Ref: Your First Custom View in 60 Seconds349408
-Ref: Understanding View Specs349968
-Ref: Combining Filters350552
-Ref: Multi-Block Views350987
-Ref: Common Patterns (3)351610
-Ref: Weekly Review View351639
-Ref: Morning Planning View352209
-Ref: Area of Focus View352900
-Ref: Filter Reference353540
-Ref: View Structure353680
-Ref: Multi-Block Views (1)354025
-Ref: Block Types354763
-Ref: Native Blocks (Escape Hatch)355284
-Ref: When You'll Need This355744
-Ref: Your First Native Block356420
-Ref: Adding Custom Sorting357589
-Ref: Mixing DSL and Native358451
-Ref: Native Block Types359403
-Ref: Quick Reference360036
-Ref: Type Filters360659
-Ref: (type delegated)360716
-Ref: (type calendar)361001
-Ref: (type project)361256
-Ref: (type active-project)361497
-Ref: (type completed-project)361776
-Ref: (type stuck-project)362082
-Ref: (type tickler)362402
-Ref: (type someday)362689
-Ref: (type habit)362983
-Ref: (type next-action)363205
-Ref: (type tickler-project)363522
-Ref: (type incubated-project)363979
-Ref: (type stuck-delegated)364462
-Ref: (type stuck-calendar)364833
-Ref: (type stuck-tickler)365116
-Ref: (type stuck-habit)365399
-Ref: Time-based Filters365657
-Ref: Semantic Time (when VALUE)365749
-Ref: Deadline (deadline VALUE)366710
-Ref: Scheduled (scheduled VALUE)366955
-Ref: Keyword Filters367210
-Ref: (todo ("KEYWORD1" "KEYWORD2"))367527
-Ref: (done VALUE)367951
-Ref: Area of Focus Filters369236
-Ref: (area-of-focus "AREA")369298
-Ref: Tag Filters369715
-Ref: (tags ("TAG1" "TAG2"))369766
-Ref: (tags-match "PATTERN")370089
-Ref: Priority Effort and Clocked Filters370624
-Ref: (priority VALUE)370766
-Ref: (effort SPEC)372085
-Ref: (clocked SPEC)373290
-Ref: (last-clocked-out SPEC)374408
-Ref: Property Filters375709
-Ref: (property (("PROP" "VALUE")))375781
-Ref: Structural Filters376100
-Ref: (level N)376171
-Ref: Special Filters376571
-Ref: (not-habit t)376600
-Ref: (invalid-timestamp t)376879
-Ref: View Configuration Options377225
-Ref: (block-type TYPE)377320
-Ref: (blocks BLOCK-LIST)378184
-Ref: Prefix DSL Customizing the Task Prefix Column378860
-Ref: Your First Prefix in 60 Seconds379359
-Ref: (prefix (ELEMENT ))380008
-Ref: (prefix-width N)381340
-Ref: Prefix Inheritance in Multi-Block Views381984
-Ref: Low-Level (prefix-format FORMAT-STRING)383167
-Ref: (view-type agenda)383769
-Ref: (agenda-span N)384106
-Ref: Simplified Multi-Block Views384272
-Ref: The Problem Verbose Block Definitions384557
-Ref: The Solution Implicit Blocks385464
-Ref: Try It Now386155
-Ref: Smart Type Defaults386817
-Ref: Top-Level Inheritance387765
-Ref: The Four-Tier Precedence Model388149
-Ref: When to Use Explicit Blocks389313
-Ref: Quick Reference (1)389991
-Ref: Saving Your Custom Views390425
-Node: Hooks Framework Reference390993
-Ref: What Are Organize Hooks?391171
-Ref: Your First Hook in 2 Minutes391718
-Ref: The org-gtd-organize-hooks Variable392745
-Ref: Built-in Hooks393066
-Ref: org-set-tags-command393094
-Ref: org-gtd-set-area-of-focus393372
-Ref: Writing Custom Hooks393953
-Ref: Basic Hook Structure394212
-Ref: Using org-gtd-organize-type-member-p394586
-Ref: Example Custom Hooks396231
-Ref: Selective Tagging with Unless396265
-Ref: Add Effort Estimation397047
-Ref: Add Priority397432
-Ref: Auto-Set Property Based on Keywords397772
-Ref: Add Custom Property398295
-Ref: Integration with Org-Roam398781
-Ref: Set Effort from Keywords399187
-Ref: Hook Execution Order399981
-Ref: Best Practices400354
-Ref: Complete Example Comprehensive Hook Setup401251
-Node: Extending org-gtd403430
-Node: Customizing types403717
-Ref: org-gtd-customize-type404404
-Ref: Hook stages405128
-Ref: Programmatic item creation406040
-Ref: Refile prompting406531
-Node: Project Traversal Functions406827
-Ref: org-gtd-project-map-tasks407011
-Ref: org-gtd-projects-map407817
-Node: Troubleshooting408500
-Node: Finding lost tasks408989
-Node: Projects without a NEXT item409996
-Node: I can't create a project when clarifying an inbox item!411256
-Node: Configuration problems412218
-Ref: Keywords not working412492
-Ref: Items not showing in engage view413226
-Node: Tasks still showing after tickler'ing or someday'ing project414036
-Node: Still stuck?415379
+Ref: Sample Doom Emacs Config59774
+Node: Getting Started with Org GTD61203
+Node: Quick Start Reference61667
+Node: Tutorial Your First Project62209
+Ref: What You'll Learn62666
+Ref: The Project62971
+Ref: Step 1 Capture the Project63278
+Ref: Step 2 Process the Inbox63768
+Ref: Step 3 Organize as a Project64187
+Ref: Step 4 View in Engage64768
+Ref: Step 5 Complete the First Task65287
+Ref: Step 6 Refresh and See the Change65637
+Ref: What Just Happened?66023
+Ref: Continue the Project67010
+Ref: Key Takeaways67453
+Ref: What's Next?67980
+Node: Tutorial Creating Your First Custom View68661
+Ref: What You'll Learn (1)69182
+Ref: Why This View?69414
+Ref: Understanding the View DSL69803
+Ref: Creating the View Function70332
+Ref: Using Your View70809
+Ref: Binding to a Key70955
+Ref: What You'll See71574
+Ref: Experiment Modify the View71990
+Ref: Available Filters72981
+Ref: Key Takeaways (1)75179
+Ref: What's Next? (1)75644
+Node: Tutorial Quick Wins and Focus Work Views76143
+Ref: Why This Matters76588
+Ref: Your First Quick Wins View (30 seconds)77067
+Ref: The Effort Filter Explained77593
+Ref: Building a Focus Work View78292
+Ref: The Priority Filter Explained78833
+Ref: Finding Tasks to Triage79503
+Ref: Bonus The Clocked Filter80106
+Ref: Putting It All Together80815
+Ref: Key Takeaways (2)81986
+Ref: Where to Go From Here82407
+Node: Using Org GTD83584
+Node: Your Daily Workflow84377
+Ref: Quick command reference85237
+Node: The GTD Flow in Depth87006
+Ref: Adding things to the inbox87242
+Ref: Processing the inbox88571
+Ref: Clarifying each item89295
+Ref: How to start clarifying89664
+Ref: data shape requirements90217
+Ref: Options and commands related to clarification90844
+Ref: Duplicating items during clarification93292
+Ref: Your first duplicate in 30 seconds93783
+Ref: Understanding the workflow94224
+Ref: The queue window95031
+Ref: Two ways to duplicate95588
+Ref: What happens if you cancel?96279
+Ref: Nested duplicates96952
+Ref: Data safety97189
+Ref: Configuration97674
+Ref: Organizing an item into the system98068
+Ref: Refiling to the appropriate area98856
+Ref: Understanding Refiling in V498907
+Ref: Refile Target System99358
+Ref: Controlling Refile Prompts by Item Type100564
+Ref: Creating New Refile Targets103069
+Ref: Multiple Types Per Heading103862
+Ref: Using Your Own Refile Targets104585
+Ref: Migration from V3105328
+Ref: Engaging with your GTD items106002
+Ref: Quick Task Actions from the Agenda106632
+Ref: First Contact Why This Feature?106685
+Ref: Black Triangle Your First Quick Action107421
+Ref: Understanding the Actions108260
+Ref: State Changes108419
+Ref: Time Adjustments (Conditional)108969
+Ref: Clocking110059
+Ref: Metadata110272
+Ref: Clarify110825
+Ref: Command Reference111176
+Ref: Suggested Keybinding112516
+Node: Checklists112886
+Ref: The template file113535
+Ref: Spawning a checklist114642
+Ref: Recurring checklists compose with habits115262
+Ref: Checkbox reset on repeat115958
+Node: Weekly Review (guided)117151
+Ref: Running a session117675
+Ref: Step types118895
+Ref: Pause resume and crash recovery120150
+Ref: Customizing the ritual org-gtd-review-profiles121111
+Ref: Scheduling the review org-gtd-review-schedule124400
+Ref: First-time setup org-gtd-init-system125558
+Node: Understanding GTD Item Types126642
+Ref: Single Action [S]127160
+Ref: Project [P]127735
+Ref: Add to existing project [A]128647
+Ref: Calendar [C]129412
+Ref: Delegate [D]130171
+Ref: Quick Action [Q]131429
+Ref: Tickler [I]131971
+Ref: Someday/Maybe [y]133506
+Ref: Habit [H]136299
+Ref: Knowledge [K]137085
+Ref: Trash [T]137749
+Ref: Working with the GTD Horizons138523
+Ref: Areas of focus139147
+Ref: Longer-term horizons140548
+Node: Working with Projects (Advanced)142348
+Ref: Quick Navigation142841
+Ref: First Contact Why Visual Project Management?144060
+Ref: Black Triangle Your First Project Graph View144895
+Ref: Step 1 Find a project144996
+Ref: Step 2 Open the graph view145194
+Ref: Step 3 Explore145377
+Ref: Understanding Project Dependencies146001
+Ref: The Dependency Graph (DAG)146143
+Ref: What You See in Graph View146750
+Ref: Sequential vs Parallel vs Mixed147477
+Ref: Tutorial Parallel Tasks with Graph View148480
+Ref: The Scenario148602
+Ref: Step 1 Capture and Organize149058
+Ref: Step 2 Open Graph View149461
+Ref: Step 3 Modify Dependencies to Create Parallel Tasks150107
+Ref: What Graph View CAN Do150783
+Ref: Building Our Parallel Structure151436
+Ref: The Diamond Pattern in Action152314
+Ref: Alternative Approach Add Blockers152864
+Ref: Tutorial Complex Dependencies with Graph View153459
+Ref: The Scenario (1)153519
+Ref: The Dependency Graph154145
+Ref: Building with Graph View154738
+Ref: Creating the Convergence Point155237
+Ref: Building the Rest155718
+Ref: The Complete Graph156268
+Ref: Key Patterns This Example Shows156949
+Ref: Common Dependency Patterns (Visual Reference)157410
+Ref: Sequential Chain (A → B → C)157531
+Ref: Parallel Independent (A B C all start together)158001
+Ref: Fan-out (A → B A → C A → D)158390
+Ref: Fan-in / Convergence (A → C B → C)158899
+Ref: Diamond (A → B → D A → C → D)159358
+Ref: Graph View Command Reference160026
+Ref: Opening Graph View160226
+Ref: Tier 1 Single-Key Commands (Always Available)160524
+Ref: Tier 2 Prefixed Commands163874
+Ref: Visual Indicators165427
+Ref: Operations Not Available in Graph View165733
+Ref: Text-Based Alternatives166556
+Ref: Graph Rendering Modes167891
+Ref: SVG Mode (Default)168093
+Ref: ASCII Mode168454
+Ref: Toggling Modes168839
+Ref: Troubleshooting ASCII Rendering168965
+Ref: Complete Keyboard Reference169328
+Ref: Tier 1 Single Keys169452
+Ref: Tier 2 Task Operations (t prefix)170397
+Ref: Tier 2 Project and View Operations170774
+Ref: Auto-Refresh on File Changes171225
+Ref: Technical Details171720
+Ref: Graph Data Structure171751
+Ref: Layout Algorithm172151
+Ref: Properties Used172507
+Ref: Undo/Redo Support173453
+Ref: Practical Tips for Project Management173832
+Ref: When to Use Graph View173883
+Ref: When to Use Sequential (Default)174290
+Ref: When to Create Parallel Structures174706
+Ref: Managing Complexity175074
+Ref: Growing Projects Over Time175518
+Ref: Canceling Projects175957
+Ref: Exporting Project Graphs176973
+Ref: First Contact What is Graph Export?177011
+Ref: Tutorial Export Your First Graph177753
+Ref: Progressive Learning Choosing Export Formats178315
+Ref: When Exports Differ from Display180156
+Ref: Reference Export Commands180770
+Ref: Troubleshooting Exports181460
+Ref: Troubleshooting Projects with Graph View182248
+Ref: Project is Stuck (has TODO tasks but no NEXT)182302
+Ref: Task Should Be NEXT But Shows as TODO183236
+Ref: Too Many Tasks Are NEXT183886
+Ref: Graph Won't Open184386
+Ref: Graph Shows No Tasks184786
+Ref: Task Shows Wrong State (NEXT vs TODO)185221
+Ref: Can't Modify Dependencies185724
+Ref: See Also186176
+Ref: Tickler Projects Pausing Work You're Not Ready For186673
+Ref: First Contact Why Tickler Projects?186738
+Ref: Black Triangle Tickler Your First Project in 30 Seconds187806
+Ref: Understanding Tickler What Actually Happens188719
+Ref: Tutorial Managing Seasonal Projects190969
+Ref: Common Patterns and Scenarios193433
+Ref: Advanced External Dependencies and Warnings195714
+Ref: Technical Details How Tickler Works Under the Hood198030
+Ref: Troubleshooting Tickler201891
+Ref: See Also (1)205178
+Ref: Project Progress Cookies See Your Progress at a Glance205808
+Ref: First Contact What Are Progress Cookies?205877
+Ref: Black Triangle See Progress in 30 Seconds206438
+Ref: Tutorial Watch Cookies Update Automatically206925
+Ref: Understanding How Cookies Work207739
+Ref: Configuring Cookie Position208811
+Ref: Common Scenarios209645
+Ref: Technical Reference210482
+Ref: Cleaning up / archiving completed work211411
+Ref: Commands you can call on org-agenda212105
+Ref: Defining your own agenda views212903
+Ref: Adding your own hooks when organizing213603
+Node: Automating through emacs214873
+Node: Reference216176
+Node: Configuration Variables Reference217622
+Ref: Required Configuration217929
+Ref: org-todo-keywords (org-mode variable)217965
+Ref: org-gtd-keyword-mapping219052
+Ref: Directory and File Configuration220216
+Ref: org-gtd-directory220262
+Ref: org-gtd-additional-inbox-files221361
+Ref: org-gtd-horizons-file222334
+Ref: Capture Configuration222767
+Ref: org-gtd-capture-templates222802
+Ref: Organize and Process Configuration224082
+Ref: org-gtd-organize-hooks224130
+Ref: org-gtd-save-after-organize225674
+Ref: org-gtd-refile-to-any-target (deprecated)226025
+Ref: org-gtd-refile-prompt-for-types227327
+Ref: Mode-Line Configuration228762
+Ref: org-gtd-mode-update-interval228799
+Ref: org-gtd-mode-lighter-display229690
+Ref: Clarification Configuration230264
+Ref: org-gtd-clarify-show-horizons230305
+Ref: org-gtd-clarify-show-organize-help231069
+Ref: org-gtd-clarify-display-helper-buffer232193
+Ref: org-gtd-clarify-project-templates232842
+Ref: org-gtd-clarify-duplicate-queue-position234043
+Ref: Areas of Focus Configuration234876
+Ref: org-gtd-areas-of-focus234918
+Ref: View Prefix Configuration235570
+Ref: org-gtd-prefix-width235609
+Ref: org-gtd-agenda-truncate-ellipsis236612
+Ref: Archive Configuration237393
+Ref: org-gtd-archive-location237428
+Ref: Missed Engagements Review Configuration239071
+Ref: org-gtd-reflect-missed-custom-views239124
+Ref: Guided Review Configuration240499
+Ref: org-gtd-review-profiles240540
+Ref: Advanced Item Configuration241638
+Ref: org-gtd-user-types241679
+Ref: Agenda Display Configuration245068
+Ref: org-gtd-agenda-property-list245348
+Ref: org-gtd-agenda-property-position245898
+Ref: org-gtd-agenda-property-column246535
+Ref: org-gtd-agenda-property-separator246986
+Ref: Graph View Configuration247346
+Ref: org-gtd-graph-render-mode247455
+Ref: org-gtd-graph-ui-split-ratio248207
+Ref: org-gtd-graph-sibling-mode248980
+Ref: Projects Configuration251428
+Ref: org-gtd-project-progress-cookie-position251464
+Ref: Obsolete Variables (Do Not Use)253644
+Ref: org-gtd-todo-keyword (obsolete)253790
+Ref: org-gtd-next-keyword (obsolete)253918
+Ref: org-gtd-wait-keyword (obsolete)254046
+Ref: org-gtd-canceled-keyword (obsolete)254174
+Node: Commands Reference254298
+Ref: Core GTD Workflow Commands254613
+Ref: org-gtd-command-center254653
+Ref: org-gtd-capture256043
+Ref: org-gtd-process-inbox256687
+Ref: org-gtd-organize257532
+Ref: org-gtd-engage258503
+Ref: org-gtd-show-all-next259309
+Ref: Reflect Commands259702
+Ref: org-gtd-review259732
+Ref: org-gtd-review-schedule260693
+Ref: org-gtd-reflect-stuck-projects261343
+Ref: org-gtd-reflect-area-of-focus261911
+Ref: org-gtd-reflect-completed-items262522
+Ref: org-gtd-reflect-completed-projects263072
+Ref: org-gtd-reflect-missed-items263321
+Ref: Stuck Item Review Commands263610
+Ref: org-gtd-reflect-stuck-calendar-items263734
+Ref: org-gtd-reflect-stuck-tickler-items263858
+Ref: org-gtd-reflect-stuck-habit-items263982
+Ref: org-gtd-reflect-stuck-delegated-items264094
+Ref: org-gtd-reflect-stuck-next-action-items264237
+Ref: Reviewing Someday/Maybe Items264351
+Ref: Your First Review in 60 Seconds264975
+Ref: Understanding the Review Workflow265452
+Ref: Tutorial Weekly Someday Review266166
+Ref: Organizing Your Someday Items (Optional)267075
+Ref: Common Patterns267866
+Ref: Command Reference (1)268623
+Ref: org-gtd-reflect-someday-review269082
+Ref: Reflect Commands (Missed Engagements)270097
+Ref: What Are Missed Engagements?270148
+Ref: Your First Review in 30 Seconds270965
+Ref: Understanding the Review Workflow (1)271432
+Ref: Tutorial Daily Review Workflow272180
+Ref: Common Patterns (1)273013
+Ref: Command Reference (2)273525
+Ref: Backward Compatibility Note274285
+Ref: Reflect Commands (Upcoming Delegated)274977
+Ref: What Are Upcoming Delegated Check-ins?275028
+Ref: Your First Review in 30 Seconds (1)275856
+Ref: Understanding Proactive Delegation Management276364
+Ref: Tutorial Weekly Planning Workflow277023
+Ref: Common Patterns (2)278157
+Ref: Understanding What You See278938
+Ref: Comparison Missed vs Upcoming279724
+Ref: Command Reference (3)280234
+Ref: Checklist Commands280659
+Ref: org-gtd-checklist-template-insert280691
+Ref: org-gtd-checklist-template-visit281253
+Ref: Custom View Commands281879
+Ref: org-gtd-view-show281913
+Ref: Clarification Commands292226
+Ref: org-gtd-clarify-item292262
+Ref: org-gtd-clarify-agenda-item292748
+Ref: org-gtd-clarify-toggle-horizons-window293041
+Ref: org-gtd-clarify-toggle-organize-help293407
+Ref: org-gtd-clarify-project-insert-template294000
+Ref: org-gtd-clarify-duplicate294343
+Ref: org-gtd-clarify-duplicate-exact295195
+Ref: org-gtd-clarify-stop295688
+Ref: Updating Items Without Refiling296079
+Ref: Archive Commands301160
+Ref: org-gtd-archive-completed-items301190
+Ref: Agenda-Specific Commands301715
+Ref: org-gtd-delegate-agenda-item301817
+Ref: org-gtd-project-cancel-from-agenda302180
+Ref: Timestamp Commands (DWIM)302622
+Ref: org-gtd-set-timestamp302778
+Ref: Project Task Commands (DWIM)303465
+Ref: org-gtd-project-add-successor303666
+Ref: org-gtd-project-add-blocker304145
+Ref: org-gtd-project-add-root-task304637
+Ref: org-gtd-project-remove-task305035
+Ref: org-gtd-project-trash-task305447
+Ref: org-gtd-project-change-state305819
+Ref: Project Management Commands306107
+Ref: org-gtd-projects-fix-todo-keywords-for-project-at-point306148
+Ref: org-gtd-projects-fix-all-todo-keywords306798
+Ref: org-gtd-project-update-all-cookies309840
+Ref: org-gtd-tickler311466
+Ref: org-gtd-someday313308
+Ref: org-gtd-reactivate315015
+Ref: Task Dependency Commands317132
+Ref: org-gtd-task-add-blockers317910
+Ref: org-gtd-task-remove-blockers318731
+Ref: org-gtd-task-add-dependent319037
+Ref: org-gtd-task-add-dependents319770
+Ref: org-gtd-task-clear-relationships320042
+Ref: org-gtd-task-show-relationships320415
+Ref: org-gtd-validate-project-dependencies320805
+Ref: org-gtd-remove-task-from-project321279
+Ref: Area of Focus Commands321653
+Ref: org-gtd-area-of-focus-set-on-item-at-point321689
+Ref: org-gtd-area-of-focus-set-on-agenda-item322096
+Ref: Programmatic Creation Commands322471
+Ref: org-gtd-habit-create322620
+Ref: org-gtd-calendar-create322881
+Ref: org-gtd-delegate-create323145
+Ref: org-gtd-tickler-create323869
+Ref: org-gtd-someday-create324162
+Ref: org-gtd-single-action-create324411
+Ref: Utility Commands324632
+Ref: org-gtd-init-system324662
+Ref: org-gtd-setup-keywords-wizard325480
+Ref: org-gtd-inbox-path325832
+Ref: Migration and Upgrade Commands326246
+Ref: org-gtd-upgrade-v3-to-v4326290
+Ref: Mode-Line Integration326902
+Ref: org-gtd-mode326937
+Ref: org-gtd-inbox-count327680
+Ref: Obsolete Commands327964
+Ref: org-gtd-delegate-item-at-point (removed in 40)327995
+Node: Properties Reference (Internal Implementation)328857
+Ref: Core GTD Properties329746
+Ref: ORG_GTD329779
+Ref: ORG_GTD_REFILE330857
+Ref: Project Properties333208
+Ref: ORG_GTD_FIRST_TASKS333240
+Ref: Task Dependency Properties334179
+Ref: ORG_GTD_DEPENDS_ON334219
+Ref: ORG_GTD_BLOCKS336137
+Ref: ORG_GTD_PROJECT_IDS336974
+Ref: Calendar and Time Properties337324
+Ref: ORG_GTD_TIMESTAMP337366
+Ref: Delegation Properties338308
+Ref: DELEGATED_TO338343
+Ref: Habit Properties339295
+Ref: STYLE339325
+Ref: Area of Focus Properties339796
+Ref: CATEGORY339834
+Ref: Standard Org Properties Used by org-gtd340705
+Ref: ID340758
+Ref: keyword341035
+Ref: SCHEDULED (org-mode standard)341690
+Ref: DEADLINE (org-mode standard)341965
+Node: Troubleshooting Projects342208
+Ref: Fixing Broken Dependencies342729
+Ref: When Manual Property Editing is Needed344016
+Ref: Common Problems and Solutions345812
+Ref: Project Shows No NEXT Tasks (Stuck Project)345855
+Ref: Too Many NEXT Tasks346689
+Ref: Task Won't Advance to NEXT347163
+Ref: Task States Inconsistent After External Edits347865
+Node: View DSL Filter Reference349073
+Ref: Your First Custom View in 60 Seconds349590
+Ref: Understanding View Specs350150
+Ref: Combining Filters350734
+Ref: Multi-Block Views351169
+Ref: Common Patterns (3)351792
+Ref: Weekly Review View351821
+Ref: Morning Planning View352391
+Ref: Area of Focus View353082
+Ref: Filter Reference353722
+Ref: View Structure353862
+Ref: Multi-Block Views (1)354207
+Ref: Block Types354945
+Ref: Native Blocks (Escape Hatch)355466
+Ref: When You'll Need This355926
+Ref: Your First Native Block356602
+Ref: Adding Custom Sorting357771
+Ref: Mixing DSL and Native358633
+Ref: Native Block Types359585
+Ref: Quick Reference360218
+Ref: Type Filters360841
+Ref: (type delegated)360898
+Ref: (type calendar)361183
+Ref: (type project)361438
+Ref: (type active-project)361679
+Ref: (type completed-project)361958
+Ref: (type stuck-project)362264
+Ref: (type tickler)362584
+Ref: (type someday)362871
+Ref: (type habit)363165
+Ref: (type next-action)363387
+Ref: (type tickler-project)363704
+Ref: (type incubated-project)364161
+Ref: (type stuck-delegated)364644
+Ref: (type stuck-calendar)365015
+Ref: (type stuck-tickler)365298
+Ref: (type stuck-habit)365581
+Ref: Time-based Filters365839
+Ref: Semantic Time (when VALUE)365931
+Ref: Deadline (deadline VALUE)366892
+Ref: Scheduled (scheduled VALUE)367137
+Ref: Keyword Filters367392
+Ref: (todo ("KEYWORD1" "KEYWORD2"))367709
+Ref: (done VALUE)368133
+Ref: Area of Focus Filters369418
+Ref: (area-of-focus "AREA")369480
+Ref: Tag Filters369897
+Ref: (tags ("TAG1" "TAG2"))369948
+Ref: (tags-match "PATTERN")370271
+Ref: Priority Effort and Clocked Filters370806
+Ref: (priority VALUE)370948
+Ref: (effort SPEC)372267
+Ref: (clocked SPEC)373472
+Ref: (last-clocked-out SPEC)374590
+Ref: Property Filters375891
+Ref: (property (("PROP" "VALUE")))375963
+Ref: Structural Filters376282
+Ref: (level N)376353
+Ref: Special Filters376753
+Ref: (not-habit t)376782
+Ref: (invalid-timestamp t)377061
+Ref: View Configuration Options377407
+Ref: (block-type TYPE)377502
+Ref: (blocks BLOCK-LIST)378366
+Ref: Prefix DSL Customizing the Task Prefix Column379042
+Ref: Your First Prefix in 60 Seconds379541
+Ref: (prefix (ELEMENT ))380190
+Ref: (prefix-width N)381522
+Ref: Prefix Inheritance in Multi-Block Views382166
+Ref: Low-Level (prefix-format FORMAT-STRING)383349
+Ref: (view-type agenda)383951
+Ref: (agenda-span N)384288
+Ref: Simplified Multi-Block Views384454
+Ref: The Problem Verbose Block Definitions384739
+Ref: The Solution Implicit Blocks385646
+Ref: Try It Now386337
+Ref: Smart Type Defaults386999
+Ref: Top-Level Inheritance387947
+Ref: The Four-Tier Precedence Model388331
+Ref: When to Use Explicit Blocks389495
+Ref: Quick Reference (1)390173
+Ref: Saving Your Custom Views390607
+Node: Hooks Framework Reference391175
+Ref: What Are Organize Hooks?391353
+Ref: Your First Hook in 2 Minutes391900
+Ref: The org-gtd-organize-hooks Variable392927
+Ref: Built-in Hooks393248
+Ref: org-set-tags-command393276
+Ref: org-gtd-set-area-of-focus393554
+Ref: Writing Custom Hooks394135
+Ref: Basic Hook Structure394394
+Ref: Using org-gtd-organize-type-member-p394768
+Ref: Example Custom Hooks396413
+Ref: Selective Tagging with Unless396447
+Ref: Add Effort Estimation397229
+Ref: Add Priority397614
+Ref: Auto-Set Property Based on Keywords397954
+Ref: Add Custom Property398477
+Ref: Integration with Org-Roam398963
+Ref: Set Effort from Keywords399369
+Ref: Hook Execution Order400163
+Ref: Best Practices400536
+Ref: Complete Example Comprehensive Hook Setup401433
+Node: Extending org-gtd403612
+Node: Customizing types403899
+Ref: org-gtd-customize-type404586
+Ref: Hook stages405310
+Ref: Programmatic item creation406222
+Ref: Refile prompting406713
+Node: Project Traversal Functions407009
+Ref: org-gtd-project-map-tasks407193
+Ref: org-gtd-projects-map407999
+Node: Troubleshooting408682
+Node: Finding lost tasks409171
+Node: Projects without a NEXT item410178
+Node: I can't create a project when clarifying an inbox item!411438
+Node: Configuration problems412400
+Ref: Keywords not working412674
+Ref: Items not showing in engage view413408
+Node: Tasks still showing after tickler'ing or someday'ing project414218
+Node: Still stuck?415561
 
 End Tag Table
 

--- a/org-gtd.info
+++ b/org-gtd.info
@@ -719,6 +719,10 @@ File: org-gtd.info,  Node: Configuring,  Prev: Installing,  Up: Setting up Org G
 
      See the configuration sections below for details.
 
+     To create the GTD files and optionally schedule a recurring Weekly
+     Review reminder in one step, run ‘M-x org-gtd-init-system’ (see
+     *note Weekly Review (guided)::).
+
      *Optional*: Enable ‘org-gtd-mode’ if you want to see your inbox
      count in the mode-line (e.g., ‘GTD[5]’).
 
@@ -1376,8 +1380,9 @@ File: org-gtd.info,  Node: Configuring,  Prev: Installing,  Up: Setting up Org G
                What to work on now
           *Capture & Process* (‘c’, ‘p’, ‘k’)
                Add items and process inbox
-          *Reflect* (‘a’, ‘y’, ‘d’, ‘r’, ‘R’)
-               Review areas, someday items, completed work
+          *Reflect* (‘w’, ‘a’, ‘y’, ‘d’, ‘r’, ‘R’, ‘l’)
+               Guided Weekly Review, review areas, someday items,
+               completed work, checklists
           *Review System* (‘S’, ‘M’)
                Sub-menus for stuck and missed items
           *Archive* (‘A’)
@@ -2117,13 +2122,14 @@ part.
      These are the commands you'll use most:
 
      Command                                    What it does                           When to use it
-     --------------------------------------------------------------------------------------------------------------------------
+     ------------------------------------------------------------------------------------------------------------------------------
      ‘org-gtd-capture’                          Add item to inbox                      Anytime something comes up
      ‘org-gtd-process-inbox’                    Start processing inbox                 Daily (or when inbox has items)
      ‘org-gtd-organize’                         Organize current item                  During processing (in clarify buffer)
      ‘org-gtd-engage’                           See actionable items                   Daily (your "work from" view)
      ‘org-gtd-show-all-next’                    See only NEXT actions                  When you want to focus on actions
      ‘org-gtd-review’                           Guided Weekly Review session           Weekly
+     ‘org-gtd-checklist-insert’                 Insert a reusable checklist at point   Packing lists, release steps, mind sweeps
      ‘org-gtd-reflect-stuck-projects’           Find stuck projects                    Weekly review
      ‘org-gtd-reflect-someday-review’           Review someday items one-by-one        Weekly/monthly review
      ‘org-gtd-projects-fix-all-todo-keywords’   Fix task states after external edits   After mobile/web edits
@@ -2813,8 +2819,8 @@ prompts".  They're yours — edit or delete them freely.
      including boxes under child headings, and updates any ‘[1/3]’-style
      statistics cookies.  The next run starts fresh.
 
-     The guard mirrors org's own re-arm rule exactly, so the reset
-     happens only when org actually re-arms the heading:
+     The reset follows org's own re-arm rule exactly — it happens only
+     when org actually re-arms the heading:
 
         • A heading with no repeater never resets: a plain ‘DONE’ keeps
           its record.
@@ -2827,6 +2833,9 @@ prompts".  They're yours — edit or delete them freely.
      This applies to *every* repeating heading with checkboxes — spawned
      from a template or written by hand.  The hook is installed by
      ‘org-gtd-mode’.
+
+     *See also*: *note Commands Reference:: for
+     ‘org-gtd-checklist-insert’ and ‘org-gtd-checklist-visit’.
 
 
 File: org-gtd.info,  Node: Weekly Review (guided),  Next: Understanding GTD Item Types,  Prev: Checklists,  Up: Using Org GTD
@@ -3013,6 +3022,10 @@ it one step at a time, so you don't have to hold the ritual in your head
 
      You never _have_ to run it: every file it creates is also created
      lazily the first time something needs it.
+
+     *See also*: *note Commands Reference:: for ‘org-gtd-review’,
+     ‘org-gtd-review-schedule’, and ‘org-gtd-init-system’, and *note
+     Configuration Variables Reference:: for ‘org-gtd-review-profiles’.
 
 
 File: org-gtd.info,  Node: Understanding GTD Item Types,  Next: Working with Projects (Advanced),  Prev: Weekly Review (guided),  Up: Using Org GTD
@@ -3286,6 +3299,10 @@ Here's the complete reference for all item types:
 
      *Note*: See org-mode documentation for habit repeat patterns and
      tracking.
+
+     *See also*: *note Recurring checklists compose with habits:: for
+     turning a reusable checklist into a repeating habit whose
+     checkboxes reset on each repeat.
 
    • Knowledge [K]
 
@@ -5952,6 +5969,31 @@ These variables control how org-gtd behaves.  All can be customized via
           ‘org-gtd-oops-custom-views’ still works but will be removed in
           a future version.
 
+   • Guided Review Configuration
+
+        • ‘org-gtd-review-profiles’
+
+          *Type*: Alist of ‘(PROFILE-NAME . PHASES)’
+
+          *Default*: A complete Weekly Review profile in three phases:
+          Get Clear, Get Current, Get Creative
+
+          *Purpose*: Defines the ritual ‘org-gtd-review’ walks you
+          through.  Each phase is ‘(PHASE-NAME . STEPS)’; each step is a
+          plist with ‘:title’, ‘:type’ (one of ‘prompt’, ‘command’,
+          ‘view’, ‘checklist’), an optional ‘:instruction’, and the
+          type-specific key ‘:command’, ‘:view’, or ‘:checklist’ (a
+          template name from your checklists file).
+
+          *When to customize*: To reorder or trim the Weekly Review,
+          point ‘:view’ steps at your own views, or add profiles of your
+          own (a daily shutdown, a monthly horizons review).  With
+          several profiles configured, ‘org-gtd-review’ prompts for
+          which one to run.
+
+          See *note Weekly Review (guided):: for the full default value
+          and a step-by-step explanation.
+
    • Advanced Item Configuration
 
         • ‘org-gtd-user-types’
@@ -6318,18 +6360,20 @@ organized by workflow step.
 
           *Menu structure*:
           Key   Command
-          ------------------------------------
+          ----------------------------------------
           e     Engage (daily view)
           @     Engage by context
           n     Show all next actions
           c     Capture to inbox
           p     Process inbox
           k     Clarify item at point
+          w     Reflect: Weekly Review (guided)
           a     Reflect: area of focus
           y     Reflect: someday/maybe
           d     Reflect: upcoming delegated
           r     Reflect: completed items
           R     Reflect: completed projects
+          l     Reflect: checklists
           A     Archive completed items
           S     Stuck items sub-menu
           M     Missed items sub-menu
@@ -6450,6 +6494,47 @@ organized by workflow step.
              • Useful for "get things done" focus mode
 
    • Reflect Commands
+
+        • ‘org-gtd-review’
+
+          *Binding*: ‘w’ from the command center
+
+          *When to use*: Weekly, or whenever you sit down for a full
+          review
+
+          *What it does*:
+             • Runs a guided, step-by-step review session in a ‘*GTD
+               Review*’ console buffer
+             • The ritual comes from ‘org-gtd-review-profiles’ (a Weekly
+               Review ships as the default; with several profiles
+               configured, prompts for one)
+             • Keys: ‘n’ do/advance, ‘s’ skip, ‘c’ capture, ‘p’ pause,
+               ‘q’ quit
+             • Checkpoints progress to disk at every step, so a paused
+               (or crashed) session is offered for resumption on the
+               next invocation
+
+          *Arguments*: Optional PROFILE-NAME to select a profile
+          non-interactively
+
+          See *note Weekly Review (guided):: for the full walkthrough.
+
+        • ‘org-gtd-review-schedule’
+
+          *When to use*: Once, to make the review a recurring commitment
+
+          *What it does*:
+             • Prompts for a profile (when you have several), a first
+               date, and an org repeater (e.g.  ‘.+1w’)
+             • Creates a habit named after the profile, so the reminder
+               appears in your engage view
+             • Validates the repeater and asks before scheduling a
+               duplicate reminder
+
+          *Arguments*: Optional PROFILE-NAME, DATE (‘YYYY-MM-DD’), and
+          REPEATER
+
+          See *note Weekly Review (guided):: for details.
 
         • ‘org-gtd-reflect-stuck-projects’
 
@@ -6942,6 +7027,36 @@ organized by workflow step.
           Command                                Shows                                            Use When
           --------------------------------------------------------------------------------------------------------------------------------------
           ‘org-gtd-reflect-upcoming-delegated’   All delegated items with future check-in dates   Weekly planning, early completion responses
+
+   • Checklist Commands
+
+        • ‘org-gtd-checklist-insert’
+
+          *When to use*: Whenever you need a fresh copy of a reusable
+          checklist (a packing list, release steps, mind-sweep triggers)
+
+          *What it does*:
+             • Offers the template names from ‘checklists.org’ for
+               completion
+             • Inserts a fresh copy of the chosen template as a subtree
+               at point (on a heading line, as that heading's first
+               child)
+             • The copy is plain org; org-gtd does not track it
+
+        • ‘org-gtd-checklist-visit’
+
+          *Binding*: ‘l’ from the command center
+
+          *When to use*: To add, edit, or retire checklist templates
+
+          *What it does*:
+             • Opens ‘checklists.org’ in ‘org-gtd-directory’, creating
+               and seeding it with starter templates on first use
+             • Each top-level heading is a template; editing this file
+               is how you customize your checklists
+
+          See *note Checklists:: for the file format, the checkbox reset
+          on repeat, and the recurring-checklist pattern.
 
    • Custom View Commands
 
@@ -8078,6 +8193,26 @@ organized by workflow step.
                (org-gtd-single-action-create "Follow up on proposal")
 
    • Utility Commands
+
+        • ‘org-gtd-init-system’
+
+          *When to use*: First-time setup (safe to run again at any
+          time)
+
+          *What it does*:
+             • Ensures ‘org-gtd-directory’ and the GTD files exist: the
+               tasks file, the inbox, and ‘checklists.org’ with its
+               starter templates
+             • Offers to schedule a recurring Weekly Review via
+               ‘org-gtd-review-schedule’ (skips the offer when a
+               reminder already exists)
+             • Idempotent: anything already in place is simply reported
+               as ready
+
+          *Does not*: touch ‘org-agenda-files’ or TODO keywords — those
+          remain manual configuration (see *note Configuring::)
+
+          See *note Weekly Review (guided):: for details.
 
         • ‘org-gtd-setup-keywords-wizard’
 
@@ -10650,546 +10785,554 @@ Ref: use-package27784
 Ref: Manually27913
 Node: Configuring28207
 Ref: Basic setup28337
-Ref: Complete Configuration Examples29180
-Ref: Example 1 Vanilla Emacs (Minimal Configuration)29390
-Ref: Example 2 Doom Emacs Configuration32248
-Ref: Example 3 Spacemacs Configuration34506
-Ref: What These Configurations Do36742
-Ref: Testing Your Configuration38308
-Ref: Common Configuration Problems39651
-Ref: Working with Your Existing Org Setup43469
-Ref: Understanding Keybindings45562
-Ref: Global Keybindings45698
-Ref: Clarify Map Keybindings46343
-Ref: Required configuration of sub-packages47584
-Ref: Configuring org-edna47636
-Ref: Adding org-gtd files to your agenda47965
-Ref: configuration options for org-gtd48777
-Ref: I don't care just let me start using it48824
-Ref: Tell me all the levers I can pull49461
-Ref: Required keyword configuration49639
-Ref: Optional configuration52475
-Ref: Recommended key bindings57972
-Ref: Command Center58622
-Ref: Sample Doom Emacs Config59514
-Node: Getting Started with Org GTD60943
-Node: Quick Start Reference61407
-Node: Tutorial Your First Project61949
-Ref: What You'll Learn62406
-Ref: The Project62711
-Ref: Step 1 Capture the Project63018
-Ref: Step 2 Process the Inbox63508
-Ref: Step 3 Organize as a Project63927
-Ref: Step 4 View in Engage64508
-Ref: Step 5 Complete the First Task65027
-Ref: Step 6 Refresh and See the Change65377
-Ref: What Just Happened?65763
-Ref: Continue the Project66750
-Ref: Key Takeaways67193
-Ref: What's Next?67720
-Node: Tutorial Creating Your First Custom View68401
-Ref: What You'll Learn (1)68922
-Ref: Why This View?69154
-Ref: Understanding the View DSL69543
-Ref: Creating the View Function70072
-Ref: Using Your View70549
-Ref: Binding to a Key70695
-Ref: What You'll See71314
-Ref: Experiment Modify the View71730
-Ref: Available Filters72721
-Ref: Key Takeaways (1)74919
-Ref: What's Next? (1)75384
-Node: Tutorial Quick Wins and Focus Work Views75883
-Ref: Why This Matters76328
-Ref: Your First Quick Wins View (30 seconds)76807
-Ref: The Effort Filter Explained77333
-Ref: Building a Focus Work View78032
-Ref: The Priority Filter Explained78573
-Ref: Finding Tasks to Triage79243
-Ref: Bonus The Clocked Filter79846
-Ref: Putting It All Together80555
-Ref: Key Takeaways (2)81726
-Ref: Where to Go From Here82147
-Node: Using Org GTD83324
-Node: Your Daily Workflow84117
-Ref: Quick command reference84977
-Node: The GTD Flow in Depth86609
-Ref: Adding things to the inbox86845
-Ref: Processing the inbox88174
-Ref: Clarifying each item88898
-Ref: How to start clarifying89267
-Ref: data shape requirements89820
-Ref: Options and commands related to clarification90447
-Ref: Duplicating items during clarification92895
-Ref: Your first duplicate in 30 seconds93386
-Ref: Understanding the workflow93827
-Ref: The queue window94634
-Ref: Two ways to duplicate95191
-Ref: What happens if you cancel?95882
-Ref: Nested duplicates96555
-Ref: Data safety96792
-Ref: Configuration97277
-Ref: Organizing an item into the system97671
-Ref: Refiling to the appropriate area98459
-Ref: Understanding Refiling in V498510
-Ref: Refile Target System98961
-Ref: Controlling Refile Prompts by Item Type100167
-Ref: Creating New Refile Targets102672
-Ref: Multiple Types Per Heading103465
-Ref: Using Your Own Refile Targets104188
-Ref: Migration from V3104931
-Ref: Engaging with your GTD items105605
-Ref: Quick Task Actions from the Agenda106235
-Ref: First Contact Why This Feature?106288
-Ref: Black Triangle Your First Quick Action107024
-Ref: Understanding the Actions107863
-Ref: State Changes108022
-Ref: Time Adjustments (Conditional)108572
-Ref: Clocking109662
-Ref: Metadata109875
-Ref: Clarify110428
-Ref: Command Reference110779
-Ref: Suggested Keybinding112119
-Node: Checklists112489
-Ref: The template file113129
-Ref: Spawning a checklist114218
-Ref: Recurring checklists compose with habits114829
-Ref: Checkbox reset on repeat115516
-Node: Weekly Review (guided)116573
-Ref: Running a session117097
-Ref: Step types118317
-Ref: Pause resume and crash recovery119563
-Ref: Customizing the ritual org-gtd-review-profiles120524
-Ref: Scheduling the review org-gtd-review-schedule123804
-Ref: First-time setup org-gtd-init-system124962
-Node: Understanding GTD Item Types125813
-Ref: Single Action [S]126331
-Ref: Project [P]126906
-Ref: Add to existing project [A]127818
-Ref: Calendar [C]128583
-Ref: Delegate [D]129342
-Ref: Quick Action [Q]130600
-Ref: Tickler [I]131142
-Ref: Someday/Maybe [y]132677
-Ref: Habit [H]135470
-Ref: Knowledge [K]136084
-Ref: Trash [T]136748
-Ref: Working with the GTD Horizons137522
-Ref: Areas of focus138146
-Ref: Longer-term horizons139547
-Node: Working with Projects (Advanced)141347
-Ref: Quick Navigation141840
-Ref: First Contact Why Visual Project Management?143059
-Ref: Black Triangle Your First Project Graph View143894
-Ref: Step 1 Find a project143995
-Ref: Step 2 Open the graph view144193
-Ref: Step 3 Explore144376
-Ref: Understanding Project Dependencies145000
-Ref: The Dependency Graph (DAG)145142
-Ref: What You See in Graph View145749
-Ref: Sequential vs Parallel vs Mixed146476
-Ref: Tutorial Parallel Tasks with Graph View147479
-Ref: The Scenario147601
-Ref: Step 1 Capture and Organize148057
-Ref: Step 2 Open Graph View148460
-Ref: Step 3 Modify Dependencies to Create Parallel Tasks149106
-Ref: What Graph View CAN Do149782
-Ref: Building Our Parallel Structure150435
-Ref: The Diamond Pattern in Action151313
-Ref: Alternative Approach Add Blockers151863
-Ref: Tutorial Complex Dependencies with Graph View152458
-Ref: The Scenario (1)152518
-Ref: The Dependency Graph153144
-Ref: Building with Graph View153737
-Ref: Creating the Convergence Point154236
-Ref: Building the Rest154717
-Ref: The Complete Graph155267
-Ref: Key Patterns This Example Shows155948
-Ref: Common Dependency Patterns (Visual Reference)156409
-Ref: Sequential Chain (A → B → C)156530
-Ref: Parallel Independent (A B C all start together)157000
-Ref: Fan-out (A → B A → C A → D)157389
-Ref: Fan-in / Convergence (A → C B → C)157898
-Ref: Diamond (A → B → D A → C → D)158357
-Ref: Graph View Command Reference159025
-Ref: Opening Graph View159225
-Ref: Tier 1 Single-Key Commands (Always Available)159523
-Ref: Tier 2 Prefixed Commands162873
-Ref: Visual Indicators164426
-Ref: Operations Not Available in Graph View164732
-Ref: Text-Based Alternatives165555
-Ref: Graph Rendering Modes166890
-Ref: SVG Mode (Default)167092
-Ref: ASCII Mode167453
-Ref: Toggling Modes167838
-Ref: Troubleshooting ASCII Rendering167964
-Ref: Complete Keyboard Reference168327
-Ref: Tier 1 Single Keys168451
-Ref: Tier 2 Task Operations (t prefix)169396
-Ref: Tier 2 Project and View Operations169773
-Ref: Auto-Refresh on File Changes170224
-Ref: Technical Details170719
-Ref: Graph Data Structure170750
-Ref: Layout Algorithm171150
-Ref: Properties Used171506
-Ref: Undo/Redo Support172452
-Ref: Practical Tips for Project Management172831
-Ref: When to Use Graph View172882
-Ref: When to Use Sequential (Default)173289
-Ref: When to Create Parallel Structures173705
-Ref: Managing Complexity174073
-Ref: Growing Projects Over Time174517
-Ref: Canceling Projects174956
-Ref: Exporting Project Graphs175972
-Ref: First Contact What is Graph Export?176010
-Ref: Tutorial Export Your First Graph176752
-Ref: Progressive Learning Choosing Export Formats177314
-Ref: When Exports Differ from Display179155
-Ref: Reference Export Commands179769
-Ref: Troubleshooting Exports180459
-Ref: Troubleshooting Projects with Graph View181247
-Ref: Project is Stuck (has TODO tasks but no NEXT)181301
-Ref: Task Should Be NEXT But Shows as TODO182235
-Ref: Too Many Tasks Are NEXT182885
-Ref: Graph Won't Open183385
-Ref: Graph Shows No Tasks183785
-Ref: Task Shows Wrong State (NEXT vs TODO)184220
-Ref: Can't Modify Dependencies184723
-Ref: See Also185175
-Ref: Tickler Projects Pausing Work You're Not Ready For185672
-Ref: First Contact Why Tickler Projects?185737
-Ref: Black Triangle Tickler Your First Project in 30 Seconds186805
-Ref: Understanding Tickler What Actually Happens187718
-Ref: Tutorial Managing Seasonal Projects189968
-Ref: Common Patterns and Scenarios192432
-Ref: Advanced External Dependencies and Warnings194713
-Ref: Technical Details How Tickler Works Under the Hood197029
-Ref: Troubleshooting Tickler200890
-Ref: See Also (1)204177
-Ref: Project Progress Cookies See Your Progress at a Glance204807
-Ref: First Contact What Are Progress Cookies?204876
-Ref: Black Triangle See Progress in 30 Seconds205437
-Ref: Tutorial Watch Cookies Update Automatically205924
-Ref: Understanding How Cookies Work206738
-Ref: Configuring Cookie Position207810
-Ref: Common Scenarios208644
-Ref: Technical Reference209481
-Ref: Cleaning up / archiving completed work210410
-Ref: Commands you can call on org-agenda211104
-Ref: Defining your own agenda views211902
-Ref: Adding your own hooks when organizing212602
-Node: Automating through emacs213872
-Node: Reference215175
-Node: Configuration Variables Reference216621
-Ref: Required Configuration216928
-Ref: org-todo-keywords (org-mode variable)216964
-Ref: org-gtd-keyword-mapping218051
-Ref: Directory and File Configuration219215
-Ref: org-gtd-directory219261
-Ref: org-gtd-additional-inbox-files220360
-Ref: org-gtd-horizons-file221333
-Ref: Capture Configuration221766
-Ref: org-gtd-capture-templates221801
-Ref: Organize and Process Configuration223081
-Ref: org-gtd-organize-hooks223129
-Ref: org-gtd-save-after-organize224673
-Ref: org-gtd-refile-to-any-target (deprecated)225024
-Ref: org-gtd-refile-prompt-for-types226326
-Ref: Mode-Line Configuration227761
-Ref: org-gtd-mode-update-interval227798
-Ref: org-gtd-mode-lighter-display228689
-Ref: Clarification Configuration229263
-Ref: org-gtd-clarify-show-horizons229304
-Ref: org-gtd-clarify-show-organize-help230068
-Ref: org-gtd-clarify-display-helper-buffer231192
-Ref: org-gtd-clarify-project-templates231841
-Ref: org-gtd-clarify-duplicate-queue-position233042
-Ref: Areas of Focus Configuration233875
-Ref: org-gtd-areas-of-focus233917
-Ref: View Prefix Configuration234569
-Ref: org-gtd-prefix-width234608
-Ref: org-gtd-agenda-truncate-ellipsis235611
-Ref: Archive Configuration236392
-Ref: org-gtd-archive-location236427
-Ref: Missed Engagements Review Configuration238070
-Ref: org-gtd-reflect-missed-custom-views238123
-Ref: Advanced Item Configuration239498
-Ref: org-gtd-user-types239539
-Ref: Agenda Display Configuration242928
-Ref: org-gtd-agenda-property-list243208
-Ref: org-gtd-agenda-property-position243758
-Ref: org-gtd-agenda-property-column244395
-Ref: org-gtd-agenda-property-separator244846
-Ref: Graph View Configuration245206
-Ref: org-gtd-graph-render-mode245315
-Ref: org-gtd-graph-ui-split-ratio246067
-Ref: org-gtd-graph-sibling-mode246840
-Ref: Projects Configuration249288
-Ref: org-gtd-project-progress-cookie-position249324
-Ref: Obsolete Variables (Do Not Use)251504
-Ref: org-gtd-todo-keyword (obsolete)251650
-Ref: org-gtd-next-keyword (obsolete)251778
-Ref: org-gtd-wait-keyword (obsolete)251906
-Ref: org-gtd-canceled-keyword (obsolete)252034
-Node: Commands Reference252158
-Ref: Core GTD Workflow Commands252473
-Ref: org-gtd-command-center252513
-Ref: org-gtd-capture253806
-Ref: org-gtd-process-inbox254450
-Ref: org-gtd-organize255295
-Ref: org-gtd-engage256266
-Ref: org-gtd-show-all-next257072
-Ref: Reflect Commands257465
-Ref: org-gtd-reflect-stuck-projects257495
-Ref: org-gtd-reflect-area-of-focus258063
-Ref: org-gtd-reflect-completed-items258674
-Ref: org-gtd-reflect-completed-projects259224
-Ref: org-gtd-reflect-missed-items259473
-Ref: Stuck Item Review Commands259762
-Ref: org-gtd-reflect-stuck-calendar-items259886
-Ref: org-gtd-reflect-stuck-tickler-items260010
-Ref: org-gtd-reflect-stuck-habit-items260134
-Ref: org-gtd-reflect-stuck-delegated-items260246
-Ref: org-gtd-reflect-stuck-next-action-items260389
-Ref: Reviewing Someday/Maybe Items260503
-Ref: Your First Review in 60 Seconds261127
-Ref: Understanding the Review Workflow261604
-Ref: Tutorial Weekly Someday Review262318
-Ref: Organizing Your Someday Items (Optional)263227
-Ref: Common Patterns264018
-Ref: Command Reference (1)264775
-Ref: org-gtd-reflect-someday-review265234
-Ref: Reflect Commands (Missed Engagements)266249
-Ref: What Are Missed Engagements?266300
-Ref: Your First Review in 30 Seconds267117
-Ref: Understanding the Review Workflow (1)267584
-Ref: Tutorial Daily Review Workflow268332
-Ref: Common Patterns (1)269165
-Ref: Command Reference (2)269677
-Ref: Backward Compatibility Note270437
-Ref: Reflect Commands (Upcoming Delegated)271129
-Ref: What Are Upcoming Delegated Check-ins?271180
-Ref: Your First Review in 30 Seconds (1)272008
-Ref: Understanding Proactive Delegation Management272516
-Ref: Tutorial Weekly Planning Workflow273175
-Ref: Common Patterns (2)274309
-Ref: Understanding What You See275090
-Ref: Comparison Missed vs Upcoming275876
-Ref: Command Reference (3)276386
-Ref: Custom View Commands276811
-Ref: org-gtd-view-show276845
-Ref: Clarification Commands287158
-Ref: org-gtd-clarify-item287194
-Ref: org-gtd-clarify-agenda-item287680
-Ref: org-gtd-clarify-toggle-horizons-window287973
-Ref: org-gtd-clarify-toggle-organize-help288339
-Ref: org-gtd-clarify-project-insert-template288932
-Ref: org-gtd-clarify-duplicate289275
-Ref: org-gtd-clarify-duplicate-exact290127
-Ref: org-gtd-clarify-stop290620
-Ref: Updating Items Without Refiling291011
-Ref: Archive Commands296092
-Ref: org-gtd-archive-completed-items296122
-Ref: Agenda-Specific Commands296647
-Ref: org-gtd-delegate-agenda-item296749
-Ref: org-gtd-project-cancel-from-agenda297112
-Ref: Timestamp Commands (DWIM)297554
-Ref: org-gtd-set-timestamp297710
-Ref: Project Task Commands (DWIM)298397
-Ref: org-gtd-project-add-successor298598
-Ref: org-gtd-project-add-blocker299077
-Ref: org-gtd-project-add-root-task299569
-Ref: org-gtd-project-remove-task299967
-Ref: org-gtd-project-trash-task300379
-Ref: org-gtd-project-change-state300751
-Ref: Project Management Commands301039
-Ref: org-gtd-projects-fix-todo-keywords-for-project-at-point301080
-Ref: org-gtd-projects-fix-all-todo-keywords301730
-Ref: org-gtd-project-update-all-cookies304772
-Ref: org-gtd-tickler306398
-Ref: org-gtd-someday308240
-Ref: org-gtd-reactivate309947
-Ref: Task Dependency Commands312064
-Ref: org-gtd-task-add-blockers312842
-Ref: org-gtd-task-remove-blockers313663
-Ref: org-gtd-task-add-dependent313969
-Ref: org-gtd-task-add-dependents314702
-Ref: org-gtd-task-clear-relationships314974
-Ref: org-gtd-task-show-relationships315347
-Ref: org-gtd-validate-project-dependencies315737
-Ref: org-gtd-remove-task-from-project316211
-Ref: Area of Focus Commands316585
-Ref: org-gtd-area-of-focus-set-on-item-at-point316621
-Ref: org-gtd-area-of-focus-set-on-agenda-item317028
-Ref: Programmatic Creation Commands317403
-Ref: org-gtd-habit-create317552
-Ref: org-gtd-calendar-create317813
-Ref: org-gtd-delegate-create318077
-Ref: org-gtd-tickler-create318801
-Ref: org-gtd-someday-create319094
-Ref: org-gtd-single-action-create319343
-Ref: Utility Commands319564
-Ref: org-gtd-setup-keywords-wizard319594
-Ref: org-gtd-inbox-path319946
-Ref: Migration and Upgrade Commands320360
-Ref: org-gtd-upgrade-v3-to-v4320404
-Ref: Mode-Line Integration321016
-Ref: org-gtd-mode321051
-Ref: org-gtd-inbox-count321794
-Ref: Obsolete Commands322078
-Ref: org-gtd-delegate-item-at-point (removed in 40)322109
-Node: Properties Reference (Internal Implementation)322971
-Ref: Core GTD Properties323860
-Ref: ORG_GTD323893
-Ref: ORG_GTD_REFILE324971
-Ref: Project Properties327322
-Ref: ORG_GTD_FIRST_TASKS327354
-Ref: Task Dependency Properties328293
-Ref: ORG_GTD_DEPENDS_ON328333
-Ref: ORG_GTD_BLOCKS330251
-Ref: ORG_GTD_PROJECT_IDS331088
-Ref: Calendar and Time Properties331438
-Ref: ORG_GTD_TIMESTAMP331480
-Ref: Delegation Properties332422
-Ref: DELEGATED_TO332457
-Ref: Habit Properties333409
-Ref: STYLE333439
-Ref: Area of Focus Properties333910
-Ref: CATEGORY333948
-Ref: Standard Org Properties Used by org-gtd334819
-Ref: ID334872
-Ref: keyword335149
-Ref: SCHEDULED (org-mode standard)335804
-Ref: DEADLINE (org-mode standard)336079
-Node: Troubleshooting Projects336322
-Ref: Fixing Broken Dependencies336843
-Ref: When Manual Property Editing is Needed338130
-Ref: Common Problems and Solutions339926
-Ref: Project Shows No NEXT Tasks (Stuck Project)339969
-Ref: Too Many NEXT Tasks340803
-Ref: Task Won't Advance to NEXT341277
-Ref: Task States Inconsistent After External Edits341979
-Node: View DSL Filter Reference343187
-Ref: Your First Custom View in 60 Seconds343704
-Ref: Understanding View Specs344264
-Ref: Combining Filters344848
-Ref: Multi-Block Views345283
-Ref: Common Patterns (3)345906
-Ref: Weekly Review View345935
-Ref: Morning Planning View346505
-Ref: Area of Focus View347196
-Ref: Filter Reference347836
-Ref: View Structure347976
-Ref: Multi-Block Views (1)348321
-Ref: Block Types349059
-Ref: Native Blocks (Escape Hatch)349580
-Ref: When You'll Need This350040
-Ref: Your First Native Block350716
-Ref: Adding Custom Sorting351885
-Ref: Mixing DSL and Native352747
-Ref: Native Block Types353699
-Ref: Quick Reference354332
-Ref: Type Filters354955
-Ref: (type delegated)355012
-Ref: (type calendar)355297
-Ref: (type project)355552
-Ref: (type active-project)355793
-Ref: (type completed-project)356072
-Ref: (type stuck-project)356378
-Ref: (type tickler)356698
-Ref: (type someday)356985
-Ref: (type habit)357279
-Ref: (type next-action)357501
-Ref: (type tickler-project)357818
-Ref: (type incubated-project)358275
-Ref: (type stuck-delegated)358758
-Ref: (type stuck-calendar)359129
-Ref: (type stuck-tickler)359412
-Ref: (type stuck-habit)359695
-Ref: Time-based Filters359953
-Ref: Semantic Time (when VALUE)360045
-Ref: Deadline (deadline VALUE)361006
-Ref: Scheduled (scheduled VALUE)361251
-Ref: Keyword Filters361506
-Ref: (todo ("KEYWORD1" "KEYWORD2"))361823
-Ref: (done VALUE)362247
-Ref: Area of Focus Filters363532
-Ref: (area-of-focus "AREA")363594
-Ref: Tag Filters364011
-Ref: (tags ("TAG1" "TAG2"))364062
-Ref: (tags-match "PATTERN")364385
-Ref: Priority Effort and Clocked Filters364920
-Ref: (priority VALUE)365062
-Ref: (effort SPEC)366381
-Ref: (clocked SPEC)367586
-Ref: (last-clocked-out SPEC)368704
-Ref: Property Filters370005
-Ref: (property (("PROP" "VALUE")))370077
-Ref: Structural Filters370396
-Ref: (level N)370467
-Ref: Special Filters370867
-Ref: (not-habit t)370896
-Ref: (invalid-timestamp t)371175
-Ref: View Configuration Options371521
-Ref: (block-type TYPE)371616
-Ref: (blocks BLOCK-LIST)372480
-Ref: Prefix DSL Customizing the Task Prefix Column373156
-Ref: Your First Prefix in 60 Seconds373655
-Ref: (prefix (ELEMENT ))374304
-Ref: (prefix-width N)375636
-Ref: Prefix Inheritance in Multi-Block Views376280
-Ref: Low-Level (prefix-format FORMAT-STRING)377463
-Ref: (view-type agenda)378065
-Ref: (agenda-span N)378402
-Ref: Simplified Multi-Block Views378568
-Ref: The Problem Verbose Block Definitions378853
-Ref: The Solution Implicit Blocks379760
-Ref: Try It Now380451
-Ref: Smart Type Defaults381113
-Ref: Top-Level Inheritance382061
-Ref: The Four-Tier Precedence Model382445
-Ref: When to Use Explicit Blocks383609
-Ref: Quick Reference (1)384287
-Ref: Saving Your Custom Views384721
-Node: Hooks Framework Reference385289
-Ref: What Are Organize Hooks?385467
-Ref: Your First Hook in 2 Minutes386014
-Ref: The org-gtd-organize-hooks Variable387041
-Ref: Built-in Hooks387362
-Ref: org-set-tags-command387390
-Ref: org-gtd-set-area-of-focus387668
-Ref: Writing Custom Hooks388249
-Ref: Basic Hook Structure388508
-Ref: Using org-gtd-organize-type-member-p388882
-Ref: Example Custom Hooks390527
-Ref: Selective Tagging with Unless390561
-Ref: Add Effort Estimation391343
-Ref: Add Priority391728
-Ref: Auto-Set Property Based on Keywords392068
-Ref: Add Custom Property392591
-Ref: Integration with Org-Roam393077
-Ref: Set Effort from Keywords393483
-Ref: Hook Execution Order394277
-Ref: Best Practices394650
-Ref: Complete Example Comprehensive Hook Setup395547
-Node: Extending org-gtd397726
-Node: Customizing types398013
-Ref: org-gtd-customize-type398700
-Ref: Hook stages399424
-Ref: Programmatic item creation400336
-Ref: Refile prompting400827
-Node: Project Traversal Functions401123
-Ref: org-gtd-project-map-tasks401307
-Ref: org-gtd-projects-map402113
-Node: Troubleshooting402796
-Node: Finding lost tasks403285
-Node: Projects without a NEXT item404292
-Node: I can't create a project when clarifying an inbox item!405552
-Node: Configuration problems406514
-Ref: Keywords not working406788
-Ref: Items not showing in engage view407522
-Node: Tasks still showing after tickler'ing or someday'ing project408332
-Node: Still stuck?409675
+Ref: Complete Configuration Examples29364
+Ref: Example 1 Vanilla Emacs (Minimal Configuration)29574
+Ref: Example 2 Doom Emacs Configuration32432
+Ref: Example 3 Spacemacs Configuration34690
+Ref: What These Configurations Do36926
+Ref: Testing Your Configuration38492
+Ref: Common Configuration Problems39835
+Ref: Working with Your Existing Org Setup43653
+Ref: Understanding Keybindings45746
+Ref: Global Keybindings45882
+Ref: Clarify Map Keybindings46527
+Ref: Required configuration of sub-packages47768
+Ref: Configuring org-edna47820
+Ref: Adding org-gtd files to your agenda48149
+Ref: configuration options for org-gtd48961
+Ref: I don't care just let me start using it49008
+Ref: Tell me all the levers I can pull49645
+Ref: Required keyword configuration49823
+Ref: Optional configuration52659
+Ref: Recommended key bindings58156
+Ref: Command Center58806
+Ref: Sample Doom Emacs Config59765
+Node: Getting Started with Org GTD61194
+Node: Quick Start Reference61658
+Node: Tutorial Your First Project62200
+Ref: What You'll Learn62657
+Ref: The Project62962
+Ref: Step 1 Capture the Project63269
+Ref: Step 2 Process the Inbox63759
+Ref: Step 3 Organize as a Project64178
+Ref: Step 4 View in Engage64759
+Ref: Step 5 Complete the First Task65278
+Ref: Step 6 Refresh and See the Change65628
+Ref: What Just Happened?66014
+Ref: Continue the Project67001
+Ref: Key Takeaways67444
+Ref: What's Next?67971
+Node: Tutorial Creating Your First Custom View68652
+Ref: What You'll Learn (1)69173
+Ref: Why This View?69405
+Ref: Understanding the View DSL69794
+Ref: Creating the View Function70323
+Ref: Using Your View70800
+Ref: Binding to a Key70946
+Ref: What You'll See71565
+Ref: Experiment Modify the View71981
+Ref: Available Filters72972
+Ref: Key Takeaways (1)75170
+Ref: What's Next? (1)75635
+Node: Tutorial Quick Wins and Focus Work Views76134
+Ref: Why This Matters76579
+Ref: Your First Quick Wins View (30 seconds)77058
+Ref: The Effort Filter Explained77584
+Ref: Building a Focus Work View78283
+Ref: The Priority Filter Explained78824
+Ref: Finding Tasks to Triage79494
+Ref: Bonus The Clocked Filter80097
+Ref: Putting It All Together80806
+Ref: Key Takeaways (2)81977
+Ref: Where to Go From Here82398
+Node: Using Org GTD83575
+Node: Your Daily Workflow84368
+Ref: Quick command reference85228
+Node: The GTD Flow in Depth86997
+Ref: Adding things to the inbox87233
+Ref: Processing the inbox88562
+Ref: Clarifying each item89286
+Ref: How to start clarifying89655
+Ref: data shape requirements90208
+Ref: Options and commands related to clarification90835
+Ref: Duplicating items during clarification93283
+Ref: Your first duplicate in 30 seconds93774
+Ref: Understanding the workflow94215
+Ref: The queue window95022
+Ref: Two ways to duplicate95579
+Ref: What happens if you cancel?96270
+Ref: Nested duplicates96943
+Ref: Data safety97180
+Ref: Configuration97665
+Ref: Organizing an item into the system98059
+Ref: Refiling to the appropriate area98847
+Ref: Understanding Refiling in V498898
+Ref: Refile Target System99349
+Ref: Controlling Refile Prompts by Item Type100555
+Ref: Creating New Refile Targets103060
+Ref: Multiple Types Per Heading103853
+Ref: Using Your Own Refile Targets104576
+Ref: Migration from V3105319
+Ref: Engaging with your GTD items105993
+Ref: Quick Task Actions from the Agenda106623
+Ref: First Contact Why This Feature?106676
+Ref: Black Triangle Your First Quick Action107412
+Ref: Understanding the Actions108251
+Ref: State Changes108410
+Ref: Time Adjustments (Conditional)108960
+Ref: Clocking110050
+Ref: Metadata110263
+Ref: Clarify110816
+Ref: Command Reference111167
+Ref: Suggested Keybinding112507
+Node: Checklists112877
+Ref: The template file113517
+Ref: Spawning a checklist114606
+Ref: Recurring checklists compose with habits115217
+Ref: Checkbox reset on repeat115904
+Node: Weekly Review (guided)117074
+Ref: Running a session117598
+Ref: Step types118818
+Ref: Pause resume and crash recovery120064
+Ref: Customizing the ritual org-gtd-review-profiles121025
+Ref: Scheduling the review org-gtd-review-schedule124305
+Ref: First-time setup org-gtd-init-system125463
+Node: Understanding GTD Item Types126538
+Ref: Single Action [S]127056
+Ref: Project [P]127631
+Ref: Add to existing project [A]128543
+Ref: Calendar [C]129308
+Ref: Delegate [D]130067
+Ref: Quick Action [Q]131325
+Ref: Tickler [I]131867
+Ref: Someday/Maybe [y]133402
+Ref: Habit [H]136195
+Ref: Knowledge [K]136981
+Ref: Trash [T]137645
+Ref: Working with the GTD Horizons138419
+Ref: Areas of focus139043
+Ref: Longer-term horizons140444
+Node: Working with Projects (Advanced)142244
+Ref: Quick Navigation142737
+Ref: First Contact Why Visual Project Management?143956
+Ref: Black Triangle Your First Project Graph View144791
+Ref: Step 1 Find a project144892
+Ref: Step 2 Open the graph view145090
+Ref: Step 3 Explore145273
+Ref: Understanding Project Dependencies145897
+Ref: The Dependency Graph (DAG)146039
+Ref: What You See in Graph View146646
+Ref: Sequential vs Parallel vs Mixed147373
+Ref: Tutorial Parallel Tasks with Graph View148376
+Ref: The Scenario148498
+Ref: Step 1 Capture and Organize148954
+Ref: Step 2 Open Graph View149357
+Ref: Step 3 Modify Dependencies to Create Parallel Tasks150003
+Ref: What Graph View CAN Do150679
+Ref: Building Our Parallel Structure151332
+Ref: The Diamond Pattern in Action152210
+Ref: Alternative Approach Add Blockers152760
+Ref: Tutorial Complex Dependencies with Graph View153355
+Ref: The Scenario (1)153415
+Ref: The Dependency Graph154041
+Ref: Building with Graph View154634
+Ref: Creating the Convergence Point155133
+Ref: Building the Rest155614
+Ref: The Complete Graph156164
+Ref: Key Patterns This Example Shows156845
+Ref: Common Dependency Patterns (Visual Reference)157306
+Ref: Sequential Chain (A → B → C)157427
+Ref: Parallel Independent (A B C all start together)157897
+Ref: Fan-out (A → B A → C A → D)158286
+Ref: Fan-in / Convergence (A → C B → C)158795
+Ref: Diamond (A → B → D A → C → D)159254
+Ref: Graph View Command Reference159922
+Ref: Opening Graph View160122
+Ref: Tier 1 Single-Key Commands (Always Available)160420
+Ref: Tier 2 Prefixed Commands163770
+Ref: Visual Indicators165323
+Ref: Operations Not Available in Graph View165629
+Ref: Text-Based Alternatives166452
+Ref: Graph Rendering Modes167787
+Ref: SVG Mode (Default)167989
+Ref: ASCII Mode168350
+Ref: Toggling Modes168735
+Ref: Troubleshooting ASCII Rendering168861
+Ref: Complete Keyboard Reference169224
+Ref: Tier 1 Single Keys169348
+Ref: Tier 2 Task Operations (t prefix)170293
+Ref: Tier 2 Project and View Operations170670
+Ref: Auto-Refresh on File Changes171121
+Ref: Technical Details171616
+Ref: Graph Data Structure171647
+Ref: Layout Algorithm172047
+Ref: Properties Used172403
+Ref: Undo/Redo Support173349
+Ref: Practical Tips for Project Management173728
+Ref: When to Use Graph View173779
+Ref: When to Use Sequential (Default)174186
+Ref: When to Create Parallel Structures174602
+Ref: Managing Complexity174970
+Ref: Growing Projects Over Time175414
+Ref: Canceling Projects175853
+Ref: Exporting Project Graphs176869
+Ref: First Contact What is Graph Export?176907
+Ref: Tutorial Export Your First Graph177649
+Ref: Progressive Learning Choosing Export Formats178211
+Ref: When Exports Differ from Display180052
+Ref: Reference Export Commands180666
+Ref: Troubleshooting Exports181356
+Ref: Troubleshooting Projects with Graph View182144
+Ref: Project is Stuck (has TODO tasks but no NEXT)182198
+Ref: Task Should Be NEXT But Shows as TODO183132
+Ref: Too Many Tasks Are NEXT183782
+Ref: Graph Won't Open184282
+Ref: Graph Shows No Tasks184682
+Ref: Task Shows Wrong State (NEXT vs TODO)185117
+Ref: Can't Modify Dependencies185620
+Ref: See Also186072
+Ref: Tickler Projects Pausing Work You're Not Ready For186569
+Ref: First Contact Why Tickler Projects?186634
+Ref: Black Triangle Tickler Your First Project in 30 Seconds187702
+Ref: Understanding Tickler What Actually Happens188615
+Ref: Tutorial Managing Seasonal Projects190865
+Ref: Common Patterns and Scenarios193329
+Ref: Advanced External Dependencies and Warnings195610
+Ref: Technical Details How Tickler Works Under the Hood197926
+Ref: Troubleshooting Tickler201787
+Ref: See Also (1)205074
+Ref: Project Progress Cookies See Your Progress at a Glance205704
+Ref: First Contact What Are Progress Cookies?205773
+Ref: Black Triangle See Progress in 30 Seconds206334
+Ref: Tutorial Watch Cookies Update Automatically206821
+Ref: Understanding How Cookies Work207635
+Ref: Configuring Cookie Position208707
+Ref: Common Scenarios209541
+Ref: Technical Reference210378
+Ref: Cleaning up / archiving completed work211307
+Ref: Commands you can call on org-agenda212001
+Ref: Defining your own agenda views212799
+Ref: Adding your own hooks when organizing213499
+Node: Automating through emacs214769
+Node: Reference216072
+Node: Configuration Variables Reference217518
+Ref: Required Configuration217825
+Ref: org-todo-keywords (org-mode variable)217861
+Ref: org-gtd-keyword-mapping218948
+Ref: Directory and File Configuration220112
+Ref: org-gtd-directory220158
+Ref: org-gtd-additional-inbox-files221257
+Ref: org-gtd-horizons-file222230
+Ref: Capture Configuration222663
+Ref: org-gtd-capture-templates222698
+Ref: Organize and Process Configuration223978
+Ref: org-gtd-organize-hooks224026
+Ref: org-gtd-save-after-organize225570
+Ref: org-gtd-refile-to-any-target (deprecated)225921
+Ref: org-gtd-refile-prompt-for-types227223
+Ref: Mode-Line Configuration228658
+Ref: org-gtd-mode-update-interval228695
+Ref: org-gtd-mode-lighter-display229586
+Ref: Clarification Configuration230160
+Ref: org-gtd-clarify-show-horizons230201
+Ref: org-gtd-clarify-show-organize-help230965
+Ref: org-gtd-clarify-display-helper-buffer232089
+Ref: org-gtd-clarify-project-templates232738
+Ref: org-gtd-clarify-duplicate-queue-position233939
+Ref: Areas of Focus Configuration234772
+Ref: org-gtd-areas-of-focus234814
+Ref: View Prefix Configuration235466
+Ref: org-gtd-prefix-width235505
+Ref: org-gtd-agenda-truncate-ellipsis236508
+Ref: Archive Configuration237289
+Ref: org-gtd-archive-location237324
+Ref: Missed Engagements Review Configuration238967
+Ref: org-gtd-reflect-missed-custom-views239020
+Ref: Guided Review Configuration240395
+Ref: org-gtd-review-profiles240436
+Ref: Advanced Item Configuration241525
+Ref: org-gtd-user-types241566
+Ref: Agenda Display Configuration244955
+Ref: org-gtd-agenda-property-list245235
+Ref: org-gtd-agenda-property-position245785
+Ref: org-gtd-agenda-property-column246422
+Ref: org-gtd-agenda-property-separator246873
+Ref: Graph View Configuration247233
+Ref: org-gtd-graph-render-mode247342
+Ref: org-gtd-graph-ui-split-ratio248094
+Ref: org-gtd-graph-sibling-mode248867
+Ref: Projects Configuration251315
+Ref: org-gtd-project-progress-cookie-position251351
+Ref: Obsolete Variables (Do Not Use)253531
+Ref: org-gtd-todo-keyword (obsolete)253677
+Ref: org-gtd-next-keyword (obsolete)253805
+Ref: org-gtd-wait-keyword (obsolete)253933
+Ref: org-gtd-canceled-keyword (obsolete)254061
+Node: Commands Reference254185
+Ref: Core GTD Workflow Commands254500
+Ref: org-gtd-command-center254540
+Ref: org-gtd-capture255921
+Ref: org-gtd-process-inbox256565
+Ref: org-gtd-organize257410
+Ref: org-gtd-engage258381
+Ref: org-gtd-show-all-next259187
+Ref: Reflect Commands259580
+Ref: org-gtd-review259610
+Ref: org-gtd-review-schedule260571
+Ref: org-gtd-reflect-stuck-projects261221
+Ref: org-gtd-reflect-area-of-focus261789
+Ref: org-gtd-reflect-completed-items262400
+Ref: org-gtd-reflect-completed-projects262950
+Ref: org-gtd-reflect-missed-items263199
+Ref: Stuck Item Review Commands263488
+Ref: org-gtd-reflect-stuck-calendar-items263612
+Ref: org-gtd-reflect-stuck-tickler-items263736
+Ref: org-gtd-reflect-stuck-habit-items263860
+Ref: org-gtd-reflect-stuck-delegated-items263972
+Ref: org-gtd-reflect-stuck-next-action-items264115
+Ref: Reviewing Someday/Maybe Items264229
+Ref: Your First Review in 60 Seconds264853
+Ref: Understanding the Review Workflow265330
+Ref: Tutorial Weekly Someday Review266044
+Ref: Organizing Your Someday Items (Optional)266953
+Ref: Common Patterns267744
+Ref: Command Reference (1)268501
+Ref: org-gtd-reflect-someday-review268960
+Ref: Reflect Commands (Missed Engagements)269975
+Ref: What Are Missed Engagements?270026
+Ref: Your First Review in 30 Seconds270843
+Ref: Understanding the Review Workflow (1)271310
+Ref: Tutorial Daily Review Workflow272058
+Ref: Common Patterns (1)272891
+Ref: Command Reference (2)273403
+Ref: Backward Compatibility Note274163
+Ref: Reflect Commands (Upcoming Delegated)274855
+Ref: What Are Upcoming Delegated Check-ins?274906
+Ref: Your First Review in 30 Seconds (1)275734
+Ref: Understanding Proactive Delegation Management276242
+Ref: Tutorial Weekly Planning Workflow276901
+Ref: Common Patterns (2)278035
+Ref: Understanding What You See278816
+Ref: Comparison Missed vs Upcoming279602
+Ref: Command Reference (3)280112
+Ref: Checklist Commands280537
+Ref: org-gtd-checklist-insert280569
+Ref: org-gtd-checklist-visit281113
+Ref: Custom View Commands281706
+Ref: org-gtd-view-show281740
+Ref: Clarification Commands292053
+Ref: org-gtd-clarify-item292089
+Ref: org-gtd-clarify-agenda-item292575
+Ref: org-gtd-clarify-toggle-horizons-window292868
+Ref: org-gtd-clarify-toggle-organize-help293234
+Ref: org-gtd-clarify-project-insert-template293827
+Ref: org-gtd-clarify-duplicate294170
+Ref: org-gtd-clarify-duplicate-exact295022
+Ref: org-gtd-clarify-stop295515
+Ref: Updating Items Without Refiling295906
+Ref: Archive Commands300987
+Ref: org-gtd-archive-completed-items301017
+Ref: Agenda-Specific Commands301542
+Ref: org-gtd-delegate-agenda-item301644
+Ref: org-gtd-project-cancel-from-agenda302007
+Ref: Timestamp Commands (DWIM)302449
+Ref: org-gtd-set-timestamp302605
+Ref: Project Task Commands (DWIM)303292
+Ref: org-gtd-project-add-successor303493
+Ref: org-gtd-project-add-blocker303972
+Ref: org-gtd-project-add-root-task304464
+Ref: org-gtd-project-remove-task304862
+Ref: org-gtd-project-trash-task305274
+Ref: org-gtd-project-change-state305646
+Ref: Project Management Commands305934
+Ref: org-gtd-projects-fix-todo-keywords-for-project-at-point305975
+Ref: org-gtd-projects-fix-all-todo-keywords306625
+Ref: org-gtd-project-update-all-cookies309667
+Ref: org-gtd-tickler311293
+Ref: org-gtd-someday313135
+Ref: org-gtd-reactivate314842
+Ref: Task Dependency Commands316959
+Ref: org-gtd-task-add-blockers317737
+Ref: org-gtd-task-remove-blockers318558
+Ref: org-gtd-task-add-dependent318864
+Ref: org-gtd-task-add-dependents319597
+Ref: org-gtd-task-clear-relationships319869
+Ref: org-gtd-task-show-relationships320242
+Ref: org-gtd-validate-project-dependencies320632
+Ref: org-gtd-remove-task-from-project321106
+Ref: Area of Focus Commands321480
+Ref: org-gtd-area-of-focus-set-on-item-at-point321516
+Ref: org-gtd-area-of-focus-set-on-agenda-item321923
+Ref: Programmatic Creation Commands322298
+Ref: org-gtd-habit-create322447
+Ref: org-gtd-calendar-create322708
+Ref: org-gtd-delegate-create322972
+Ref: org-gtd-tickler-create323696
+Ref: org-gtd-someday-create323989
+Ref: org-gtd-single-action-create324238
+Ref: Utility Commands324459
+Ref: org-gtd-init-system324489
+Ref: org-gtd-setup-keywords-wizard325298
+Ref: org-gtd-inbox-path325650
+Ref: Migration and Upgrade Commands326064
+Ref: org-gtd-upgrade-v3-to-v4326108
+Ref: Mode-Line Integration326720
+Ref: org-gtd-mode326755
+Ref: org-gtd-inbox-count327498
+Ref: Obsolete Commands327782
+Ref: org-gtd-delegate-item-at-point (removed in 40)327813
+Node: Properties Reference (Internal Implementation)328675
+Ref: Core GTD Properties329564
+Ref: ORG_GTD329597
+Ref: ORG_GTD_REFILE330675
+Ref: Project Properties333026
+Ref: ORG_GTD_FIRST_TASKS333058
+Ref: Task Dependency Properties333997
+Ref: ORG_GTD_DEPENDS_ON334037
+Ref: ORG_GTD_BLOCKS335955
+Ref: ORG_GTD_PROJECT_IDS336792
+Ref: Calendar and Time Properties337142
+Ref: ORG_GTD_TIMESTAMP337184
+Ref: Delegation Properties338126
+Ref: DELEGATED_TO338161
+Ref: Habit Properties339113
+Ref: STYLE339143
+Ref: Area of Focus Properties339614
+Ref: CATEGORY339652
+Ref: Standard Org Properties Used by org-gtd340523
+Ref: ID340576
+Ref: keyword340853
+Ref: SCHEDULED (org-mode standard)341508
+Ref: DEADLINE (org-mode standard)341783
+Node: Troubleshooting Projects342026
+Ref: Fixing Broken Dependencies342547
+Ref: When Manual Property Editing is Needed343834
+Ref: Common Problems and Solutions345630
+Ref: Project Shows No NEXT Tasks (Stuck Project)345673
+Ref: Too Many NEXT Tasks346507
+Ref: Task Won't Advance to NEXT346981
+Ref: Task States Inconsistent After External Edits347683
+Node: View DSL Filter Reference348891
+Ref: Your First Custom View in 60 Seconds349408
+Ref: Understanding View Specs349968
+Ref: Combining Filters350552
+Ref: Multi-Block Views350987
+Ref: Common Patterns (3)351610
+Ref: Weekly Review View351639
+Ref: Morning Planning View352209
+Ref: Area of Focus View352900
+Ref: Filter Reference353540
+Ref: View Structure353680
+Ref: Multi-Block Views (1)354025
+Ref: Block Types354763
+Ref: Native Blocks (Escape Hatch)355284
+Ref: When You'll Need This355744
+Ref: Your First Native Block356420
+Ref: Adding Custom Sorting357589
+Ref: Mixing DSL and Native358451
+Ref: Native Block Types359403
+Ref: Quick Reference360036
+Ref: Type Filters360659
+Ref: (type delegated)360716
+Ref: (type calendar)361001
+Ref: (type project)361256
+Ref: (type active-project)361497
+Ref: (type completed-project)361776
+Ref: (type stuck-project)362082
+Ref: (type tickler)362402
+Ref: (type someday)362689
+Ref: (type habit)362983
+Ref: (type next-action)363205
+Ref: (type tickler-project)363522
+Ref: (type incubated-project)363979
+Ref: (type stuck-delegated)364462
+Ref: (type stuck-calendar)364833
+Ref: (type stuck-tickler)365116
+Ref: (type stuck-habit)365399
+Ref: Time-based Filters365657
+Ref: Semantic Time (when VALUE)365749
+Ref: Deadline (deadline VALUE)366710
+Ref: Scheduled (scheduled VALUE)366955
+Ref: Keyword Filters367210
+Ref: (todo ("KEYWORD1" "KEYWORD2"))367527
+Ref: (done VALUE)367951
+Ref: Area of Focus Filters369236
+Ref: (area-of-focus "AREA")369298
+Ref: Tag Filters369715
+Ref: (tags ("TAG1" "TAG2"))369766
+Ref: (tags-match "PATTERN")370089
+Ref: Priority Effort and Clocked Filters370624
+Ref: (priority VALUE)370766
+Ref: (effort SPEC)372085
+Ref: (clocked SPEC)373290
+Ref: (last-clocked-out SPEC)374408
+Ref: Property Filters375709
+Ref: (property (("PROP" "VALUE")))375781
+Ref: Structural Filters376100
+Ref: (level N)376171
+Ref: Special Filters376571
+Ref: (not-habit t)376600
+Ref: (invalid-timestamp t)376879
+Ref: View Configuration Options377225
+Ref: (block-type TYPE)377320
+Ref: (blocks BLOCK-LIST)378184
+Ref: Prefix DSL Customizing the Task Prefix Column378860
+Ref: Your First Prefix in 60 Seconds379359
+Ref: (prefix (ELEMENT ))380008
+Ref: (prefix-width N)381340
+Ref: Prefix Inheritance in Multi-Block Views381984
+Ref: Low-Level (prefix-format FORMAT-STRING)383167
+Ref: (view-type agenda)383769
+Ref: (agenda-span N)384106
+Ref: Simplified Multi-Block Views384272
+Ref: The Problem Verbose Block Definitions384557
+Ref: The Solution Implicit Blocks385464
+Ref: Try It Now386155
+Ref: Smart Type Defaults386817
+Ref: Top-Level Inheritance387765
+Ref: The Four-Tier Precedence Model388149
+Ref: When to Use Explicit Blocks389313
+Ref: Quick Reference (1)389991
+Ref: Saving Your Custom Views390425
+Node: Hooks Framework Reference390993
+Ref: What Are Organize Hooks?391171
+Ref: Your First Hook in 2 Minutes391718
+Ref: The org-gtd-organize-hooks Variable392745
+Ref: Built-in Hooks393066
+Ref: org-set-tags-command393094
+Ref: org-gtd-set-area-of-focus393372
+Ref: Writing Custom Hooks393953
+Ref: Basic Hook Structure394212
+Ref: Using org-gtd-organize-type-member-p394586
+Ref: Example Custom Hooks396231
+Ref: Selective Tagging with Unless396265
+Ref: Add Effort Estimation397047
+Ref: Add Priority397432
+Ref: Auto-Set Property Based on Keywords397772
+Ref: Add Custom Property398295
+Ref: Integration with Org-Roam398781
+Ref: Set Effort from Keywords399187
+Ref: Hook Execution Order399981
+Ref: Best Practices400354
+Ref: Complete Example Comprehensive Hook Setup401251
+Node: Extending org-gtd403430
+Node: Customizing types403717
+Ref: org-gtd-customize-type404404
+Ref: Hook stages405128
+Ref: Programmatic item creation406040
+Ref: Refile prompting406531
+Node: Project Traversal Functions406827
+Ref: org-gtd-project-map-tasks407011
+Ref: org-gtd-projects-map407817
+Node: Troubleshooting408500
+Node: Finding lost tasks408989
+Node: Projects without a NEXT item409996
+Node: I can't create a project when clarifying an inbox item!411256
+Node: Configuration problems412218
+Ref: Keywords not working412492
+Ref: Items not showing in engage view413226
+Node: Tasks still showing after tickler'ing or someday'ing project414036
+Node: Still stuck?415379
 
 End Tag Table
 

--- a/org-gtd.info
+++ b/org-gtd.info
@@ -1,4 +1,4 @@
-This is org-gtd.info, produced by makeinfo version 7.2 from
+This is org-gtd.info, produced by makeinfo version 7.3 from
 org-gtd.texi.
 
 Copyright (C) 2018-2026 Aldric Giacomoni <trevoke@gmail.com>
@@ -80,6 +80,8 @@ Using Org GTD
 
 * Your Daily Workflow::          The GTD cycle you'll practice every day
 * The GTD Flow in Depth::        Detailed explanation of each GTD step
+* Checklists::                   Reusable checklist templates you can spawn anywhere
+* Weekly Review (guided)::       A pausable, step-by-step guided review session
 * Understanding GTD Item Types:: When to use each type in the organize menu
 * Working with Projects (Advanced)::
 * Automating through emacs::
@@ -97,6 +99,7 @@ Reference
 
 Extending org-gtd
 
+* Customizing types::
 * Project Traversal Functions::
 
 
@@ -2081,6 +2084,8 @@ want to explore more advanced features.
 
 * Your Daily Workflow::          The GTD cycle you'll practice every day
 * The GTD Flow in Depth::        Detailed explanation of each GTD step
+* Checklists::                   Reusable checklist templates you can spawn anywhere
+* Weekly Review (guided)::       A pausable, step-by-step guided review session
 * Understanding GTD Item Types:: When to use each type in the organize menu
 * Working with Projects (Advanced)::
 * Automating through emacs::
@@ -2118,6 +2123,7 @@ part.
      ‘org-gtd-organize’                         Organize current item                  During processing (in clarify buffer)
      ‘org-gtd-engage’                           See actionable items                   Daily (your "work from" view)
      ‘org-gtd-show-all-next’                    See only NEXT actions                  When you want to focus on actions
+     ‘org-gtd-review’                           Guided Weekly Review session           Weekly
      ‘org-gtd-reflect-stuck-projects’           Find stuck projects                    Weekly review
      ‘org-gtd-reflect-someday-review’           Review someday items one-by-one        Weekly/monthly review
      ‘org-gtd-projects-fix-all-todo-keywords’   Fix task states after external edits   After mobile/web edits
@@ -2129,7 +2135,7 @@ part.
      For details on each workflow step, see the subsections below.
 
 
-File: org-gtd.info,  Node: The GTD Flow in Depth,  Next: Understanding GTD Item Types,  Prev: Your Daily Workflow,  Up: Using Org GTD
+File: org-gtd.info,  Node: The GTD Flow in Depth,  Next: Checklists,  Prev: Your Daily Workflow,  Up: Using Org GTD
 
 1.4.2 The GTD Flow in Depth
 ---------------------------
@@ -2582,7 +2588,8 @@ Here are the domain elements of GTD that we handle:
      late projects.  This is your safety net for catching things that
      slipped through the cracks.
 
-     The weekly review is not yet implemented.
+     For the Reflect step's central ritual, org-gtd ships a guided,
+     pausable Weekly Review session: see *note Weekly Review (guided)::.
 
         • Quick Task Actions from the Agenda
 
@@ -2724,9 +2731,293 @@ Here are the domain elements of GTD that we handle:
                     (define-key org-agenda-mode-map (kbd "C-c .") #'org-gtd-agenda-transient)
 
 
-File: org-gtd.info,  Node: Understanding GTD Item Types,  Next: Working with Projects (Advanced),  Prev: The GTD Flow in Depth,  Up: Using Org GTD
+File: org-gtd.info,  Node: Checklists,  Next: Weekly Review (guided),  Prev: The GTD Flow in Depth,  Up: Using Org GTD
 
-1.4.3 Understanding GTD Item Types
+1.4.3 Checklists
+----------------
+
+Some lists you use over and over: packing for a trip, releasing
+software, the trigger list of a Weekly Review mind sweep.  org-gtd
+stores these as templates in a file called ‘checklists.org’ in
+‘org-gtd-directory’, and lets you stamp out a fresh copy whenever you
+need one.
+
+   The file is created the first time anything touches it, seeded with
+two starter templates: "Weekly Review triggers" and "Mind sweep
+prompts".  They're yours — edit or delete them freely.
+
+   • The template file
+
+     Each top-level heading in ‘checklists.org’ is a template; its
+     checkbox items are the checklist:
+
+          * Beach packing
+          - [ ] Sunscreen
+          - [ ] Swimsuit
+          - [ ] Beach towel
+
+     Two conventions to respect:
+
+        • Templates are *top-level headings*.  Sub-headings inside a
+          template are copied along when you spawn it, but only
+          top-level headings appear as template names.
+        • Items are *dash-style checkboxes* (‘- [ ]’).  Other list
+          bullets are not recognized as checklist items.
+
+     That's the whole format: no TODO keywords, no properties, nothing
+     org-gtd-specific.  *Editing this file is how you customize your
+     checklists.*  Open it with ‘M-x org-gtd-checklist-visit’ (or ‘l’
+     from the command center) and use ordinary org editing.  A heading
+     marked with org's ‘COMMENT’ keyword is ignored — a handy way to
+     retire a template without deleting it.
+
+     The file is not part of your agenda: templates are content, not
+     tasks.
+
+   • Spawning a checklist
+
+     Call ‘M-x org-gtd-checklist-insert’ in any org buffer.  It offers
+     your template names for completion, then inserts a fresh copy of
+     the chosen template as a subtree:
+
+        • On a heading line, the copy becomes the *first child* of that
+          heading.
+        • In body text, the copy is inserted at point, as a child of the
+          heading you're under (or as a top-level heading when there's
+          no heading above point).
+
+     The copy is plain org.  org-gtd does not track it, and checking off
+     its boxes never touches the template file.
+
+   • Recurring checklists: compose with habits
+
+     Want your packing list — or your mind-sweep trigger list — as a
+     recurring task in your system?  Compose the pieces you already
+     have:
+
+       1. In your inbox (or any org file), ‘M-x
+          org-gtd-checklist-insert’ and pick the template.
+       2. ‘M-x org-gtd-clarify-item’ on the new heading; rename it if
+          you like.
+       3. Organize it as a *Habit* with a repeater (say, ‘.+1w’).
+
+     Now it's a real habit: ‘org-gtd-engage’ shows it on schedule, you
+     work through the boxes, you mark it ‘DONE’ — and the checkboxes
+     reset themselves for next time, as described below.
+
+   • Checkbox reset on repeat
+
+     When a repeating heading *re-arms* — you mark it done and org's
+     repeater flips it back to a not-done state for the next occurrence
+     — org-gtd clears every checkbox in that heading's subtree,
+     including boxes under child headings, and updates any ‘[1/3]’-style
+     statistics cookies.  The next run starts fresh.
+
+     The guard mirrors org's own re-arm rule exactly, so the reset
+     happens only when org actually re-arms the heading:
+
+        • A heading with no repeater never resets: a plain ‘DONE’ keeps
+          its record.
+        • A zero-interval repeater (like ‘.+0w’, org's idiom for "this
+          repeating task is finished for good") does not re-arm, so the
+          checked boxes are preserved.
+        • A done-to-done transition (e.g.  changing ‘DONE’ to
+          ‘CANCELED’) doesn't reset.
+
+     This applies to *every* repeating heading with checkboxes — spawned
+     from a template or written by hand.  The hook is installed by
+     ‘org-gtd-mode’.
+
+
+File: org-gtd.info,  Node: Weekly Review (guided),  Next: Understanding GTD Item Types,  Prev: Checklists,  Up: Using Org GTD
+
+1.4.4 Weekly Review (guided)
+----------------------------
+
+GTD's Reflect step asks you to step back regularly and get your system
+clear, current, and creative.  Its central ritual is the Weekly Review.
+‘M-x org-gtd-review’ (or ‘w’ from the command center) walks you through
+it one step at a time, so you don't have to hold the ritual in your head
+— sit down and press ‘n’.
+
+   • Running a session
+
+     The session opens a console buffer, ‘*GTD Review*’, showing the
+     profile name, a phase tracker, and the current step with its
+     instruction.  The keys are advertised in the header line:
+
+     Key   Action
+     -----------------------------------------------------------------
+     ‘n’   Do the current step, or advance past it
+     ‘s’   Skip this step, for this run only
+     ‘c’   Capture something to the inbox (available on every step)
+     ‘p’   Pause; resume later with ‘M-x org-gtd-review’
+     ‘q’   Quit; offers to keep or abandon your progress
+
+     Capture deserves emphasis: any step of a review can shake something
+     loose, and ‘c’ is always one keypress away.
+
+     Each phase boundary shows a checkpoint message ("Get Clear complete
+     — on to Get Current.").  When the session finishes, you get a tally
+     of steps done and skipped, your window configuration is restored,
+     and — until you've scheduled a review reminder — a one-time tip
+     points you at ‘org-gtd-review-schedule’.
+
+     Only one session runs at a time; if one is already active,
+     ‘org-gtd-review’ tells you to finish or quit it first.
+
+   • Step types
+
+     A review is made of four kinds of steps.  Here's what ‘n’ does on
+     each:
+
+     prompt
+          Read the instruction, do the thing in the real world, press
+          ‘n’ to move on.
+     command
+          Two presses.  The first ‘n’ runs the step's command (for
+          example ‘org-gtd-process-inbox’).  When you're done, come back
+          to the review buffer and press ‘n’ again to confirm and
+          advance — or ‘s’ if you're leaving it unfinished.  If the
+          command signals an error, the step doesn't count as started;
+          ‘n’ simply retries it.
+     view
+          Two presses, same shape.  The first ‘n’ opens the step's
+          agenda view in another window; browse it and act on what needs
+          acting.  The second ‘n’ advances.
+     checklist
+          Walks the items of a named template from your *note checklists
+          file: Checklists, one item at a time.  The first ‘n’ shows the
+          first item; each further ‘n’ shows the next; press ‘c’
+          whenever an item shakes something loose.  The template file
+          itself is never modified.  An empty or missing checklist just
+          says so and moves on.
+
+   • Pause, resume, and crash recovery
+
+     The session checkpoints itself to a small file, ‘review-state.eld’
+     in ‘org-gtd-directory’ — once when it starts, and again at every
+     step boundary and every checklist-walk advance.  Pausing with ‘p’,
+     killing the buffer, or even a crashed Emacs loses nothing: the next
+     ‘M-x org-gtd-review’ offers to resume exactly where you were.  Work
+     done mid-step — a half-processed inbox, say — lives in your org
+     files anyway, so resuming a command step simply re-offers it.
+
+     There is a single checkpoint slot.  Declining the resume offer
+     starts a fresh session, whose first checkpoint replaces the old
+     one.  To abandon a session outright, press ‘q’ and answer no to
+     "Keep progress" — that deletes the checkpoint.  If you edit your
+     profiles while a session is paused and the saved position no longer
+     fits, org-gtd says so and starts over.
+
+   • Customizing the ritual: org-gtd-review-profiles
+
+     The whole ritual is data.  ‘org-gtd-review-profiles’ is an alist of
+     profiles; each profile is a list of named phases; each phase is a
+     list of steps; each step is a plist with a ‘:title’, a ‘:type’ (one
+     of ‘prompt’, ‘command’, ‘view’, ‘checklist’), an optional
+     ‘:instruction’, and the type-specific key ‘:command’, ‘:view’, or
+     ‘:checklist’ (a template name from your checklists file).
+
+     The Weekly Review ships as the default value, so customizing means
+     editing this variable — reorder steps, delete what you don't use,
+     point ‘:view’ steps at *note your own views: View DSL Filter
+     Reference, or add entirely new profiles (a daily shutdown, a
+     monthly horizons review).  When more than one profile is
+     configured, ‘org-gtd-review’ asks which one to run.  Malformed
+     profiles are rejected up front with an error that names the
+     offending phase or step and shows the expected shape.
+
+     Here is the full default, as a starting point for your own:
+
+          (setq org-gtd-review-profiles
+                '(("Weekly Review"
+                   ("Get Clear"
+                    (:title "Gather loose materials"
+                     :type prompt
+                     :instruction "Collect loose papers, receipts, and notes.  Capture each one into the inbox.")
+                    (:title "Mind sweep"
+                     :type checklist
+                     :checklist "Weekly Review triggers"
+                     :instruction "Walk each trigger.  Press c to capture whatever it shakes loose.")
+                    (:title "Inbox to zero"
+                     :type command
+                     :command org-gtd-process-inbox
+                     :instruction "Process every inbox item.  Come back here and press n when the inbox is empty."))
+                   ("Get Current"
+                    (:title "Review missed items"
+                     :type view
+                     :view org-gtd-reflect-missed-items
+                     :instruction "Reschedule, complete, or cancel anything that slipped.")
+                    (:title "Review Waiting-For"
+                     :type view
+                     :view org-gtd-reflect-upcoming-delegated
+                     :instruction "Nudge, close, or re-delegate each delegated item.")
+                    (:title "Review next actions"
+                     :type view
+                     :view org-gtd-show-all-next
+                     :instruction "Mark done what is done; check these still feel current.")
+                    (:title "Review stuck projects"
+                     :type view
+                     :view org-gtd-reflect-stuck-projects
+                     :instruction "Give every active project a next action."))
+                   ("Get Creative"
+                    (:title "Review Someday/Maybe"
+                     :type view
+                     :view org-gtd-reflect-someday-maybe
+                     :instruction "Reactivate anything whose time has come.")
+                    (:title "Capture new ideas"
+                     :type prompt
+                     :instruction "Any creative, risky, or fun ideas?  Capture them.")))))
+
+   • Scheduling the review: org-gtd-review-schedule
+
+     A Weekly Review only works if it actually happens weekly.  ‘M-x
+     org-gtd-review-schedule’ prompts for a profile (when you have more
+     than one), a first date, and a repeat interval, then creates an
+     ordinary org-gtd habit named after the profile — so the reminder
+     shows up in your engage view like any other habit:
+
+          * Weekly Review
+          SCHEDULED: <2026-07-10 Fri .+1w>
+          :PROPERTIES:
+          :ORG_GTD:  Habit
+          :STYLE:    habit
+          :END:
+          Run M-x org-gtd-review when you sit down for this.
+
+     The repeat interval is a standard org repeater: ‘.+1w’ means "a
+     week after I actually do it" (the usual choice for reviews), ‘+1w’
+     is a fixed calendar cadence, and ‘++1w’ jumps to the next future
+     occurrence.  Units are ‘h’, ‘d’, ‘w’, ‘m’, ‘y’, and habit-style
+     maximum intervals like ‘.+2d/4d’ are accepted.  Anything else is
+     rejected with an explanation.
+
+     If a reminder for one of your profiles already exists, the command
+     asks before scheduling another one.
+
+   • First-time setup: org-gtd-init-system
+
+     ‘M-x org-gtd-init-system’ is a small first-run concierge.  It
+     ensures ‘org-gtd-directory’ and the GTD files exist — the tasks
+     file, the inbox, and ‘checklists.org’ with its starter templates —
+     and then offers to schedule a recurring Weekly Review (skipping the
+     offer when a reminder already exists).  It is idempotent: run it
+     again anytime, and anything already in place is simply reported as
+     ready.
+
+     Two things it deliberately does *not* do, because they belong in
+     your Emacs configuration: adding your GTD files to
+     ‘org-agenda-files’, and TODO keyword setup.  Those remain manual
+     steps — see *note Configuring::.
+
+     You never _have_ to run it: every file it creates is also created
+     lazily the first time something needs it.
+
+
+File: org-gtd.info,  Node: Understanding GTD Item Types,  Next: Working with Projects (Advanced),  Prev: Weekly Review (guided),  Up: Using Org GTD
+
+1.4.5 Understanding GTD Item Types
 ----------------------------------
 
 When you organize an item (‘org-gtd-organize’), a transient menu appears
@@ -3137,7 +3428,7 @@ Here's the complete reference for all item types:
 
 File: org-gtd.info,  Node: Working with Projects (Advanced),  Next: Automating through emacs,  Prev: Understanding GTD Item Types,  Up: Using Org GTD
 
-1.4.4 Working with Projects (Advanced)
+1.4.6 Working with Projects (Advanced)
 --------------------------------------
 
 You learned sequential projects in *note Tutorial Your First Project::.
@@ -4954,7 +5245,7 @@ structures—all using visual project management.
 
 File: org-gtd.info,  Node: Automating through emacs,  Prev: Working with Projects (Advanced),  Up: Using Org GTD
 
-1.4.5 Automating through emacs
+1.4.7 Automating through emacs
 ------------------------------
 
 There's now a few functions you can use when you are doing work within
@@ -6251,7 +6542,7 @@ organized by workflow step.
           Finds delegated items with missing delegate or date
           information.
 
-        • ‘org-gtd-reflect-stuck-single-action-items’
+        • ‘org-gtd-reflect-stuck-next-action-items’
 
           Finds single actions that aren't marked as NEXT.
 
@@ -9991,12 +10282,86 @@ org-gtd provides public API functions for building custom functionality.
 
 * Menu:
 
+* Customizing types::
 * Project Traversal Functions::
 
 
-File: org-gtd.info,  Node: Project Traversal Functions,  Up: Extending org-gtd
+File: org-gtd.info,  Node: Customizing types,  Next: Project Traversal Functions,  Up: Extending org-gtd
 
-1.6.1 Project Traversal Functions
+1.6.1 Customizing types
+-----------------------
+
+The built-in GTD types (next-action, calendar, delegated, tickler,
+someday, habit, reference, trash, quick-action, project) are entries in
+the ‘org-gtd-types’ registry.  Each entry declares wiring fields that
+drive the unified dispatch pipeline: ‘:organize-fn’, ‘:disposition’,
+‘:organize-project-fn’, ‘:prompt-to-refile’, ‘:transient-key’,
+‘:refile-target’, and ‘:hooks’.  Use ‘org-gtd-customize-type’ to
+override fields on a built-in type — you cannot register new top-level
+types.
+
+   • ‘org-gtd-customize-type’
+
+     Override individual fields on a built-in type.  You cannot add
+     brand-new types this way — only customize existing ones.
+
+          ;; Always prompt when refiling calendar items, even without a universal
+          ;; prefix argument:
+          (org-gtd-customize-type 'calendar :prompt-to-refile t)
+
+          ;; Use EBDB contacts for delegation:
+          (org-gtd-customize-type 'delegated
+                                  :properties
+                                  '((:who :org-property "DELEGATED_TO" :type text
+                                          :required t :prompt "Delegate to"
+                                          :input-fn my/ebdb-completing-read)))
+
+   • Hook stages
+
+     Each classification fires six observation-only stages via
+     ‘org-gtd-hooks-run’.  Each stage supports global listeners (run for
+     every type) and per-type local listeners (set via ‘:hooks’ on a
+     type).  The stages, in order, are:
+
+       1. ‘:before-clarify’ — before a heading enters the clarify/WIP
+          flow
+       2. ‘:after-clarify’ — after clarify finishes, before organize
+          begins
+       3. ‘:before-organize’ — before the type's ‘:organize-fn’ runs
+       4. ‘:after-organize’ — after the type's ‘:organize-fn’ runs
+       5. ‘:before-file’ — before the disposition (refile, archive,
+          etc.)
+       6. ‘:after-file’ — after the disposition
+
+     Hooks receive the type symbol and the heading marker; they are for
+     observation and bookkeeping, not for changing the pipeline's
+     behavior.
+
+   • Programmatic item creation
+
+     Use ‘org-gtd-create-item’ as a single entry point for creating
+     items of any registered type:
+
+          (org-gtd-create-item 'next-action "Buy milk")
+
+          (org-gtd-create-item 'calendar "Dentist"
+                               '((:when . "<2026-05-01 Fri 09:00>")))
+
+          (org-gtd-create-item 'delegated "Review draft"
+                               '((:who  . "Alice")
+                                 (:when . "<2026-05-10>")))
+
+   • Refile prompting
+
+     The old ‘org-gtd-refile-prompt-for-types’ customization variable is
+     obsolete.  Use the per-type ‘:prompt-to-refile’ field via
+     ‘org-gtd-customize-type’ instead.  Existing values in
+     ‘org-gtd-refile-prompt-for-types’ are migrated at load time.
+
+
+File: org-gtd.info,  Node: Project Traversal Functions,  Prev: Customizing types,  Up: Extending org-gtd
+
+1.6.2 Project Traversal Functions
 ---------------------------------
 
    • ‘org-gtd-project-map-tasks’
@@ -10082,7 +10447,7 @@ several commands to find problematic items:
      Habits with incorrect configuration
 ‘org-gtd-reflect-stuck-delegated-items’
      Delegated items missing delegate or date information
-‘org-gtd-reflect-stuck-single-action-items’
+‘org-gtd-reflect-stuck-next-action-items’
      Single actions that aren't marked as NEXT
 ‘org-gtd-reflect-stuck-projects’
      Projects that have tasks but no NEXT actions
@@ -10255,559 +10620,576 @@ If you're still having problems:
 
 Tag Table:
 Node: Top736
-Node: Summary3352
-Node: What's new in 407382
-Node: Flexible project dependencies (the big one!)8126
-Node: Simplified keyword configuration9246
-Node: Data-driven configuration10270
-Node: Declarative view language10859
-Node: Better project modification11460
-Node: Updated terminology Review → Reflect11939
-Node: Updated terminology Incubate → Tickler + Someday/Maybe12534
-Node: Enhanced reflect capabilities14084
-Node: Simplified configuration14560
-Node: Per-type refile prompting15042
-Node: Capture timestamps15831
-Node: What you need to do16524
-Node: Previous versions17203
-Node: Setting up Org GTD17437
-Node: Upgrading17841
-Ref: 400 <- 3xx18095
-Ref: Required Configuration changes18390
-Ref: Required Configure org-agenda-files20202
-Ref: Required Data migration20967
-Ref: Required Acknowledge the upgrade23408
-Ref: Why these changes?24814
-Ref: org-gtd-mode has a new purpose25569
-Ref: org-agenda-property has been vendored26134
-Node: Installing27330
-Ref: use-package27597
-Ref: Manually27726
-Node: Configuring28020
-Ref: Basic setup28150
-Ref: Complete Configuration Examples28993
-Ref: Example 1 Vanilla Emacs (Minimal Configuration)29203
-Ref: Example 2 Doom Emacs Configuration32061
-Ref: Example 3 Spacemacs Configuration34319
-Ref: What These Configurations Do36555
-Ref: Testing Your Configuration38121
-Ref: Common Configuration Problems39464
-Ref: Working with Your Existing Org Setup43282
-Ref: Understanding Keybindings45375
-Ref: Global Keybindings45511
-Ref: Clarify Map Keybindings46156
-Ref: Required configuration of sub-packages47397
-Ref: Configuring org-edna47449
-Ref: Adding org-gtd files to your agenda47778
-Ref: configuration options for org-gtd48590
-Ref: I don't care just let me start using it48637
-Ref: Tell me all the levers I can pull49274
-Ref: Required keyword configuration49452
-Ref: Optional configuration52288
-Ref: Recommended key bindings57785
-Ref: Command Center58435
-Ref: Sample Doom Emacs Config59327
-Node: Getting Started with Org GTD60756
-Node: Quick Start Reference61220
-Node: Tutorial Your First Project61762
-Ref: What You'll Learn62219
-Ref: The Project62524
-Ref: Step 1 Capture the Project62831
-Ref: Step 2 Process the Inbox63321
-Ref: Step 3 Organize as a Project63740
-Ref: Step 4 View in Engage64321
-Ref: Step 5 Complete the First Task64840
-Ref: Step 6 Refresh and See the Change65190
-Ref: What Just Happened?65576
-Ref: Continue the Project66563
-Ref: Key Takeaways67006
-Ref: What's Next?67533
-Node: Tutorial Creating Your First Custom View68214
-Ref: What You'll Learn (1)68735
-Ref: Why This View?68967
-Ref: Understanding the View DSL69356
-Ref: Creating the View Function69885
-Ref: Using Your View70362
-Ref: Binding to a Key70508
-Ref: What You'll See71127
-Ref: Experiment Modify the View71543
-Ref: Available Filters72534
-Ref: Key Takeaways (1)74732
-Ref: What's Next? (1)75197
-Node: Tutorial Quick Wins and Focus Work Views75696
-Ref: Why This Matters76141
-Ref: Your First Quick Wins View (30 seconds)76620
-Ref: The Effort Filter Explained77146
-Ref: Building a Focus Work View77845
-Ref: The Priority Filter Explained78386
-Ref: Finding Tasks to Triage79056
-Ref: Bonus The Clocked Filter79659
-Ref: Putting It All Together80368
-Ref: Key Takeaways (2)81539
-Ref: Where to Go From Here81960
-Node: Using Org GTD83137
-Node: Your Daily Workflow83765
-Ref: Quick command reference84625
-Node: The GTD Flow in Depth86159
-Ref: Adding things to the inbox86413
-Ref: Processing the inbox87742
-Ref: Clarifying each item88466
-Ref: How to start clarifying88835
-Ref: data shape requirements89388
-Ref: Options and commands related to clarification90015
-Ref: Duplicating items during clarification92463
-Ref: Your first duplicate in 30 seconds92954
-Ref: Understanding the workflow93395
-Ref: The queue window94202
-Ref: Two ways to duplicate94759
-Ref: What happens if you cancel?95450
-Ref: Nested duplicates96123
-Ref: Data safety96360
-Ref: Configuration96845
-Ref: Organizing an item into the system97239
-Ref: Refiling to the appropriate area98027
-Ref: Understanding Refiling in V498078
-Ref: Refile Target System98529
-Ref: Controlling Refile Prompts by Item Type99735
-Ref: Creating New Refile Targets102240
-Ref: Multiple Types Per Heading103033
-Ref: Using Your Own Refile Targets103756
-Ref: Migration from V3104499
-Ref: Engaging with your GTD items105173
-Ref: Quick Task Actions from the Agenda105709
-Ref: First Contact Why This Feature?105762
-Ref: Black Triangle Your First Quick Action106498
-Ref: Understanding the Actions107337
-Ref: State Changes107496
-Ref: Time Adjustments (Conditional)108046
-Ref: Clocking109136
-Ref: Metadata109349
-Ref: Clarify109902
-Ref: Command Reference110253
-Ref: Suggested Keybinding111593
-Node: Understanding GTD Item Types111963
-Ref: Single Action [S]112480
-Ref: Project [P]113055
-Ref: Add to existing project [A]113967
-Ref: Calendar [C]114732
-Ref: Delegate [D]115491
-Ref: Quick Action [Q]116749
-Ref: Tickler [I]117291
-Ref: Someday/Maybe [y]118826
-Ref: Habit [H]121619
-Ref: Knowledge [K]122233
-Ref: Trash [T]122897
-Ref: Working with the GTD Horizons123671
-Ref: Areas of focus124295
-Ref: Longer-term horizons125696
-Node: Working with Projects (Advanced)127496
-Ref: Quick Navigation127989
-Ref: First Contact Why Visual Project Management?129208
-Ref: Black Triangle Your First Project Graph View130043
-Ref: Step 1 Find a project130144
-Ref: Step 2 Open the graph view130342
-Ref: Step 3 Explore130525
-Ref: Understanding Project Dependencies131149
-Ref: The Dependency Graph (DAG)131291
-Ref: What You See in Graph View131898
-Ref: Sequential vs Parallel vs Mixed132625
-Ref: Tutorial Parallel Tasks with Graph View133628
-Ref: The Scenario133750
-Ref: Step 1 Capture and Organize134206
-Ref: Step 2 Open Graph View134609
-Ref: Step 3 Modify Dependencies to Create Parallel Tasks135255
-Ref: What Graph View CAN Do135931
-Ref: Building Our Parallel Structure136584
-Ref: The Diamond Pattern in Action137462
-Ref: Alternative Approach Add Blockers138012
-Ref: Tutorial Complex Dependencies with Graph View138607
-Ref: The Scenario (1)138667
-Ref: The Dependency Graph139293
-Ref: Building with Graph View139886
-Ref: Creating the Convergence Point140385
-Ref: Building the Rest140866
-Ref: The Complete Graph141416
-Ref: Key Patterns This Example Shows142097
-Ref: Common Dependency Patterns (Visual Reference)142558
-Ref: Sequential Chain (A → B → C)142679
-Ref: Parallel Independent (A B C all start together)143149
-Ref: Fan-out (A → B A → C A → D)143538
-Ref: Fan-in / Convergence (A → C B → C)144047
-Ref: Diamond (A → B → D A → C → D)144506
-Ref: Graph View Command Reference145174
-Ref: Opening Graph View145374
-Ref: Tier 1 Single-Key Commands (Always Available)145672
-Ref: Tier 2 Prefixed Commands149022
-Ref: Visual Indicators150575
-Ref: Operations Not Available in Graph View150881
-Ref: Text-Based Alternatives151704
-Ref: Graph Rendering Modes153039
-Ref: SVG Mode (Default)153241
-Ref: ASCII Mode153602
-Ref: Toggling Modes153987
-Ref: Troubleshooting ASCII Rendering154113
-Ref: Complete Keyboard Reference154476
-Ref: Tier 1 Single Keys154600
-Ref: Tier 2 Task Operations (t prefix)155545
-Ref: Tier 2 Project and View Operations155922
-Ref: Auto-Refresh on File Changes156373
-Ref: Technical Details156868
-Ref: Graph Data Structure156899
-Ref: Layout Algorithm157299
-Ref: Properties Used157655
-Ref: Undo/Redo Support158601
-Ref: Practical Tips for Project Management158980
-Ref: When to Use Graph View159031
-Ref: When to Use Sequential (Default)159438
-Ref: When to Create Parallel Structures159854
-Ref: Managing Complexity160222
-Ref: Growing Projects Over Time160666
-Ref: Canceling Projects161105
-Ref: Exporting Project Graphs162121
-Ref: First Contact What is Graph Export?162159
-Ref: Tutorial Export Your First Graph162901
-Ref: Progressive Learning Choosing Export Formats163463
-Ref: When Exports Differ from Display165304
-Ref: Reference Export Commands165918
-Ref: Troubleshooting Exports166608
-Ref: Troubleshooting Projects with Graph View167396
-Ref: Project is Stuck (has TODO tasks but no NEXT)167450
-Ref: Task Should Be NEXT But Shows as TODO168384
-Ref: Too Many Tasks Are NEXT169034
-Ref: Graph Won't Open169534
-Ref: Graph Shows No Tasks169934
-Ref: Task Shows Wrong State (NEXT vs TODO)170369
-Ref: Can't Modify Dependencies170872
-Ref: See Also171324
-Ref: Tickler Projects Pausing Work You're Not Ready For171821
-Ref: First Contact Why Tickler Projects?171886
-Ref: Black Triangle Tickler Your First Project in 30 Seconds172954
-Ref: Understanding Tickler What Actually Happens173867
-Ref: Tutorial Managing Seasonal Projects176117
-Ref: Common Patterns and Scenarios178581
-Ref: Advanced External Dependencies and Warnings180862
-Ref: Technical Details How Tickler Works Under the Hood183178
-Ref: Troubleshooting Tickler187039
-Ref: See Also (1)190326
-Ref: Project Progress Cookies See Your Progress at a Glance190956
-Ref: First Contact What Are Progress Cookies?191025
-Ref: Black Triangle See Progress in 30 Seconds191586
-Ref: Tutorial Watch Cookies Update Automatically192073
-Ref: Understanding How Cookies Work192887
-Ref: Configuring Cookie Position193959
-Ref: Common Scenarios194793
-Ref: Technical Reference195630
-Ref: Cleaning up / archiving completed work196559
-Ref: Commands you can call on org-agenda197253
-Ref: Defining your own agenda views198051
-Ref: Adding your own hooks when organizing198751
-Node: Automating through emacs200021
-Node: Reference201324
-Node: Configuration Variables Reference202770
-Ref: Required Configuration203077
-Ref: org-todo-keywords (org-mode variable)203113
-Ref: org-gtd-keyword-mapping204200
-Ref: Directory and File Configuration205364
-Ref: org-gtd-directory205410
-Ref: org-gtd-additional-inbox-files206509
-Ref: org-gtd-horizons-file207482
-Ref: Capture Configuration207915
-Ref: org-gtd-capture-templates207950
-Ref: Organize and Process Configuration209230
-Ref: org-gtd-organize-hooks209278
-Ref: org-gtd-save-after-organize210822
-Ref: org-gtd-refile-to-any-target (deprecated)211173
-Ref: org-gtd-refile-prompt-for-types212475
-Ref: Mode-Line Configuration213910
-Ref: org-gtd-mode-update-interval213947
-Ref: org-gtd-mode-lighter-display214838
-Ref: Clarification Configuration215412
-Ref: org-gtd-clarify-show-horizons215453
-Ref: org-gtd-clarify-show-organize-help216217
-Ref: org-gtd-clarify-display-helper-buffer217341
-Ref: org-gtd-clarify-project-templates217990
-Ref: org-gtd-clarify-duplicate-queue-position219191
-Ref: Areas of Focus Configuration220024
-Ref: org-gtd-areas-of-focus220066
-Ref: View Prefix Configuration220718
-Ref: org-gtd-prefix-width220757
-Ref: org-gtd-agenda-truncate-ellipsis221760
-Ref: Archive Configuration222541
-Ref: org-gtd-archive-location222576
-Ref: Missed Engagements Review Configuration224219
-Ref: org-gtd-reflect-missed-custom-views224272
-Ref: Advanced Item Configuration225647
-Ref: org-gtd-user-types225688
-Ref: Agenda Display Configuration229077
-Ref: org-gtd-agenda-property-list229357
-Ref: org-gtd-agenda-property-position229907
-Ref: org-gtd-agenda-property-column230544
-Ref: org-gtd-agenda-property-separator230995
-Ref: Graph View Configuration231355
-Ref: org-gtd-graph-render-mode231464
-Ref: org-gtd-graph-ui-split-ratio232216
-Ref: org-gtd-graph-sibling-mode232989
-Ref: Projects Configuration235437
-Ref: org-gtd-project-progress-cookie-position235473
-Ref: Obsolete Variables (Do Not Use)237653
-Ref: org-gtd-todo-keyword (obsolete)237799
-Ref: org-gtd-next-keyword (obsolete)237927
-Ref: org-gtd-wait-keyword (obsolete)238055
-Ref: org-gtd-canceled-keyword (obsolete)238183
-Node: Commands Reference238307
-Ref: Core GTD Workflow Commands238622
-Ref: org-gtd-command-center238662
-Ref: org-gtd-capture239955
-Ref: org-gtd-process-inbox240599
-Ref: org-gtd-organize241444
-Ref: org-gtd-engage242415
-Ref: org-gtd-show-all-next243221
-Ref: Reflect Commands243614
-Ref: org-gtd-reflect-stuck-projects243644
-Ref: org-gtd-reflect-area-of-focus244212
-Ref: org-gtd-reflect-completed-items244823
-Ref: org-gtd-reflect-completed-projects245373
-Ref: org-gtd-reflect-missed-items245622
-Ref: Stuck Item Review Commands245911
-Ref: org-gtd-reflect-stuck-calendar-items246035
-Ref: org-gtd-reflect-stuck-tickler-items246159
-Ref: org-gtd-reflect-stuck-habit-items246283
-Ref: org-gtd-reflect-stuck-delegated-items246395
-Ref: org-gtd-reflect-stuck-single-action-items246538
-Ref: Reviewing Someday/Maybe Items246654
-Ref: Your First Review in 60 Seconds247278
-Ref: Understanding the Review Workflow247755
-Ref: Tutorial Weekly Someday Review248469
-Ref: Organizing Your Someday Items (Optional)249378
-Ref: Common Patterns250169
-Ref: Command Reference (1)250926
-Ref: org-gtd-reflect-someday-review251385
-Ref: Reflect Commands (Missed Engagements)252400
-Ref: What Are Missed Engagements?252451
-Ref: Your First Review in 30 Seconds253268
-Ref: Understanding the Review Workflow (1)253735
-Ref: Tutorial Daily Review Workflow254483
-Ref: Common Patterns (1)255316
-Ref: Command Reference (2)255828
-Ref: Backward Compatibility Note256588
-Ref: Reflect Commands (Upcoming Delegated)257280
-Ref: What Are Upcoming Delegated Check-ins?257331
-Ref: Your First Review in 30 Seconds (1)258159
-Ref: Understanding Proactive Delegation Management258667
-Ref: Tutorial Weekly Planning Workflow259326
-Ref: Common Patterns (2)260460
-Ref: Understanding What You See261241
-Ref: Comparison Missed vs Upcoming262027
-Ref: Command Reference (3)262537
-Ref: Custom View Commands262962
-Ref: org-gtd-view-show262996
-Ref: Clarification Commands273309
-Ref: org-gtd-clarify-item273345
-Ref: org-gtd-clarify-agenda-item273831
-Ref: org-gtd-clarify-toggle-horizons-window274124
-Ref: org-gtd-clarify-toggle-organize-help274490
-Ref: org-gtd-clarify-project-insert-template275083
-Ref: org-gtd-clarify-duplicate275426
-Ref: org-gtd-clarify-duplicate-exact276278
-Ref: org-gtd-clarify-stop276771
-Ref: Updating Items Without Refiling277162
-Ref: Archive Commands282243
-Ref: org-gtd-archive-completed-items282273
-Ref: Agenda-Specific Commands282798
-Ref: org-gtd-delegate-agenda-item282900
-Ref: org-gtd-project-cancel-from-agenda283263
-Ref: Timestamp Commands (DWIM)283705
-Ref: org-gtd-set-timestamp283861
-Ref: Project Task Commands (DWIM)284548
-Ref: org-gtd-project-add-successor284749
-Ref: org-gtd-project-add-blocker285228
-Ref: org-gtd-project-add-root-task285720
-Ref: org-gtd-project-remove-task286118
-Ref: org-gtd-project-trash-task286530
-Ref: org-gtd-project-change-state286902
-Ref: Project Management Commands287190
-Ref: org-gtd-projects-fix-todo-keywords-for-project-at-point287231
-Ref: org-gtd-projects-fix-all-todo-keywords287881
-Ref: org-gtd-project-update-all-cookies290923
-Ref: org-gtd-tickler292549
-Ref: org-gtd-someday294391
-Ref: org-gtd-reactivate296098
-Ref: Task Dependency Commands298215
-Ref: org-gtd-task-add-blockers298993
-Ref: org-gtd-task-remove-blockers299814
-Ref: org-gtd-task-add-dependent300120
-Ref: org-gtd-task-add-dependents300853
-Ref: org-gtd-task-clear-relationships301125
-Ref: org-gtd-task-show-relationships301498
-Ref: org-gtd-validate-project-dependencies301888
-Ref: org-gtd-remove-task-from-project302362
-Ref: Area of Focus Commands302736
-Ref: org-gtd-area-of-focus-set-on-item-at-point302772
-Ref: org-gtd-area-of-focus-set-on-agenda-item303179
-Ref: Programmatic Creation Commands303554
-Ref: org-gtd-habit-create303703
-Ref: org-gtd-calendar-create303964
-Ref: org-gtd-delegate-create304228
-Ref: org-gtd-tickler-create304952
-Ref: org-gtd-someday-create305245
-Ref: org-gtd-single-action-create305494
-Ref: Utility Commands305715
-Ref: org-gtd-setup-keywords-wizard305745
-Ref: org-gtd-inbox-path306097
-Ref: Migration and Upgrade Commands306511
-Ref: org-gtd-upgrade-v3-to-v4306555
-Ref: Mode-Line Integration307167
-Ref: org-gtd-mode307202
-Ref: org-gtd-inbox-count307945
-Ref: Obsolete Commands308229
-Ref: org-gtd-delegate-item-at-point (removed in 40)308260
-Node: Properties Reference (Internal Implementation)309122
-Ref: Core GTD Properties310011
-Ref: ORG_GTD310044
-Ref: ORG_GTD_REFILE311122
-Ref: Project Properties313473
-Ref: ORG_GTD_FIRST_TASKS313505
-Ref: Task Dependency Properties314444
-Ref: ORG_GTD_DEPENDS_ON314484
-Ref: ORG_GTD_BLOCKS316402
-Ref: ORG_GTD_PROJECT_IDS317239
-Ref: Calendar and Time Properties317589
-Ref: ORG_GTD_TIMESTAMP317631
-Ref: Delegation Properties318573
-Ref: DELEGATED_TO318608
-Ref: Habit Properties319560
-Ref: STYLE319590
-Ref: Area of Focus Properties320061
-Ref: CATEGORY320099
-Ref: Standard Org Properties Used by org-gtd320970
-Ref: ID321023
-Ref: keyword321300
-Ref: SCHEDULED (org-mode standard)321955
-Ref: DEADLINE (org-mode standard)322230
-Node: Troubleshooting Projects322473
-Ref: Fixing Broken Dependencies322994
-Ref: When Manual Property Editing is Needed324281
-Ref: Common Problems and Solutions326077
-Ref: Project Shows No NEXT Tasks (Stuck Project)326120
-Ref: Too Many NEXT Tasks326954
-Ref: Task Won't Advance to NEXT327428
-Ref: Task States Inconsistent After External Edits328130
-Node: View DSL Filter Reference329338
-Ref: Your First Custom View in 60 Seconds329855
-Ref: Understanding View Specs330415
-Ref: Combining Filters330999
-Ref: Multi-Block Views331434
-Ref: Common Patterns (3)332057
-Ref: Weekly Review View332086
-Ref: Morning Planning View332656
-Ref: Area of Focus View333347
-Ref: Filter Reference333987
-Ref: View Structure334127
-Ref: Multi-Block Views (1)334472
-Ref: Block Types335210
-Ref: Native Blocks (Escape Hatch)335731
-Ref: When You'll Need This336191
-Ref: Your First Native Block336867
-Ref: Adding Custom Sorting338036
-Ref: Mixing DSL and Native338898
-Ref: Native Block Types339850
-Ref: Quick Reference340483
-Ref: Type Filters341106
-Ref: (type delegated)341163
-Ref: (type calendar)341448
-Ref: (type project)341703
-Ref: (type active-project)341944
-Ref: (type completed-project)342223
-Ref: (type stuck-project)342529
-Ref: (type tickler)342849
-Ref: (type someday)343136
-Ref: (type habit)343430
-Ref: (type next-action)343652
-Ref: (type tickler-project)343969
-Ref: (type incubated-project)344426
-Ref: (type stuck-delegated)344909
-Ref: (type stuck-calendar)345280
-Ref: (type stuck-tickler)345563
-Ref: (type stuck-habit)345846
-Ref: Time-based Filters346104
-Ref: Semantic Time (when VALUE)346196
-Ref: Deadline (deadline VALUE)347157
-Ref: Scheduled (scheduled VALUE)347402
-Ref: Keyword Filters347657
-Ref: (todo ("KEYWORD1" "KEYWORD2"))347974
-Ref: (done VALUE)348398
-Ref: Area of Focus Filters349683
-Ref: (area-of-focus "AREA")349745
-Ref: Tag Filters350162
-Ref: (tags ("TAG1" "TAG2"))350213
-Ref: (tags-match "PATTERN")350536
-Ref: Priority Effort and Clocked Filters351071
-Ref: (priority VALUE)351213
-Ref: (effort SPEC)352532
-Ref: (clocked SPEC)353737
-Ref: (last-clocked-out SPEC)354855
-Ref: Property Filters356156
-Ref: (property (("PROP" "VALUE")))356228
-Ref: Structural Filters356547
-Ref: (level N)356618
-Ref: Special Filters357018
-Ref: (not-habit t)357047
-Ref: (invalid-timestamp t)357326
-Ref: View Configuration Options357672
-Ref: (block-type TYPE)357767
-Ref: (blocks BLOCK-LIST)358631
-Ref: Prefix DSL Customizing the Task Prefix Column359307
-Ref: Your First Prefix in 60 Seconds359806
-Ref: (prefix (ELEMENT ))360455
-Ref: (prefix-width N)361787
-Ref: Prefix Inheritance in Multi-Block Views362431
-Ref: Low-Level (prefix-format FORMAT-STRING)363614
-Ref: (view-type agenda)364216
-Ref: (agenda-span N)364553
-Ref: Simplified Multi-Block Views364719
-Ref: The Problem Verbose Block Definitions365004
-Ref: The Solution Implicit Blocks365911
-Ref: Try It Now366602
-Ref: Smart Type Defaults367264
-Ref: Top-Level Inheritance368212
-Ref: The Four-Tier Precedence Model368596
-Ref: When to Use Explicit Blocks369760
-Ref: Quick Reference (1)370438
-Ref: Saving Your Custom Views370872
-Node: Hooks Framework Reference371440
-Ref: What Are Organize Hooks?371618
-Ref: Your First Hook in 2 Minutes372165
-Ref: The org-gtd-organize-hooks Variable373192
-Ref: Built-in Hooks373513
-Ref: org-set-tags-command373541
-Ref: org-gtd-set-area-of-focus373819
-Ref: Writing Custom Hooks374400
-Ref: Basic Hook Structure374659
-Ref: Using org-gtd-organize-type-member-p375033
-Ref: Example Custom Hooks376678
-Ref: Selective Tagging with Unless376712
-Ref: Add Effort Estimation377494
-Ref: Add Priority377879
-Ref: Auto-Set Property Based on Keywords378219
-Ref: Add Custom Property378742
-Ref: Integration with Org-Roam379228
-Ref: Set Effort from Keywords379634
-Ref: Hook Execution Order380428
-Ref: Best Practices380801
-Ref: Complete Example Comprehensive Hook Setup381698
-Node: Extending org-gtd383877
-Node: Project Traversal Functions384142
-Ref: org-gtd-project-map-tasks384300
-Ref: org-gtd-projects-map385106
-Node: Troubleshooting385789
-Node: Finding lost tasks386278
-Node: Projects without a NEXT item387287
-Node: I can't create a project when clarifying an inbox item!388547
-Node: Configuration problems389509
-Ref: Keywords not working389783
-Ref: Items not showing in engage view390517
-Node: Tasks still showing after tickler'ing or someday'ing project391327
-Node: Still stuck?392670
+Node: Summary3539
+Node: What's new in 407569
+Node: Flexible project dependencies (the big one!)8313
+Node: Simplified keyword configuration9433
+Node: Data-driven configuration10457
+Node: Declarative view language11046
+Node: Better project modification11647
+Node: Updated terminology Review → Reflect12126
+Node: Updated terminology Incubate → Tickler + Someday/Maybe12721
+Node: Enhanced reflect capabilities14271
+Node: Simplified configuration14747
+Node: Per-type refile prompting15229
+Node: Capture timestamps16018
+Node: What you need to do16711
+Node: Previous versions17390
+Node: Setting up Org GTD17624
+Node: Upgrading18028
+Ref: 400 <- 3xx18282
+Ref: Required Configuration changes18577
+Ref: Required Configure org-agenda-files20389
+Ref: Required Data migration21154
+Ref: Required Acknowledge the upgrade23595
+Ref: Why these changes?25001
+Ref: org-gtd-mode has a new purpose25756
+Ref: org-agenda-property has been vendored26321
+Node: Installing27517
+Ref: use-package27784
+Ref: Manually27913
+Node: Configuring28207
+Ref: Basic setup28337
+Ref: Complete Configuration Examples29180
+Ref: Example 1 Vanilla Emacs (Minimal Configuration)29390
+Ref: Example 2 Doom Emacs Configuration32248
+Ref: Example 3 Spacemacs Configuration34506
+Ref: What These Configurations Do36742
+Ref: Testing Your Configuration38308
+Ref: Common Configuration Problems39651
+Ref: Working with Your Existing Org Setup43469
+Ref: Understanding Keybindings45562
+Ref: Global Keybindings45698
+Ref: Clarify Map Keybindings46343
+Ref: Required configuration of sub-packages47584
+Ref: Configuring org-edna47636
+Ref: Adding org-gtd files to your agenda47965
+Ref: configuration options for org-gtd48777
+Ref: I don't care just let me start using it48824
+Ref: Tell me all the levers I can pull49461
+Ref: Required keyword configuration49639
+Ref: Optional configuration52475
+Ref: Recommended key bindings57972
+Ref: Command Center58622
+Ref: Sample Doom Emacs Config59514
+Node: Getting Started with Org GTD60943
+Node: Quick Start Reference61407
+Node: Tutorial Your First Project61949
+Ref: What You'll Learn62406
+Ref: The Project62711
+Ref: Step 1 Capture the Project63018
+Ref: Step 2 Process the Inbox63508
+Ref: Step 3 Organize as a Project63927
+Ref: Step 4 View in Engage64508
+Ref: Step 5 Complete the First Task65027
+Ref: Step 6 Refresh and See the Change65377
+Ref: What Just Happened?65763
+Ref: Continue the Project66750
+Ref: Key Takeaways67193
+Ref: What's Next?67720
+Node: Tutorial Creating Your First Custom View68401
+Ref: What You'll Learn (1)68922
+Ref: Why This View?69154
+Ref: Understanding the View DSL69543
+Ref: Creating the View Function70072
+Ref: Using Your View70549
+Ref: Binding to a Key70695
+Ref: What You'll See71314
+Ref: Experiment Modify the View71730
+Ref: Available Filters72721
+Ref: Key Takeaways (1)74919
+Ref: What's Next? (1)75384
+Node: Tutorial Quick Wins and Focus Work Views75883
+Ref: Why This Matters76328
+Ref: Your First Quick Wins View (30 seconds)76807
+Ref: The Effort Filter Explained77333
+Ref: Building a Focus Work View78032
+Ref: The Priority Filter Explained78573
+Ref: Finding Tasks to Triage79243
+Ref: Bonus The Clocked Filter79846
+Ref: Putting It All Together80555
+Ref: Key Takeaways (2)81726
+Ref: Where to Go From Here82147
+Node: Using Org GTD83324
+Node: Your Daily Workflow84117
+Ref: Quick command reference84977
+Node: The GTD Flow in Depth86609
+Ref: Adding things to the inbox86845
+Ref: Processing the inbox88174
+Ref: Clarifying each item88898
+Ref: How to start clarifying89267
+Ref: data shape requirements89820
+Ref: Options and commands related to clarification90447
+Ref: Duplicating items during clarification92895
+Ref: Your first duplicate in 30 seconds93386
+Ref: Understanding the workflow93827
+Ref: The queue window94634
+Ref: Two ways to duplicate95191
+Ref: What happens if you cancel?95882
+Ref: Nested duplicates96555
+Ref: Data safety96792
+Ref: Configuration97277
+Ref: Organizing an item into the system97671
+Ref: Refiling to the appropriate area98459
+Ref: Understanding Refiling in V498510
+Ref: Refile Target System98961
+Ref: Controlling Refile Prompts by Item Type100167
+Ref: Creating New Refile Targets102672
+Ref: Multiple Types Per Heading103465
+Ref: Using Your Own Refile Targets104188
+Ref: Migration from V3104931
+Ref: Engaging with your GTD items105605
+Ref: Quick Task Actions from the Agenda106235
+Ref: First Contact Why This Feature?106288
+Ref: Black Triangle Your First Quick Action107024
+Ref: Understanding the Actions107863
+Ref: State Changes108022
+Ref: Time Adjustments (Conditional)108572
+Ref: Clocking109662
+Ref: Metadata109875
+Ref: Clarify110428
+Ref: Command Reference110779
+Ref: Suggested Keybinding112119
+Node: Checklists112489
+Ref: The template file113129
+Ref: Spawning a checklist114218
+Ref: Recurring checklists compose with habits114829
+Ref: Checkbox reset on repeat115516
+Node: Weekly Review (guided)116573
+Ref: Running a session117097
+Ref: Step types118317
+Ref: Pause resume and crash recovery119563
+Ref: Customizing the ritual org-gtd-review-profiles120524
+Ref: Scheduling the review org-gtd-review-schedule123804
+Ref: First-time setup org-gtd-init-system124962
+Node: Understanding GTD Item Types125813
+Ref: Single Action [S]126331
+Ref: Project [P]126906
+Ref: Add to existing project [A]127818
+Ref: Calendar [C]128583
+Ref: Delegate [D]129342
+Ref: Quick Action [Q]130600
+Ref: Tickler [I]131142
+Ref: Someday/Maybe [y]132677
+Ref: Habit [H]135470
+Ref: Knowledge [K]136084
+Ref: Trash [T]136748
+Ref: Working with the GTD Horizons137522
+Ref: Areas of focus138146
+Ref: Longer-term horizons139547
+Node: Working with Projects (Advanced)141347
+Ref: Quick Navigation141840
+Ref: First Contact Why Visual Project Management?143059
+Ref: Black Triangle Your First Project Graph View143894
+Ref: Step 1 Find a project143995
+Ref: Step 2 Open the graph view144193
+Ref: Step 3 Explore144376
+Ref: Understanding Project Dependencies145000
+Ref: The Dependency Graph (DAG)145142
+Ref: What You See in Graph View145749
+Ref: Sequential vs Parallel vs Mixed146476
+Ref: Tutorial Parallel Tasks with Graph View147479
+Ref: The Scenario147601
+Ref: Step 1 Capture and Organize148057
+Ref: Step 2 Open Graph View148460
+Ref: Step 3 Modify Dependencies to Create Parallel Tasks149106
+Ref: What Graph View CAN Do149782
+Ref: Building Our Parallel Structure150435
+Ref: The Diamond Pattern in Action151313
+Ref: Alternative Approach Add Blockers151863
+Ref: Tutorial Complex Dependencies with Graph View152458
+Ref: The Scenario (1)152518
+Ref: The Dependency Graph153144
+Ref: Building with Graph View153737
+Ref: Creating the Convergence Point154236
+Ref: Building the Rest154717
+Ref: The Complete Graph155267
+Ref: Key Patterns This Example Shows155948
+Ref: Common Dependency Patterns (Visual Reference)156409
+Ref: Sequential Chain (A → B → C)156530
+Ref: Parallel Independent (A B C all start together)157000
+Ref: Fan-out (A → B A → C A → D)157389
+Ref: Fan-in / Convergence (A → C B → C)157898
+Ref: Diamond (A → B → D A → C → D)158357
+Ref: Graph View Command Reference159025
+Ref: Opening Graph View159225
+Ref: Tier 1 Single-Key Commands (Always Available)159523
+Ref: Tier 2 Prefixed Commands162873
+Ref: Visual Indicators164426
+Ref: Operations Not Available in Graph View164732
+Ref: Text-Based Alternatives165555
+Ref: Graph Rendering Modes166890
+Ref: SVG Mode (Default)167092
+Ref: ASCII Mode167453
+Ref: Toggling Modes167838
+Ref: Troubleshooting ASCII Rendering167964
+Ref: Complete Keyboard Reference168327
+Ref: Tier 1 Single Keys168451
+Ref: Tier 2 Task Operations (t prefix)169396
+Ref: Tier 2 Project and View Operations169773
+Ref: Auto-Refresh on File Changes170224
+Ref: Technical Details170719
+Ref: Graph Data Structure170750
+Ref: Layout Algorithm171150
+Ref: Properties Used171506
+Ref: Undo/Redo Support172452
+Ref: Practical Tips for Project Management172831
+Ref: When to Use Graph View172882
+Ref: When to Use Sequential (Default)173289
+Ref: When to Create Parallel Structures173705
+Ref: Managing Complexity174073
+Ref: Growing Projects Over Time174517
+Ref: Canceling Projects174956
+Ref: Exporting Project Graphs175972
+Ref: First Contact What is Graph Export?176010
+Ref: Tutorial Export Your First Graph176752
+Ref: Progressive Learning Choosing Export Formats177314
+Ref: When Exports Differ from Display179155
+Ref: Reference Export Commands179769
+Ref: Troubleshooting Exports180459
+Ref: Troubleshooting Projects with Graph View181247
+Ref: Project is Stuck (has TODO tasks but no NEXT)181301
+Ref: Task Should Be NEXT But Shows as TODO182235
+Ref: Too Many Tasks Are NEXT182885
+Ref: Graph Won't Open183385
+Ref: Graph Shows No Tasks183785
+Ref: Task Shows Wrong State (NEXT vs TODO)184220
+Ref: Can't Modify Dependencies184723
+Ref: See Also185175
+Ref: Tickler Projects Pausing Work You're Not Ready For185672
+Ref: First Contact Why Tickler Projects?185737
+Ref: Black Triangle Tickler Your First Project in 30 Seconds186805
+Ref: Understanding Tickler What Actually Happens187718
+Ref: Tutorial Managing Seasonal Projects189968
+Ref: Common Patterns and Scenarios192432
+Ref: Advanced External Dependencies and Warnings194713
+Ref: Technical Details How Tickler Works Under the Hood197029
+Ref: Troubleshooting Tickler200890
+Ref: See Also (1)204177
+Ref: Project Progress Cookies See Your Progress at a Glance204807
+Ref: First Contact What Are Progress Cookies?204876
+Ref: Black Triangle See Progress in 30 Seconds205437
+Ref: Tutorial Watch Cookies Update Automatically205924
+Ref: Understanding How Cookies Work206738
+Ref: Configuring Cookie Position207810
+Ref: Common Scenarios208644
+Ref: Technical Reference209481
+Ref: Cleaning up / archiving completed work210410
+Ref: Commands you can call on org-agenda211104
+Ref: Defining your own agenda views211902
+Ref: Adding your own hooks when organizing212602
+Node: Automating through emacs213872
+Node: Reference215175
+Node: Configuration Variables Reference216621
+Ref: Required Configuration216928
+Ref: org-todo-keywords (org-mode variable)216964
+Ref: org-gtd-keyword-mapping218051
+Ref: Directory and File Configuration219215
+Ref: org-gtd-directory219261
+Ref: org-gtd-additional-inbox-files220360
+Ref: org-gtd-horizons-file221333
+Ref: Capture Configuration221766
+Ref: org-gtd-capture-templates221801
+Ref: Organize and Process Configuration223081
+Ref: org-gtd-organize-hooks223129
+Ref: org-gtd-save-after-organize224673
+Ref: org-gtd-refile-to-any-target (deprecated)225024
+Ref: org-gtd-refile-prompt-for-types226326
+Ref: Mode-Line Configuration227761
+Ref: org-gtd-mode-update-interval227798
+Ref: org-gtd-mode-lighter-display228689
+Ref: Clarification Configuration229263
+Ref: org-gtd-clarify-show-horizons229304
+Ref: org-gtd-clarify-show-organize-help230068
+Ref: org-gtd-clarify-display-helper-buffer231192
+Ref: org-gtd-clarify-project-templates231841
+Ref: org-gtd-clarify-duplicate-queue-position233042
+Ref: Areas of Focus Configuration233875
+Ref: org-gtd-areas-of-focus233917
+Ref: View Prefix Configuration234569
+Ref: org-gtd-prefix-width234608
+Ref: org-gtd-agenda-truncate-ellipsis235611
+Ref: Archive Configuration236392
+Ref: org-gtd-archive-location236427
+Ref: Missed Engagements Review Configuration238070
+Ref: org-gtd-reflect-missed-custom-views238123
+Ref: Advanced Item Configuration239498
+Ref: org-gtd-user-types239539
+Ref: Agenda Display Configuration242928
+Ref: org-gtd-agenda-property-list243208
+Ref: org-gtd-agenda-property-position243758
+Ref: org-gtd-agenda-property-column244395
+Ref: org-gtd-agenda-property-separator244846
+Ref: Graph View Configuration245206
+Ref: org-gtd-graph-render-mode245315
+Ref: org-gtd-graph-ui-split-ratio246067
+Ref: org-gtd-graph-sibling-mode246840
+Ref: Projects Configuration249288
+Ref: org-gtd-project-progress-cookie-position249324
+Ref: Obsolete Variables (Do Not Use)251504
+Ref: org-gtd-todo-keyword (obsolete)251650
+Ref: org-gtd-next-keyword (obsolete)251778
+Ref: org-gtd-wait-keyword (obsolete)251906
+Ref: org-gtd-canceled-keyword (obsolete)252034
+Node: Commands Reference252158
+Ref: Core GTD Workflow Commands252473
+Ref: org-gtd-command-center252513
+Ref: org-gtd-capture253806
+Ref: org-gtd-process-inbox254450
+Ref: org-gtd-organize255295
+Ref: org-gtd-engage256266
+Ref: org-gtd-show-all-next257072
+Ref: Reflect Commands257465
+Ref: org-gtd-reflect-stuck-projects257495
+Ref: org-gtd-reflect-area-of-focus258063
+Ref: org-gtd-reflect-completed-items258674
+Ref: org-gtd-reflect-completed-projects259224
+Ref: org-gtd-reflect-missed-items259473
+Ref: Stuck Item Review Commands259762
+Ref: org-gtd-reflect-stuck-calendar-items259886
+Ref: org-gtd-reflect-stuck-tickler-items260010
+Ref: org-gtd-reflect-stuck-habit-items260134
+Ref: org-gtd-reflect-stuck-delegated-items260246
+Ref: org-gtd-reflect-stuck-next-action-items260389
+Ref: Reviewing Someday/Maybe Items260503
+Ref: Your First Review in 60 Seconds261127
+Ref: Understanding the Review Workflow261604
+Ref: Tutorial Weekly Someday Review262318
+Ref: Organizing Your Someday Items (Optional)263227
+Ref: Common Patterns264018
+Ref: Command Reference (1)264775
+Ref: org-gtd-reflect-someday-review265234
+Ref: Reflect Commands (Missed Engagements)266249
+Ref: What Are Missed Engagements?266300
+Ref: Your First Review in 30 Seconds267117
+Ref: Understanding the Review Workflow (1)267584
+Ref: Tutorial Daily Review Workflow268332
+Ref: Common Patterns (1)269165
+Ref: Command Reference (2)269677
+Ref: Backward Compatibility Note270437
+Ref: Reflect Commands (Upcoming Delegated)271129
+Ref: What Are Upcoming Delegated Check-ins?271180
+Ref: Your First Review in 30 Seconds (1)272008
+Ref: Understanding Proactive Delegation Management272516
+Ref: Tutorial Weekly Planning Workflow273175
+Ref: Common Patterns (2)274309
+Ref: Understanding What You See275090
+Ref: Comparison Missed vs Upcoming275876
+Ref: Command Reference (3)276386
+Ref: Custom View Commands276811
+Ref: org-gtd-view-show276845
+Ref: Clarification Commands287158
+Ref: org-gtd-clarify-item287194
+Ref: org-gtd-clarify-agenda-item287680
+Ref: org-gtd-clarify-toggle-horizons-window287973
+Ref: org-gtd-clarify-toggle-organize-help288339
+Ref: org-gtd-clarify-project-insert-template288932
+Ref: org-gtd-clarify-duplicate289275
+Ref: org-gtd-clarify-duplicate-exact290127
+Ref: org-gtd-clarify-stop290620
+Ref: Updating Items Without Refiling291011
+Ref: Archive Commands296092
+Ref: org-gtd-archive-completed-items296122
+Ref: Agenda-Specific Commands296647
+Ref: org-gtd-delegate-agenda-item296749
+Ref: org-gtd-project-cancel-from-agenda297112
+Ref: Timestamp Commands (DWIM)297554
+Ref: org-gtd-set-timestamp297710
+Ref: Project Task Commands (DWIM)298397
+Ref: org-gtd-project-add-successor298598
+Ref: org-gtd-project-add-blocker299077
+Ref: org-gtd-project-add-root-task299569
+Ref: org-gtd-project-remove-task299967
+Ref: org-gtd-project-trash-task300379
+Ref: org-gtd-project-change-state300751
+Ref: Project Management Commands301039
+Ref: org-gtd-projects-fix-todo-keywords-for-project-at-point301080
+Ref: org-gtd-projects-fix-all-todo-keywords301730
+Ref: org-gtd-project-update-all-cookies304772
+Ref: org-gtd-tickler306398
+Ref: org-gtd-someday308240
+Ref: org-gtd-reactivate309947
+Ref: Task Dependency Commands312064
+Ref: org-gtd-task-add-blockers312842
+Ref: org-gtd-task-remove-blockers313663
+Ref: org-gtd-task-add-dependent313969
+Ref: org-gtd-task-add-dependents314702
+Ref: org-gtd-task-clear-relationships314974
+Ref: org-gtd-task-show-relationships315347
+Ref: org-gtd-validate-project-dependencies315737
+Ref: org-gtd-remove-task-from-project316211
+Ref: Area of Focus Commands316585
+Ref: org-gtd-area-of-focus-set-on-item-at-point316621
+Ref: org-gtd-area-of-focus-set-on-agenda-item317028
+Ref: Programmatic Creation Commands317403
+Ref: org-gtd-habit-create317552
+Ref: org-gtd-calendar-create317813
+Ref: org-gtd-delegate-create318077
+Ref: org-gtd-tickler-create318801
+Ref: org-gtd-someday-create319094
+Ref: org-gtd-single-action-create319343
+Ref: Utility Commands319564
+Ref: org-gtd-setup-keywords-wizard319594
+Ref: org-gtd-inbox-path319946
+Ref: Migration and Upgrade Commands320360
+Ref: org-gtd-upgrade-v3-to-v4320404
+Ref: Mode-Line Integration321016
+Ref: org-gtd-mode321051
+Ref: org-gtd-inbox-count321794
+Ref: Obsolete Commands322078
+Ref: org-gtd-delegate-item-at-point (removed in 40)322109
+Node: Properties Reference (Internal Implementation)322971
+Ref: Core GTD Properties323860
+Ref: ORG_GTD323893
+Ref: ORG_GTD_REFILE324971
+Ref: Project Properties327322
+Ref: ORG_GTD_FIRST_TASKS327354
+Ref: Task Dependency Properties328293
+Ref: ORG_GTD_DEPENDS_ON328333
+Ref: ORG_GTD_BLOCKS330251
+Ref: ORG_GTD_PROJECT_IDS331088
+Ref: Calendar and Time Properties331438
+Ref: ORG_GTD_TIMESTAMP331480
+Ref: Delegation Properties332422
+Ref: DELEGATED_TO332457
+Ref: Habit Properties333409
+Ref: STYLE333439
+Ref: Area of Focus Properties333910
+Ref: CATEGORY333948
+Ref: Standard Org Properties Used by org-gtd334819
+Ref: ID334872
+Ref: keyword335149
+Ref: SCHEDULED (org-mode standard)335804
+Ref: DEADLINE (org-mode standard)336079
+Node: Troubleshooting Projects336322
+Ref: Fixing Broken Dependencies336843
+Ref: When Manual Property Editing is Needed338130
+Ref: Common Problems and Solutions339926
+Ref: Project Shows No NEXT Tasks (Stuck Project)339969
+Ref: Too Many NEXT Tasks340803
+Ref: Task Won't Advance to NEXT341277
+Ref: Task States Inconsistent After External Edits341979
+Node: View DSL Filter Reference343187
+Ref: Your First Custom View in 60 Seconds343704
+Ref: Understanding View Specs344264
+Ref: Combining Filters344848
+Ref: Multi-Block Views345283
+Ref: Common Patterns (3)345906
+Ref: Weekly Review View345935
+Ref: Morning Planning View346505
+Ref: Area of Focus View347196
+Ref: Filter Reference347836
+Ref: View Structure347976
+Ref: Multi-Block Views (1)348321
+Ref: Block Types349059
+Ref: Native Blocks (Escape Hatch)349580
+Ref: When You'll Need This350040
+Ref: Your First Native Block350716
+Ref: Adding Custom Sorting351885
+Ref: Mixing DSL and Native352747
+Ref: Native Block Types353699
+Ref: Quick Reference354332
+Ref: Type Filters354955
+Ref: (type delegated)355012
+Ref: (type calendar)355297
+Ref: (type project)355552
+Ref: (type active-project)355793
+Ref: (type completed-project)356072
+Ref: (type stuck-project)356378
+Ref: (type tickler)356698
+Ref: (type someday)356985
+Ref: (type habit)357279
+Ref: (type next-action)357501
+Ref: (type tickler-project)357818
+Ref: (type incubated-project)358275
+Ref: (type stuck-delegated)358758
+Ref: (type stuck-calendar)359129
+Ref: (type stuck-tickler)359412
+Ref: (type stuck-habit)359695
+Ref: Time-based Filters359953
+Ref: Semantic Time (when VALUE)360045
+Ref: Deadline (deadline VALUE)361006
+Ref: Scheduled (scheduled VALUE)361251
+Ref: Keyword Filters361506
+Ref: (todo ("KEYWORD1" "KEYWORD2"))361823
+Ref: (done VALUE)362247
+Ref: Area of Focus Filters363532
+Ref: (area-of-focus "AREA")363594
+Ref: Tag Filters364011
+Ref: (tags ("TAG1" "TAG2"))364062
+Ref: (tags-match "PATTERN")364385
+Ref: Priority Effort and Clocked Filters364920
+Ref: (priority VALUE)365062
+Ref: (effort SPEC)366381
+Ref: (clocked SPEC)367586
+Ref: (last-clocked-out SPEC)368704
+Ref: Property Filters370005
+Ref: (property (("PROP" "VALUE")))370077
+Ref: Structural Filters370396
+Ref: (level N)370467
+Ref: Special Filters370867
+Ref: (not-habit t)370896
+Ref: (invalid-timestamp t)371175
+Ref: View Configuration Options371521
+Ref: (block-type TYPE)371616
+Ref: (blocks BLOCK-LIST)372480
+Ref: Prefix DSL Customizing the Task Prefix Column373156
+Ref: Your First Prefix in 60 Seconds373655
+Ref: (prefix (ELEMENT ))374304
+Ref: (prefix-width N)375636
+Ref: Prefix Inheritance in Multi-Block Views376280
+Ref: Low-Level (prefix-format FORMAT-STRING)377463
+Ref: (view-type agenda)378065
+Ref: (agenda-span N)378402
+Ref: Simplified Multi-Block Views378568
+Ref: The Problem Verbose Block Definitions378853
+Ref: The Solution Implicit Blocks379760
+Ref: Try It Now380451
+Ref: Smart Type Defaults381113
+Ref: Top-Level Inheritance382061
+Ref: The Four-Tier Precedence Model382445
+Ref: When to Use Explicit Blocks383609
+Ref: Quick Reference (1)384287
+Ref: Saving Your Custom Views384721
+Node: Hooks Framework Reference385289
+Ref: What Are Organize Hooks?385467
+Ref: Your First Hook in 2 Minutes386014
+Ref: The org-gtd-organize-hooks Variable387041
+Ref: Built-in Hooks387362
+Ref: org-set-tags-command387390
+Ref: org-gtd-set-area-of-focus387668
+Ref: Writing Custom Hooks388249
+Ref: Basic Hook Structure388508
+Ref: Using org-gtd-organize-type-member-p388882
+Ref: Example Custom Hooks390527
+Ref: Selective Tagging with Unless390561
+Ref: Add Effort Estimation391343
+Ref: Add Priority391728
+Ref: Auto-Set Property Based on Keywords392068
+Ref: Add Custom Property392591
+Ref: Integration with Org-Roam393077
+Ref: Set Effort from Keywords393483
+Ref: Hook Execution Order394277
+Ref: Best Practices394650
+Ref: Complete Example Comprehensive Hook Setup395547
+Node: Extending org-gtd397726
+Node: Customizing types398013
+Ref: org-gtd-customize-type398700
+Ref: Hook stages399424
+Ref: Programmatic item creation400336
+Ref: Refile prompting400827
+Node: Project Traversal Functions401123
+Ref: org-gtd-project-map-tasks401307
+Ref: org-gtd-projects-map402113
+Node: Troubleshooting402796
+Node: Finding lost tasks403285
+Node: Projects without a NEXT item404292
+Node: I can't create a project when clarifying an inbox item!405552
+Node: Configuration problems406514
+Ref: Keywords not working406788
+Ref: Items not showing in engage view407522
+Node: Tasks still showing after tickler'ing or someday'ing project408332
+Node: Still stuck?409675
 
 End Tag Table
 

--- a/test/helpers/setup.el
+++ b/test/helpers/setup.el
@@ -146,7 +146,14 @@ Kills GTD-related buffers and clears org-mode internal state."
                      (string-match-p "\\*Warnings\\*" (buffer-name buffer))
                      (and (buffer-file-name buffer)
                           (or (string-match-p "org-gtd" (buffer-file-name buffer))
-                              (string-match-p "/mock:" (buffer-file-name buffer))))))
+                              (string-match-p "/mock:" (buffer-file-name buffer))))
+                     ;; Any buffer living in the mock filesystem (e.g.
+                     ;; *GTD Review*, created with default-directory under
+                     ;; /mock:) must not survive into later tests: after
+                     ;; mock-fs teardown its directory no longer exists.
+                     (let ((dir (buffer-local-value 'default-directory buffer)))
+                       (and (stringp dir)
+                            (string-prefix-p "/mock:" dir)))))
         (push buffer buffers-to-kill)))
 
     (when buffers-to-kill

--- a/test/helpers/setup.el
+++ b/test/helpers/setup.el
@@ -45,6 +45,28 @@
        (or load-file-name byte-compile-current-file buffer-file-name))))))
   "Absolute path to the project root directory.")
 
+;;; Mock-FS Subprocess Workaround
+
+(defun ogt-eunit--org-id-new-in-real-dir (orig-fn &rest args)
+  "Call ORIG-FN (`org-id-new') with a real `default-directory'.
+`org-id-new' shells out to the `uuidgen' program, and launching a
+subprocess makes Emacs chdir into `default-directory'.  Inside a test
+the current buffer usually lives under the virtual /mock:/gtd/, which
+has no real backing directory, so the chdir fails with \"Setting current
+directory ... No such file or directory\".  The failure is order
+dependent: it bites whenever a fresh ID is created while a mock-fs
+buffer is current (deterministically reproducible with, e.g., seed
+1783402152928884).
+
+Bind `default-directory' to the real project root for ID creation -- the
+generated ID does not depend on the working directory.  In production
+`org-gtd-directory' is a real path, so this never affects users; it is
+purely a mock-fs test-harness concern."
+  (let ((default-directory ogt-eunit--project-root))
+    (apply orig-fn args)))
+
+(advice-add 'org-id-new :around #'ogt-eunit--org-id-new-in-real-dir)
+
 ;;; Custom Assertions
 
 (defun assert-same-items (expected actual)
@@ -259,6 +281,18 @@ between tests."
          (ogt-eunit--cleanup)))))
 
 (setup-suite
+ ;; Point org-id's persistent location database at a throwaway file for the
+ ;; whole run.  org-id records every ID it sees -- including IDs in temp files
+ ;; created under the mocked /mock:/tmp/ -- and `org-id-locations-save' writes
+ ;; those paths to a *real* on-disk file.  Left at its default, that file lives
+ ;; inside the checkout and accumulates /mock: paths that survive across runs;
+ ;; a later `org-id' lookup reloads them and `file-truename's them through the
+ ;; always-registered mock-fs handler while `mock-fs--current' is nil, crashing
+ ;; with `(wrong-type-argument hash-table-p nil)'.  A fresh temp file each run
+ ;; keeps the poison from persisting.  (Set here, before any test runs and
+ ;; while the real filesystem is still active.)
+ (setq org-id-locations-file
+       (make-temp-file "ogt-eunit-org-id-locations"))
  (setq inhibit-message t)
  ;; Suppress noisy org-mode state change messages during tests
  ;; e.g., "TODO state changed to NEXT", "TODO state was already TODO"

--- a/test/helpers/utils.el
+++ b/test/helpers/utils.el
@@ -41,6 +41,17 @@ Return the buffer visiting that file."
       (basic-save-buffer))
     buffer))
 
+(defun ogt--transient-suffix-plist (prefix key)
+  "Return the suffix plist bound to KEY in transient PREFIX.
+Transient stores a suffix's plist either inline, as (CLASS :key ...),
+or nested, as (LEVEL CLASS (:key ...)), depending on version/compilation.
+Normalize both shapes to the bare plist."
+  (let ((suffix (transient-get-suffix prefix key)))
+    (or (seq-find (lambda (elt) (and (consp elt) (keywordp (car elt))))
+                  suffix)
+        (seq-drop-while (lambda (elt) (not (keywordp elt)))
+                        suffix))))
+
 (defun ogt--buffer-string (buffer)
   "Return buffer's content."
   (with-current-buffer buffer

--- a/test/unit/accessors-test.el
+++ b/test/unit/accessors-test.el
@@ -27,7 +27,22 @@
         org-gtd-keyword-mapping '((todo . "TODO")
                                   (next . "NEXT")
                                   (wait . "WAIT")
-                                  (canceled . "CNCL"))))
+                                  (canceled . "CNCL")))
+  ;; These are pure unit tests that do not use `ogt-eunit-with-mock-gtd', so
+  ;; they never run `ogt-eunit--clear-org-state'.  Reset org-id's global scan
+  ;; state here so a lookup of a non-existent ID cannot inherit a stale
+  ;; /mock:/... path from an earlier mock-fs test.  `org-id-find' triggers
+  ;; `org-id-update-id-locations', which `file-truename's every path in
+  ;; `org-id-files'/`org-agenda-files'; a leftover /mock: path is dispatched to
+  ;; the (always-registered) mock-fs handler while `mock-fs--current' is nil,
+  ;; signalling `(wrong-type-argument hash-table-p nil)'.  A fresh empty
+  ;; locations hash also stops org-id from reloading the on-disk
+  ;; `.org-id-locations' file, which can itself carry /mock: paths across runs.
+  (setq org-agenda-files nil
+        org-id-files nil
+        org-id-extra-files nil
+        org-id--locations-checksum nil
+        org-id-locations (make-hash-table :test 'equal)))
 
 ;;;; Property Readers - org-gtd-get-task-dependencies
 

--- a/test/unit/checklist-reset-test.el
+++ b/test/unit/checklist-reset-test.el
@@ -11,8 +11,10 @@
 ;; completed and re-armed by org.
 ;;
 ;; Test Coverage:
-;; - Repeating heading resets its checkboxes on completion (1 test)
+;; - Repeating heading resets its checkboxes and cookie on completion (1 test)
 ;; - Non-repeating heading keeps its checkboxes on completion (1 test)
+;; - Cancelled (zero-interval) repeater keeps its checkboxes (1 test)
+;; - Done-to-done transition on a repeating heading keeps boxes (1 test)
 ;; - org-gtd-mode installs and removes the reset hook (1 test)
 ;;
 ;;; Code:
@@ -46,11 +48,36 @@ with the reset hook installed."
 (deftest checklist-reset/repeating-heading-resets-boxes-on-done ()
   "Completing a repeating heading clears its checkboxes and re-arms."
   (checklist-reset--with-heading
-      "* TODO Weekly triggers\nSCHEDULED: <2026-07-10 Fri .+1w>\n- [X] Boss?\n- [ ] Car?\n"
+      "* TODO Weekly triggers [1/2]\nSCHEDULED: <2026-07-10 Fri .+1w>\n- [X] Boss?\n- [ ] Car?\n"
     (let ((org-inhibit-logging t) (org-log-repeat nil))
       (org-todo "DONE"))
     (assert-nil (string-match-p "\\[X\\]" (buffer-string)))
-    (assert-match "\\* TODO Weekly triggers" (buffer-string))))
+    (assert-match "\\* TODO Weekly triggers \\[0/2\\]" (buffer-string))))
+
+(deftest checklist-reset/cancelled-repeater-keeps-boxes ()
+  "Finishing a repeating task for good keeps its checkboxes.
+`org-todo' with -1 cancels the repeater first (interval becomes zero,
+the documented C-- 1 C-c C-t flow); org does not re-arm, so the
+completion record must stay intact."
+  (let ((org-todo-keywords '((sequence "TODO" "|" "DONE"))))
+    (checklist-reset--with-heading
+        "* TODO Weekly triggers\nSCHEDULED: <2026-07-10 Fri .+1w>\n- [X] Boss?\n- [ ] Car?\n"
+      (let ((org-inhibit-logging t) (org-log-repeat nil))
+        (org-todo -1))
+      (assert-match "\\[X\\] Boss\\?" (buffer-string))
+      (assert-match "\\* DONE Weekly triggers" (buffer-string)))))
+
+(deftest checklist-reset/done-to-done-keeps-boxes ()
+  "A done-to-done transition on a repeating heading does not reset.
+Org only re-arms when a done state is entered from a non-done one;
+the reset guard must match."
+  (let ((org-todo-keywords '((sequence "TODO" "|" "DONE" "CANCELED"))))
+    (checklist-reset--with-heading
+        "* DONE Weekly triggers\nSCHEDULED: <2026-07-10 Fri .+1w>\n- [X] Boss?\n- [ ] Car?\n"
+      (let ((org-inhibit-logging t) (org-log-repeat nil))
+        (org-todo "CANCELED"))
+      (assert-match "\\[X\\] Boss\\?" (buffer-string))
+      (assert-match "\\* CANCELED Weekly triggers" (buffer-string)))))
 
 (deftest checklist-reset/plain-done-keeps-boxes ()
   "Completing a non-repeating heading leaves checkboxes alone."

--- a/test/unit/checklist-reset-test.el
+++ b/test/unit/checklist-reset-test.el
@@ -1,0 +1,77 @@
+;;; checklist-reset-test.el --- Tests for checkbox reset on repeater re-arm -*- lexical-binding: t; coding: utf-8 -*-
+
+;; Copyright (C) 2026 Aldric Giacomoni
+
+;; Author: Aldric Giacomoni <trevoke@gmail.com>
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+;;
+;; Unit tests for resetting checkboxes when a repeating heading is
+;; completed and re-armed by org.
+;;
+;; Test Coverage:
+;; - Repeating heading resets its checkboxes on completion (1 test)
+;; - Non-repeating heading keeps its checkboxes on completion (1 test)
+;; - org-gtd-mode installs and removes the reset hook (1 test)
+;;
+;;; Code:
+
+(require 'ogt-eunit-prelude "test/helpers/prelude.el")
+(require 'org-gtd-checklist)
+(require 'org-gtd-mode)
+
+(e-unit-initialize)
+
+(around-each (proceed context)
+  (ogt-eunit-with-mock-gtd
+    (funcall proceed context)))
+
+(defmacro checklist-reset--with-heading (text &rest body)
+  "Run BODY in an org buffer containing TEXT, point on first heading,
+with the reset hook installed."
+  (declare (indent 1))
+  `(with-temp-buffer
+     (org-mode)
+     (insert ,text)
+     (goto-char (point-min))
+     (add-hook 'org-after-todo-state-change-hook
+               #'org-gtd-checklist--maybe-reset-checkboxes)
+     (unwind-protect (progn ,@body)
+       (remove-hook 'org-after-todo-state-change-hook
+                    #'org-gtd-checklist--maybe-reset-checkboxes))))
+
+;;; Reset Behavior Tests
+
+(deftest checklist-reset/repeating-heading-resets-boxes-on-done ()
+  "Completing a repeating heading clears its checkboxes and re-arms."
+  (checklist-reset--with-heading
+      "* TODO Weekly triggers\nSCHEDULED: <2026-07-10 Fri .+1w>\n- [X] Boss?\n- [ ] Car?\n"
+    (let ((org-inhibit-logging t) (org-log-repeat nil))
+      (org-todo "DONE"))
+    (assert-nil (string-match-p "\\[X\\]" (buffer-string)))
+    (assert-match "\\* TODO Weekly triggers" (buffer-string))))
+
+(deftest checklist-reset/plain-done-keeps-boxes ()
+  "Completing a non-repeating heading leaves checkboxes alone."
+  (checklist-reset--with-heading
+      "* TODO Beach packing\n- [X] Sunscreen\n- [ ] Towel\n"
+    (let ((org-inhibit-logging t))
+      (org-todo "DONE"))
+    (assert-match "\\[X\\] Sunscreen" (buffer-string))))
+
+;;; Mode Wiring Tests
+
+(deftest checklist-reset/org-gtd-mode-installs-hook ()
+  "org-gtd-mode adds and removes the reset hook."
+  (org-gtd-mode 1)
+  (unwind-protect
+      (assert-true (memq #'org-gtd-checklist--maybe-reset-checkboxes
+                         org-after-todo-state-change-hook))
+    (org-gtd-mode -1))
+  (assert-nil (memq #'org-gtd-checklist--maybe-reset-checkboxes
+                    org-after-todo-state-change-hook)))
+
+(provide 'checklist-reset-test)
+
+;;; checklist-reset-test.el ends here

--- a/test/unit/checklist-test.el
+++ b/test/unit/checklist-test.el
@@ -1,0 +1,45 @@
+;;; checklist-test.el --- Tests for org-gtd checklist templates -*- lexical-binding: t; coding: utf-8 -*-
+
+;; Copyright (C) 2026 Aldric Giacomoni
+
+;; Author: Aldric Giacomoni <trevoke@gmail.com>
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+;;
+;; Unit tests for org-gtd checklist templates.
+;;
+;; Test Coverage:
+;; - Lazy creation and seeding of checklists.org (2 tests)
+;;
+;;; Code:
+
+(require 'ogt-eunit-prelude "test/helpers/prelude.el")
+(require 'org-gtd-checklist)
+
+(e-unit-initialize)
+
+(around-each (proceed context)
+  (ogt-eunit-with-mock-gtd
+    (funcall proceed context)))
+
+;;; File Creation and Seeding Tests
+
+(deftest checklist/file-is-created-with-starter-templates ()
+  "First touch creates checklists.org seeded with starter trigger lists."
+  (let ((buf (org-gtd-checklist--file-buffer)))
+    (with-current-buffer buf
+      (assert-match "\\* Weekly Review triggers" (buffer-string))
+      (assert-match "\\* Mind sweep prompts" (buffer-string))
+      (assert-match "- \\[ \\]" (buffer-string)))))
+
+(deftest checklist/seeding-is-idempotent ()
+  "Touching the file twice does not duplicate the starters."
+  (org-gtd-checklist--file-buffer)
+  (with-current-buffer (org-gtd-checklist--file-buffer)
+    (goto-char (point-min))
+    (assert-equal 1 (count-matches "^\\* Weekly Review triggers$"))))
+
+(provide 'checklist-test)
+
+;;; checklist-test.el ends here

--- a/test/unit/checklist-test.el
+++ b/test/unit/checklist-test.el
@@ -40,6 +40,33 @@
     (goto-char (point-min))
     (assert-equal 1 (count-matches "^\\* Weekly Review triggers$"))))
 
+;;; Template Names and Items Tests
+
+(deftest checklist/names-lists-top-level-headings ()
+  "Template names are the top-level heading titles."
+  (assert-equal '("Weekly Review triggers" "Mind sweep prompts")
+                (org-gtd-checklist-names)))
+
+(deftest checklist/items-returns-ordered-item-strings ()
+  "Items of a named checklist come back as ordered plain strings."
+  (let ((items (org-gtd-checklist--items "Mind sweep prompts")))
+    (assert-equal "Boss, partners, colleagues?" (car items))
+    (assert-equal 8 (length items))))
+
+(deftest checklist/items-ignores-checked-state ()
+  "A checked box still yields its item text."
+  (with-current-buffer (org-gtd-checklist--file-buffer)
+    (goto-char (point-min))
+    (search-forward "- [ ] Boss")
+    (replace-match "- [X] Boss")
+    (basic-save-buffer))
+  (assert-equal "Boss, partners, colleagues?"
+                (car (org-gtd-checklist--items "Mind sweep prompts"))))
+
+(deftest checklist/items-nil-for-unknown-name ()
+  "Unknown checklist name returns nil, no error."
+  (assert-nil (org-gtd-checklist--items "No such list")))
+
 (provide 'checklist-test)
 
 ;;; checklist-test.el ends here

--- a/test/unit/checklist-test.el
+++ b/test/unit/checklist-test.el
@@ -152,6 +152,33 @@
          (progn (org-gtd-checklist-template-insert "Mind sweep prompts") nil)
        (user-error e)))))
 
+(deftest checklist/insert-declared-for-org-mode ()
+  "The command declares org-mode so M-x hides it in other major modes."
+  (assert-equal '(org-mode)
+                (command-modes 'org-gtd-checklist-template-insert)))
+
+(deftest checklist/insert-mid-body-line-not-split ()
+  "Point in the middle of a body line leaves that line intact."
+  (with-temp-buffer
+    (org-mode)
+    (insert "* Heading\nbody before and after\n")
+    (goto-char (point-min))
+    (search-forward "before ")
+    (org-gtd-checklist-template-insert "Mind sweep prompts")
+    (assert-match "^body before and after$" (buffer-string))
+    (assert-match "^\\*\\* Mind sweep prompts" (buffer-string))))
+
+(deftest checklist/insert-in-body-adds-no-blank-line ()
+  "Inserting at the end of a body line adds no blank line before the template."
+  (with-temp-buffer
+    (org-mode)
+    (insert "* Heading\nbody line\n")
+    (goto-char (point-min))
+    (search-forward "body line")
+    (end-of-line)
+    (org-gtd-checklist-template-insert "Mind sweep prompts")
+    (assert-match "^body line\n\\*\\* Mind sweep prompts" (buffer-string))))
+
 ;;; Visit Tests
 
 (deftest checklist/visit-opens-checklists-file ()

--- a/test/unit/checklist-test.el
+++ b/test/unit/checklist-test.el
@@ -16,6 +16,7 @@
 
 (require 'ogt-eunit-prelude "test/helpers/prelude.el")
 (require 'org-gtd-checklist)
+(require 'with-simulated-input)
 
 (e-unit-initialize)
 
@@ -66,6 +67,35 @@
 (deftest checklist/items-nil-for-unknown-name ()
   "Unknown checklist name returns nil, no error."
   (assert-nil (org-gtd-checklist--items "No such list")))
+
+;;; Insert Tests
+
+(deftest checklist/insert-copies-subtree-at-point ()
+  "Insert spawns the named template as a subtree at point."
+  (with-temp-buffer
+    (org-mode)
+    (with-simulated-input "Weekly SPC Review SPC triggers RET"
+      (call-interactively #'org-gtd-checklist-insert))
+    (assert-match "^\\* Weekly Review triggers" (buffer-string))
+    (assert-match "- \\[ \\] Projects started" (buffer-string))))
+
+(deftest checklist/insert-adapts-level-to-context ()
+  "Inserting under an existing heading demotes the copy."
+  (with-temp-buffer
+    (org-mode)
+    (insert "* Trip to the beach\n")
+    (goto-char (point-max))
+    (org-gtd-checklist-insert "Mind sweep prompts")
+    (assert-match "^\\*\\* Mind sweep prompts" (buffer-string))))
+
+(deftest checklist/insert-unknown-name-errors-cleanly ()
+  "Unknown name signals a user-error naming the file."
+  (with-temp-buffer
+    (org-mode)
+    (assert-true
+     (condition-case e
+         (progn (org-gtd-checklist-insert "Nope") nil)
+       (user-error e)))))
 
 (provide 'checklist-test)
 

--- a/test/unit/checklist-test.el
+++ b/test/unit/checklist-test.el
@@ -11,6 +11,9 @@
 ;;
 ;; Test Coverage:
 ;; - Lazy creation and seeding of checklists.org (2 tests)
+;; - Template name and item parsing, normalization (6 tests)
+;; - Inserting template instances at point (6 tests)
+;; - Visiting the checklists file (1 test)
 ;;
 ;;; Code:
 
@@ -68,6 +71,24 @@
   "Unknown checklist name returns nil, no error."
   (assert-nil (org-gtd-checklist--items "No such list")))
 
+(deftest checklist/tagged-heading-resolves-by-bare-name ()
+  "Tags on a template heading do not leak into its name."
+  (with-current-buffer (org-gtd-checklist--file-buffer)
+    (goto-char (point-max))
+    (insert "* Packing list :travel:\n- [ ] Socks?\n")
+    (basic-save-buffer))
+  (assert-true (member "Packing list" (org-gtd-checklist-names)))
+  (assert-equal '("Socks?") (org-gtd-checklist--items "Packing list")))
+
+(deftest checklist/comment-headings-are-excluded ()
+  "COMMENT headings are not offered as templates."
+  (with-current-buffer (org-gtd-checklist--file-buffer)
+    (goto-char (point-max))
+    (insert "* COMMENT Draft list\n- [ ] Not ready?\n")
+    (basic-save-buffer))
+  (assert-nil (member "Draft list" (org-gtd-checklist-names)))
+  (assert-nil (member "COMMENT Draft list" (org-gtd-checklist-names))))
+
 ;;; Insert Tests
 
 (deftest checklist/insert-copies-subtree-at-point ()
@@ -92,10 +113,51 @@
   "Unknown name signals a user-error naming the file."
   (with-temp-buffer
     (org-mode)
+    (let ((err (condition-case e
+                   (progn (org-gtd-checklist-insert "Nope") nil)
+                 (user-error e))))
+      (assert-true err)
+      (assert-match "checklists\\.org" (cadr err)))))
+
+(deftest checklist/insert-at-heading-bol-inserts-child-below ()
+  "Point at bol of a heading inserts the template as a child below it."
+  (with-temp-buffer
+    (org-mode)
+    (insert "* Trip to the beach\nsome body text\n")
+    (goto-char (point-min))
+    (org-gtd-checklist-insert "Mind sweep prompts")
+    (assert-match "^\\* Trip to the beach$" (buffer-string))
+    (assert-match "^\\*\\* Mind sweep prompts" (buffer-string))
+    ;; The template lands after its parent heading, not above it.
+    (goto-char (point-min))
+    (assert-true (search-forward "* Trip to the beach" nil t))
+    (assert-true (search-forward "** Mind sweep prompts" nil t))))
+
+(deftest checklist/insert-mid-heading-line-keeps-heading-intact ()
+  "Point in the middle of a heading line does not split the heading."
+  (with-temp-buffer
+    (org-mode)
+    (insert "* Trip to the beach\n")
+    (goto-char (point-min))
+    (search-forward "Trip to")
+    (org-gtd-checklist-insert "Mind sweep prompts")
+    (assert-match "^\\* Trip to the beach$" (buffer-string))
+    (assert-match "^\\*\\* Mind sweep prompts" (buffer-string))))
+
+(deftest checklist/insert-requires-org-mode ()
+  "Refuses to insert into a non-org buffer."
+  (with-temp-buffer
     (assert-true
      (condition-case e
-         (progn (org-gtd-checklist-insert "Nope") nil)
+         (progn (org-gtd-checklist-insert "Mind sweep prompts") nil)
        (user-error e)))))
+
+;;; Visit Tests
+
+(deftest checklist/visit-opens-checklists-file ()
+  "Visit command selects a buffer visiting the checklists file."
+  (org-gtd-checklist-visit)
+  (assert-match "checklists\\.org" (buffer-file-name)))
 
 (provide 'checklist-test)
 

--- a/test/unit/checklist-test.el
+++ b/test/unit/checklist-test.el
@@ -10,10 +10,10 @@
 ;; Unit tests for org-gtd checklist templates.
 ;;
 ;; Test Coverage:
-;; - Lazy creation and seeding of checklists.org (2 tests)
+;; - Lazy creation and seeding of checklist-templates.org (2 tests)
 ;; - Template name and item parsing, normalization (6 tests)
 ;; - Inserting template instances at point (6 tests)
-;; - Visiting the checklists file (1 test)
+;; - Visiting the checklist templates file (1 test)
 ;;
 ;;; Code:
 
@@ -30,8 +30,8 @@
 ;;; File Creation and Seeding Tests
 
 (deftest checklist/file-is-created-with-starter-templates ()
-  "First touch creates checklists.org seeded with starter trigger lists."
-  (let ((buf (org-gtd-checklist--file-buffer)))
+  "First touch creates checklist-templates.org seeded with starter trigger lists."
+  (let ((buf (org-gtd-checklist-template--file-buffer)))
     (with-current-buffer buf
       (assert-match "\\* Weekly Review triggers" (buffer-string))
       (assert-match "\\* Mind sweep prompts" (buffer-string))
@@ -39,8 +39,8 @@
 
 (deftest checklist/seeding-is-idempotent ()
   "Touching the file twice does not duplicate the starters."
-  (org-gtd-checklist--file-buffer)
-  (with-current-buffer (org-gtd-checklist--file-buffer)
+  (org-gtd-checklist-template--file-buffer)
+  (with-current-buffer (org-gtd-checklist-template--file-buffer)
     (goto-char (point-min))
     (assert-equal 1 (count-matches "^\\* Weekly Review triggers$"))))
 
@@ -49,45 +49,45 @@
 (deftest checklist/names-lists-top-level-headings ()
   "Template names are the top-level heading titles."
   (assert-equal '("Weekly Review triggers" "Mind sweep prompts")
-                (org-gtd-checklist-names)))
+                (org-gtd-checklist-template-names)))
 
 (deftest checklist/items-returns-ordered-item-strings ()
   "Items of a named checklist come back as ordered plain strings."
-  (let ((items (org-gtd-checklist--items "Mind sweep prompts")))
+  (let ((items (org-gtd-checklist-template--items "Mind sweep prompts")))
     (assert-equal "Boss, partners, colleagues?" (car items))
     (assert-equal 8 (length items))))
 
 (deftest checklist/items-ignores-checked-state ()
   "A checked box still yields its item text."
-  (with-current-buffer (org-gtd-checklist--file-buffer)
+  (with-current-buffer (org-gtd-checklist-template--file-buffer)
     (goto-char (point-min))
     (search-forward "- [ ] Boss")
     (replace-match "- [X] Boss")
     (basic-save-buffer))
   (assert-equal "Boss, partners, colleagues?"
-                (car (org-gtd-checklist--items "Mind sweep prompts"))))
+                (car (org-gtd-checklist-template--items "Mind sweep prompts"))))
 
 (deftest checklist/items-nil-for-unknown-name ()
   "Unknown checklist name returns nil, no error."
-  (assert-nil (org-gtd-checklist--items "No such list")))
+  (assert-nil (org-gtd-checklist-template--items "No such list")))
 
 (deftest checklist/tagged-heading-resolves-by-bare-name ()
   "Tags on a template heading do not leak into its name."
-  (with-current-buffer (org-gtd-checklist--file-buffer)
+  (with-current-buffer (org-gtd-checklist-template--file-buffer)
     (goto-char (point-max))
     (insert "* Packing list :travel:\n- [ ] Socks?\n")
     (basic-save-buffer))
-  (assert-true (member "Packing list" (org-gtd-checklist-names)))
-  (assert-equal '("Socks?") (org-gtd-checklist--items "Packing list")))
+  (assert-true (member "Packing list" (org-gtd-checklist-template-names)))
+  (assert-equal '("Socks?") (org-gtd-checklist-template--items "Packing list")))
 
 (deftest checklist/comment-headings-are-excluded ()
   "COMMENT headings are not offered as templates."
-  (with-current-buffer (org-gtd-checklist--file-buffer)
+  (with-current-buffer (org-gtd-checklist-template--file-buffer)
     (goto-char (point-max))
     (insert "* COMMENT Draft list\n- [ ] Not ready?\n")
     (basic-save-buffer))
-  (assert-nil (member "Draft list" (org-gtd-checklist-names)))
-  (assert-nil (member "COMMENT Draft list" (org-gtd-checklist-names))))
+  (assert-nil (member "Draft list" (org-gtd-checklist-template-names)))
+  (assert-nil (member "COMMENT Draft list" (org-gtd-checklist-template-names))))
 
 ;;; Insert Tests
 
@@ -96,7 +96,7 @@
   (with-temp-buffer
     (org-mode)
     (with-simulated-input "Weekly SPC Review SPC triggers RET"
-      (call-interactively #'org-gtd-checklist-insert))
+      (call-interactively #'org-gtd-checklist-template-insert))
     (assert-match "^\\* Weekly Review triggers" (buffer-string))
     (assert-match "- \\[ \\] Projects started" (buffer-string))))
 
@@ -106,7 +106,7 @@
     (org-mode)
     (insert "* Trip to the beach\n")
     (goto-char (point-max))
-    (org-gtd-checklist-insert "Mind sweep prompts")
+    (org-gtd-checklist-template-insert "Mind sweep prompts")
     (assert-match "^\\*\\* Mind sweep prompts" (buffer-string))))
 
 (deftest checklist/insert-unknown-name-errors-cleanly ()
@@ -114,10 +114,10 @@
   (with-temp-buffer
     (org-mode)
     (let ((err (condition-case e
-                   (progn (org-gtd-checklist-insert "Nope") nil)
+                   (progn (org-gtd-checklist-template-insert "Nope") nil)
                  (user-error e))))
       (assert-true err)
-      (assert-match "checklists\\.org" (cadr err)))))
+      (assert-match "checklist-templates\\.org" (cadr err)))))
 
 (deftest checklist/insert-at-heading-bol-inserts-child-below ()
   "Point at bol of a heading inserts the template as a child below it."
@@ -125,7 +125,7 @@
     (org-mode)
     (insert "* Trip to the beach\nsome body text\n")
     (goto-char (point-min))
-    (org-gtd-checklist-insert "Mind sweep prompts")
+    (org-gtd-checklist-template-insert "Mind sweep prompts")
     (assert-match "^\\* Trip to the beach$" (buffer-string))
     (assert-match "^\\*\\* Mind sweep prompts" (buffer-string))
     ;; The template lands after its parent heading, not above it.
@@ -140,7 +140,7 @@
     (insert "* Trip to the beach\n")
     (goto-char (point-min))
     (search-forward "Trip to")
-    (org-gtd-checklist-insert "Mind sweep prompts")
+    (org-gtd-checklist-template-insert "Mind sweep prompts")
     (assert-match "^\\* Trip to the beach$" (buffer-string))
     (assert-match "^\\*\\* Mind sweep prompts" (buffer-string))))
 
@@ -149,15 +149,15 @@
   (with-temp-buffer
     (assert-true
      (condition-case e
-         (progn (org-gtd-checklist-insert "Mind sweep prompts") nil)
+         (progn (org-gtd-checklist-template-insert "Mind sweep prompts") nil)
        (user-error e)))))
 
 ;;; Visit Tests
 
 (deftest checklist/visit-opens-checklists-file ()
   "Visit command selects a buffer visiting the checklists file."
-  (org-gtd-checklist-visit)
-  (assert-match "checklists\\.org" (buffer-file-name)))
+  (org-gtd-checklist-template-visit)
+  (assert-match "checklist-templates\\.org" (buffer-file-name)))
 
 (provide 'checklist-test)
 

--- a/test/unit/command-center-test.el
+++ b/test/unit/command-center-test.el
@@ -47,6 +47,19 @@
   (assert-true (fboundp 'org-gtd-reflect-completed-items))
   (assert-true (fboundp 'org-gtd-reflect-completed-projects)))
 
+(deftest command-center-has-checklists-entry ()
+  "The Reflect group binds l to visiting checklists."
+  (assert-true (fboundp 'org-gtd-checklist-visit))
+  ;; Transient stores a suffix's plist either inline, as (CLASS :key ...),
+  ;; or nested, as (LEVEL CLASS (:key ...)), depending on version/compilation.
+  (let* ((suffix (transient-get-suffix 'org-gtd-command-center "l"))
+         (plist (or (seq-find (lambda (elt) (and (consp elt) (keywordp (car elt))))
+                              suffix)
+                    (seq-drop-while (lambda (elt) (not (keywordp elt)))
+                                    suffix))))
+    (assert-equal "l" (plist-get plist :key))
+    (assert-equal 'org-gtd-checklist-visit (plist-get plist :command))))
+
 (deftest command-center-has-stuck-items-submenu ()
   "Command center has a stuck items sub-menu."
   (assert-true (fboundp 'org-gtd-command-center--stuck)))

--- a/test/unit/command-center-test.el
+++ b/test/unit/command-center-test.el
@@ -17,6 +17,7 @@
 
 (require 'e-unit)
 (require 'org-gtd)
+(require 'org-gtd-test-helper-utils "test/helpers/utils.el")
 
 ;; Initialize e-unit short syntax
 (e-unit-initialize)
@@ -50,15 +51,16 @@
 (deftest command-center-has-checklists-entry ()
   "The Reflect group binds l to visiting checklists."
   (assert-true (fboundp 'org-gtd-checklist-visit))
-  ;; Transient stores a suffix's plist either inline, as (CLASS :key ...),
-  ;; or nested, as (LEVEL CLASS (:key ...)), depending on version/compilation.
-  (let* ((suffix (transient-get-suffix 'org-gtd-command-center "l"))
-         (plist (or (seq-find (lambda (elt) (and (consp elt) (keywordp (car elt))))
-                              suffix)
-                    (seq-drop-while (lambda (elt) (not (keywordp elt)))
-                                    suffix))))
+  (let ((plist (ogt--transient-suffix-plist 'org-gtd-command-center "l")))
     (assert-equal "l" (plist-get plist :key))
     (assert-equal 'org-gtd-checklist-visit (plist-get plist :command))))
+
+(deftest command-center-has-guided-review-entry ()
+  "The Reflect group binds w to the guided review."
+  (assert-true (fboundp 'org-gtd-review))
+  (let ((plist (ogt--transient-suffix-plist 'org-gtd-command-center "w")))
+    (assert-equal "w" (plist-get plist :key))
+    (assert-equal 'org-gtd-review (plist-get plist :command))))
 
 (deftest command-center-has-stuck-items-submenu ()
   "Command center has a stuck items sub-menu."

--- a/test/unit/command-center-test.el
+++ b/test/unit/command-center-test.el
@@ -50,10 +50,10 @@
 
 (deftest command-center-has-checklists-entry ()
   "The Reflect group binds l to visiting checklists."
-  (assert-true (fboundp 'org-gtd-checklist-visit))
+  (assert-true (fboundp 'org-gtd-checklist-template-visit))
   (let ((plist (ogt--transient-suffix-plist 'org-gtd-command-center "l")))
     (assert-equal "l" (plist-get plist :key))
-    (assert-equal 'org-gtd-checklist-visit (plist-get plist :command))))
+    (assert-equal 'org-gtd-checklist-template-visit (plist-get plist :command))))
 
 (deftest command-center-has-guided-review-entry ()
   "The Reflect group binds w to the guided review."

--- a/test/unit/init-system-test.el
+++ b/test/unit/init-system-test.el
@@ -38,14 +38,14 @@
     (org-gtd-init-system))
   (assert-true (file-exists-p (org-gtd--path org-gtd-default-file-name)))
   (assert-true (file-exists-p (org-gtd-inbox-path)))
-  (assert-true (file-exists-p (org-gtd-checklist--file-path))))
+  (assert-true (file-exists-p (org-gtd-checklist-template--file-path))))
 
 (deftest init-system/is-idempotent ()
   "Running init twice neither errors nor duplicates seeds."
   (cl-letf (((symbol-function 'y-or-n-p) (lambda (_prompt) nil)))
     (org-gtd-init-system)
     (org-gtd-init-system))
-  (with-current-buffer (org-gtd-checklist--file-buffer)
+  (with-current-buffer (org-gtd-checklist-template--file-buffer)
     (goto-char (point-min))
     (assert-equal 1 (count-matches "^\\* Weekly Review triggers$"))))
 

--- a/test/unit/init-system-test.el
+++ b/test/unit/init-system-test.el
@@ -1,0 +1,87 @@
+;;; init-system-test.el --- Tests for org-gtd-init-system -*- lexical-binding: t; coding: utf-8 -*-
+
+;; Copyright (C) 2026 Aldric Giacomoni
+
+;; Author: Aldric Giacomoni <trevoke@gmail.com>
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+;;
+;; Unit tests for `org-gtd-init-system', the idempotent first-time
+;; setup concierge.
+;;
+;; Test Coverage:
+;; - All GTD files are created (1 test)
+;; - Running twice neither errors nor duplicates seeds (1 test)
+;; - Accepting the offer routes into org-gtd-review-schedule (1 test)
+;; - An existing reminder skips the offer entirely (1 test)
+;;
+;;; Code:
+
+(require 'ogt-eunit-prelude "test/helpers/prelude.el")
+(require 'org-gtd-init)
+(require 'cl-lib)
+
+(e-unit-initialize)
+
+(around-each (proceed context)
+  (ogt-eunit-with-mock-gtd
+    (funcall proceed context)))
+
+;;; File Creation Tests
+
+(deftest init-system/creates-all-gtd-files ()
+  "Init ensures tasks, inbox, and seeded checklists files exist."
+  (cl-letf (((symbol-function 'y-or-n-p) (lambda (_prompt) nil)))
+    (org-gtd-init-system))
+  (assert-true (file-exists-p (org-gtd--path org-gtd-default-file-name)))
+  (assert-true (file-exists-p (org-gtd-inbox-path)))
+  (assert-true (file-exists-p (org-gtd-checklist--file-path))))
+
+(deftest init-system/is-idempotent ()
+  "Running init twice neither errors nor duplicates seeds."
+  (cl-letf (((symbol-function 'y-or-n-p) (lambda (_prompt) nil)))
+    (org-gtd-init-system)
+    (org-gtd-init-system))
+  (with-current-buffer (org-gtd-checklist--file-buffer)
+    (goto-char (point-min))
+    (assert-equal 1 (count-matches "^\\* Weekly Review triggers$"))))
+
+;;; Review Schedule Offer Tests
+
+(deftest init-system/offers-review-schedule ()
+  "Answering yes routes into org-gtd-review-schedule.
+The real schedule command runs, wrapped so it receives concrete
+arguments instead of prompting (stubbing `read-string', a C subr,
+trips native-comp trampolines under the mock fs)."
+  (let ((real-schedule (symbol-function 'org-gtd-review-schedule)))
+    (cl-letf (((symbol-function 'y-or-n-p) (lambda (_prompt) t))
+              ((symbol-function 'org-gtd-review-schedule)
+               (lambda ()
+                 (interactive)
+                 (funcall real-schedule "Weekly Review" "2026-07-10" ".+1w"))))
+      (org-gtd-init-system)))
+  (ogt--save-all-buffers)
+  (with-current-buffer (org-gtd--default-file)
+    (let ((text (buffer-string)))
+      (assert-match "Weekly Review" text)
+      (assert-match ":ORG_GTD: +Habit" text))))
+
+(deftest init-system/skips-offer-when-reminder-exists ()
+  "An existing reminder reports as such and never offers to schedule."
+  (org-gtd-review-schedule "Weekly Review" "2026-07-10" ".+1w")
+  (let ((captured nil))
+    (cl-letf (((symbol-function 'y-or-n-p)
+               (lambda (_prompt) (error "y-or-n-p must not be called")))
+              ((symbol-function 'message)
+               (lambda (fmt &rest args)
+                 (when fmt (push (apply #'format fmt args) captured))
+                 nil)))
+      (org-gtd-init-system))
+    (assert-true
+     (seq-find (lambda (m) (string-match-p "already scheduled" m))
+               captured))))
+
+(provide 'init-system-test)
+
+;;; init-system-test.el ends here

--- a/test/unit/init-system-test.el
+++ b/test/unit/init-system-test.el
@@ -15,6 +15,8 @@
 ;; - Running twice neither errors nor duplicates seeds (1 test)
 ;; - Accepting the offer routes into org-gtd-review-schedule (1 test)
 ;; - An existing reminder skips the offer entirely (1 test)
+;; - Declining the offer still closes with a files-ready message (1 test)
+;; - A file-error while ensuring files becomes a teaching user-error (1 test)
 ;;
 ;;; Code:
 
@@ -79,8 +81,38 @@ trips native-comp trampolines under the mock fs)."
                  nil)))
       (org-gtd-init-system))
     (assert-true
-     (seq-find (lambda (m) (string-match-p "already scheduled" m))
+     (seq-find (lambda (m)
+                 (string-match-p "GTD files ready in .*review reminder is already scheduled" m))
                captured))))
+
+(deftest init-system/declined-offer-closes-with-files-ready ()
+  "Declining the offer still ends with a files-ready closing message."
+  (let ((events nil))
+    (cl-letf (((symbol-function 'y-or-n-p)
+               (lambda (_prompt) (push 'prompt events) nil))
+              ((symbol-function 'message)
+               (lambda (fmt &rest args)
+                 (when fmt (push (apply #'format fmt args) events))
+                 nil)))
+      (org-gtd-init-system))
+    ;; events is most-recent-first: the closing message must come after
+    ;; the declined prompt so the n-path doesn't end silently.
+    (assert-true (memq 'prompt events))
+    (assert-true (stringp (car events)))
+    (assert-match "GTD files ready in " (car events))))
+
+;;; Error Handling Tests
+
+(deftest init-system/file-error-becomes-teaching-user-error ()
+  "A file-error while ensuring files becomes a teaching user-error."
+  (cl-letf (((symbol-function 'org-gtd--ensure-file-exists)
+             (lambda (&rest _) (signal 'file-error (list "Permission denied")))))
+    (let ((err (condition-case e
+                   (progn (org-gtd-init-system) nil)
+                 (user-error e))))
+      (assert-true err)
+      (assert-match "Could not create GTD files" (cadr err))
+      (assert-match "org-gtd-directory" (cadr err)))))
 
 (provide 'init-system-test)
 

--- a/test/unit/init-system-test.el
+++ b/test/unit/init-system-test.el
@@ -112,6 +112,7 @@ trips native-comp trampolines under the mock fs)."
                  (user-error e))))
       (assert-true err)
       (assert-match "Could not create GTD files" (cadr err))
+      (assert-match "Permission denied" (cadr err))
       (assert-match "org-gtd-directory" (cadr err)))))
 
 (provide 'init-system-test)

--- a/test/unit/review-schedule-test.el
+++ b/test/unit/review-schedule-test.el
@@ -1,0 +1,101 @@
+;;; review-schedule-test.el --- Tests for org-gtd-review-schedule -*- lexical-binding: t; coding: utf-8 -*-
+
+;; Copyright (C) 2026 Aldric Giacomoni
+
+;; Author: Aldric Giacomoni <trevoke@gmail.com>
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+;;
+;; Unit tests for `org-gtd-review-schedule', the command that creates a
+;; recurring habit reminding the user to run their review, and for
+;; `org-gtd-review--reminder-exists-p', the predicate that detects one.
+;;
+;; Test Coverage:
+;; - Scheduling creates a typed, repeating habit (1 test)
+;; - Reminder detection before and after scheduling (2 tests)
+;; - Session completion tip conditional on a reminder existing (2 tests)
+;;
+;;; Code:
+
+(require 'ogt-eunit-prelude "test/helpers/prelude.el")
+(require 'org-gtd-review)
+(require 'cl-lib)
+
+(e-unit-initialize)
+
+(around-each (proceed context)
+  (ogt-eunit-with-mock-gtd
+    (setq org-gtd-review--state nil
+          org-gtd-review--window-config nil)
+    (when (get-buffer org-gtd-review--buffer-name)
+      (kill-buffer org-gtd-review--buffer-name))
+    (let ((state-file (f-join org-gtd-directory "review-state.eld")))
+      (when (file-exists-p state-file)
+        (delete-file state-file)))
+    (funcall proceed context)))
+
+;;; Scheduling Tests
+
+(deftest review-schedule/creates-habit-with-repeater ()
+  "Scheduling creates a properly-typed habit in the tasks file."
+  (org-gtd-review-schedule "Weekly Review" "2026-07-10" ".+1w")
+  (ogt--save-all-buffers)
+  (with-current-buffer (org-gtd--default-file)
+    (let ((text (buffer-string)))
+      (assert-match "Weekly Review" text)
+      (assert-match ":ORG_GTD: +Habit" text)
+      (assert-match "SCHEDULED: <2026-07-10 [A-Za-z]+ \\.\\+1w>" text)
+      (assert-match "M-x org-gtd-review" text))))
+
+;;; Reminder Detection Tests
+
+(deftest review-schedule/reminder-exists-p-nil-on-empty-tasks-file ()
+  "With no habit in the tasks file, no reminder is detected."
+  (assert-nil (org-gtd-review--reminder-exists-p)))
+
+(deftest review-schedule/reminder-exists-p-t-after-scheduling ()
+  "After scheduling, the reminder is detected."
+  (org-gtd-review-schedule "Weekly Review" "2026-07-10" ".+1w")
+  (assert-true (org-gtd-review--reminder-exists-p)))
+
+;;; Completion Tip Tests
+
+(defvar review-schedule-test--tiny-profile
+  '(("Tiny"
+     ("Phase A"
+      (:title "Step one" :type prompt))))
+  "Minimal one-step profile so a session completes in one keypress.")
+
+(defun review-schedule-test--complete-session-messages ()
+  "Run a Tiny session to completion, returning the messages emitted."
+  (let ((captured nil))
+    (cl-letf (((symbol-function 'message)
+               (lambda (fmt &rest args)
+                 (when fmt (push (apply #'format fmt args) captured))
+                 nil)))
+      (org-gtd-review "Tiny")
+      (with-current-buffer org-gtd-review--buffer-name
+        (org-gtd-review-next)))
+    captured))
+
+(deftest review-schedule/finish-tip-shown-without-reminder ()
+  "Completing a session with no reminder scheduled shows the tip."
+  (let ((org-gtd-review-profiles review-schedule-test--tiny-profile))
+    (let ((messages (review-schedule-test--complete-session-messages)))
+      (assert-true
+       (seq-find (lambda (m) (string-match-p "org-gtd-review-schedule" m))
+                 messages)))))
+
+(deftest review-schedule/finish-tip-suppressed-when-reminder-exists ()
+  "Completing a session after scheduling omits the one-time tip."
+  (let ((org-gtd-review-profiles review-schedule-test--tiny-profile))
+    (org-gtd-review-schedule "Tiny" "2026-07-10" ".+1w")
+    (let ((messages (review-schedule-test--complete-session-messages)))
+      (assert-nil
+       (seq-find (lambda (m) (string-match-p "org-gtd-review-schedule" m))
+                 messages)))))
+
+(provide 'review-schedule-test)
+
+;;; review-schedule-test.el ends here

--- a/test/unit/review-schedule-test.el
+++ b/test/unit/review-schedule-test.el
@@ -14,7 +14,7 @@
 ;; Test Coverage:
 ;; - Scheduling creates a typed, repeating habit (1 test)
 ;; - Body line targets the created habit, decoys and tags aside (2 tests)
-;; - Repeater validation and empty-profiles guard (2 tests)
+;; - Repeater validation and empty-profiles guard (3 tests)
 ;; - Duplicate-reminder confirmation guard (2 tests)
 ;; - Reminder detection before and after scheduling (2 tests)
 ;; - Session completion tip conditional on a reminder existing (2 tests)
@@ -93,6 +93,22 @@
   (ogt--save-all-buffers)
   (with-current-buffer (org-gtd--default-file)
     (assert-nil (string-match-p "Weekly Review" (buffer-string)))))
+
+(deftest review-schedule/rejects-zero-interval-repeater ()
+  "A zero-interval repeater never re-arms, so it is refused.
+Multi-digit intervals like .+10d remain accepted."
+  (let ((err (condition-case e
+                 (progn
+                   (org-gtd-review-schedule "Weekly Review" "2026-07-10" ".+0w")
+                   nil)
+               (user-error e))))
+    (assert-true err)
+    (assert-match "\\.\\+1w" (cadr err)))
+  (org-gtd-review-schedule "Weekly Review" "2026-07-10" ".+10d")
+  (ogt--save-all-buffers)
+  (with-current-buffer (org-gtd--default-file)
+    (assert-match "SCHEDULED: <2026-07-10 [A-Za-z]+ \\.\\+10d>"
+                  (buffer-string))))
 
 (deftest review-schedule/no-profiles-configured-errors ()
   "Scheduling with no profiles signals a clean user-error."

--- a/test/unit/review-schedule-test.el
+++ b/test/unit/review-schedule-test.el
@@ -13,6 +13,9 @@
 ;;
 ;; Test Coverage:
 ;; - Scheduling creates a typed, repeating habit (1 test)
+;; - Body line targets the created habit, decoys and tags aside (2 tests)
+;; - Repeater validation and empty-profiles guard (2 tests)
+;; - Duplicate-reminder confirmation guard (2 tests)
 ;; - Reminder detection before and after scheduling (2 tests)
 ;; - Session completion tip conditional on a reminder existing (2 tests)
 ;;
@@ -47,6 +50,80 @@
       (assert-match ":ORG_GTD: +Habit" text)
       (assert-match "SCHEDULED: <2026-07-10 [A-Za-z]+ \\.\\+1w>" text)
       (assert-match "M-x org-gtd-review" text))))
+
+;;; Heading Targeting Tests
+
+(deftest review-schedule/body-line-lands-under-habit-not-decoy ()
+  "A pre-existing heading ending in the profile name is not the target."
+  (with-current-buffer (org-gtd--default-file)
+    (org-with-wide-buffer
+     (goto-char (point-max))
+     (insert "\n* Notes on Weekly Review\nScribbles.\n")
+     (basic-save-buffer)))
+  (org-gtd-review-schedule "Weekly Review" "2026-07-10" ".+1w")
+  (ogt--save-all-buffers)
+  (with-current-buffer (org-gtd--default-file)
+    (org-with-wide-buffer
+     (goto-char (point-min))
+     (search-forward "Run M-x org-gtd-review")
+     (assert-equal "Weekly Review" (org-get-heading t t t t)))))
+
+(deftest review-schedule/body-line-added-despite-tags ()
+  "Organize hooks that tag the heading do not break body insertion."
+  (let ((org-gtd-organize-hooks (list (lambda () (org-set-tags ":review:")))))
+    (org-gtd-review-schedule "Weekly Review" "2026-07-10" ".+1w"))
+  (ogt--save-all-buffers)
+  (with-current-buffer (org-gtd--default-file)
+    (let ((text (buffer-string)))
+      (assert-match ":review:" text)
+      (assert-match "Run M-x org-gtd-review when you sit down for this\\."
+                    text))))
+
+;;; Input Validation Tests
+
+(deftest review-schedule/rejects-malformed-repeater ()
+  "A repeater org cannot parse is refused before anything is written."
+  (let ((err (condition-case e
+                 (progn
+                   (org-gtd-review-schedule "Weekly Review" "2026-07-10" "weekly")
+                   nil)
+               (user-error e))))
+    (assert-true err)
+    (assert-match "\\.\\+1w" (cadr err)))
+  (ogt--save-all-buffers)
+  (with-current-buffer (org-gtd--default-file)
+    (assert-nil (string-match-p "Weekly Review" (buffer-string)))))
+
+(deftest review-schedule/no-profiles-configured-errors ()
+  "Scheduling with no profiles signals a clean user-error."
+  (let ((org-gtd-review-profiles nil))
+    (let ((err (condition-case e
+                   (progn (org-gtd-review-schedule) nil)
+                 (user-error e))))
+      (assert-true err)
+      (assert-match "No review profiles configured" (cadr err)))))
+
+;;; Duplicate Guard Tests
+
+(deftest review-schedule/declining-duplicate-keeps-single-reminder ()
+  "When a reminder exists, answering no schedules nothing new."
+  (org-gtd-review-schedule "Weekly Review" "2026-07-10" ".+1w")
+  (cl-letf (((symbol-function 'y-or-n-p) (lambda (_prompt) nil)))
+    (org-gtd-review-schedule "Weekly Review" "2026-07-10" ".+1w"))
+  (ogt--save-all-buffers)
+  (with-current-buffer (org-gtd--default-file)
+    (goto-char (point-min))
+    (assert-equal 1 (count-matches "Run M-x org-gtd-review when"))))
+
+(deftest review-schedule/confirming-duplicate-schedules-again ()
+  "Explicit confirmation allows a second reminder."
+  (org-gtd-review-schedule "Weekly Review" "2026-07-10" ".+1w")
+  (cl-letf (((symbol-function 'y-or-n-p) (lambda (_prompt) t)))
+    (org-gtd-review-schedule "Weekly Review" "2026-07-10" ".+1w"))
+  (ogt--save-all-buffers)
+  (with-current-buffer (org-gtd--default-file)
+    (goto-char (point-min))
+    (assert-equal 2 (count-matches "Run M-x org-gtd-review when"))))
 
 ;;; Reminder Detection Tests
 

--- a/test/unit/review-test.el
+++ b/test/unit/review-test.el
@@ -13,7 +13,7 @@
 ;; - Default Weekly Review profile shape (2 tests)
 ;; - Session lifecycle: start, advance, complete, skip (4 tests)
 ;; - Entry guards, profile validation, teardown safety (10 tests)
-;; - Pause / resume / quit persistence (6 tests)
+;; - Pause / resume / quit persistence and checkpointing (14 tests)
 ;;
 ;;; Code:
 
@@ -397,7 +397,10 @@
     (org-gtd-review)                       ; no resume prompt: state invalid
     (with-current-buffer org-gtd-review--buffer-name
       (assert-match "Sole" (buffer-string)))
-    (assert-nil (file-exists-p (org-gtd-review--state-file)))))
+    ;; The stale save is replaced by the fresh session's checkpoint.
+    (assert-equal 0 (plist-get (org-gtd-review--load-state) :step))
+    (assert-true (org-gtd-review--state-valid-p
+                  (org-gtd-review--load-state)))))
 
 (deftest review/completion-deletes-state-file ()
   "Finishing a resumed session removes review-state.eld."
@@ -435,6 +438,156 @@
         (org-gtd-review-quit)))
     (assert-nil org-gtd-review--state)
     (assert-nil (file-exists-p (org-gtd-review--state-file)))))
+
+(deftest review/pause-without-session-errors-and-preserves-save ()
+  "A stray M-x pause with no session must not clobber a saved pause."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (org-gtd-review-pause))            ; save at step two
+    (let ((err (condition-case e
+                   (progn (org-gtd-review-pause) nil)
+                 (user-error e))))
+      (assert-true err))
+    (assert-equal 1 (plist-get (org-gtd-review--load-state) :step))))
+
+(deftest review/quit-without-session-errors-and-preserves-save ()
+  "A stray M-x quit with no session must not delete a saved pause."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (org-gtd-review-pause))
+    (cl-letf (((symbol-function 'y-or-n-p) (lambda (_prompt) nil)))
+      (let ((err (condition-case e
+                     (progn (org-gtd-review-quit) nil)
+                   (user-error e))))
+        (assert-true err)))
+    (assert-equal 1 (plist-get (org-gtd-review--load-state) :step))))
+
+(deftest review/declining-resume-then-abort-keeps-save ()
+  "n to resume, then C-g at the profile picker, keeps the pause resumable."
+  (let ((org-gtd-review-profiles
+         (append review-test--tiny-profile
+                 '(("Other" ("P" (:title "Elsewhere" :type prompt)))))))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (org-gtd-review-pause))
+    (cl-letf (((symbol-function 'y-or-n-p) (lambda (_prompt) nil))
+              ((symbol-function 'completing-read)
+               (lambda (&rest _) (signal 'quit nil))))
+      (condition-case nil (org-gtd-review) (quit nil)))
+    (assert-equal 1 (plist-get (org-gtd-review--load-state) :step))
+    ;; The declined-but-aborted pause is still resumable.
+    (cl-letf (((symbol-function 'y-or-n-p) (lambda (_prompt) t)))
+      (org-gtd-review))
+    (with-current-buffer org-gtd-review--buffer-name
+      (assert-match "Step two" (buffer-string)))))
+
+(deftest review/kill-buffer-leaves-checkpoint-resumable ()
+  "C-x k mid-session leaves a checkpoint; re-entry resumes in place."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (org-gtd-review-next))             ; now on Phase B / Step three
+    (kill-buffer org-gtd-review--buffer-name)
+    (assert-nil org-gtd-review--state)
+    (cl-letf (((symbol-function 'y-or-n-p) (lambda (_prompt) t)))
+      (org-gtd-review))
+    (with-current-buffer org-gtd-review--buffer-name
+      (assert-match "Step three" (buffer-string)))))
+
+(deftest review/kill-mid-walk-resumes-at-item ()
+  "Killing the buffer mid-walk resumes at the checkpointed item."
+  (let ((org-gtd-review-profiles review-test--walk-profile))
+    (org-gtd-review "Walk")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)              ; load walk, item 1
+      (org-gtd-review-next))             ; item 2
+    (kill-buffer org-gtd-review--buffer-name)
+    (cl-letf (((symbol-function 'y-or-n-p) (lambda (_prompt) t)))
+      (org-gtd-review))
+    (with-current-buffer org-gtd-review--buffer-name
+      (assert-match "(2/8)" (buffer-string)))))
+
+(deftest review/mangled-state-file-starts-fresh ()
+  "A readable but incoherent save starts fresh, without an error loop."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (with-temp-file (org-gtd-review--state-file)
+      (prin1 '(:profile "Tiny" :phase 0 :step 0 :acted t
+               :walk-items ("a" "b") :walk-pos 9 :done 0 :skipped 0)
+             (current-buffer)))
+    (org-gtd-review)                     ; no resume prompt: state invalid
+    (with-current-buffer org-gtd-review--buffer-name
+      (assert-match "Step one" (buffer-string)))
+    ;; The mangled save was replaced by the fresh session's checkpoint.
+    (assert-true (org-gtd-review--state-valid-p
+                  (org-gtd-review--load-state)))
+    (assert-equal 0 (plist-get (org-gtd-review--load-state) :walk-pos))))
+
+(deftest review/state-valid-p-rejects-corrupt-fields ()
+  "Negative indices, non-integer tallies, and bad walk shapes are invalid."
+  (let ((org-gtd-review-profiles review-test--tiny-profile)
+        (base '(:profile "Tiny" :phase 0 :step 0 :acted nil
+                :walk-items nil :walk-pos 0 :done 0 :skipped 0)))
+    (cl-flet ((mangle (key val)
+                (plist-put (copy-sequence base) key val)))
+      (assert-true (org-gtd-review--state-valid-p base))
+      (assert-nil (org-gtd-review--state-valid-p (mangle :phase -1)))
+      (assert-nil (org-gtd-review--state-valid-p (mangle :step -1)))
+      (assert-nil (org-gtd-review--state-valid-p (mangle :done "three")))
+      (assert-nil (org-gtd-review--state-valid-p (mangle :skipped nil)))
+      (assert-nil (org-gtd-review--state-valid-p
+                   (mangle :walk-items "not-a-list")))
+      (assert-nil (org-gtd-review--state-valid-p
+                   (plist-put (mangle :walk-items '("a")) :walk-pos -1))))))
+
+(deftest review/explicit-profile-arg-skips-resume-offer ()
+  "An explicit different PROFILE-NAME starts fresh with no resume offer."
+  (let ((org-gtd-review-profiles
+         (append review-test--tiny-profile
+                 '(("Other" ("P" (:title "Elsewhere" :type prompt)))))))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (org-gtd-review-pause))
+    (cl-letf (((symbol-function 'y-or-n-p)
+               (lambda (_prompt) (error "Resume offer should be skipped"))))
+      (org-gtd-review "Other"))
+    (with-current-buffer org-gtd-review--buffer-name
+      (assert-match "Elsewhere" (buffer-string)))
+    ;; No eager delete: the new session's checkpoint took the slot over.
+    (assert-equal "Other" (plist-get (org-gtd-review--load-state) :profile))))
+
+(deftest review/resume-with-edited-bad-profile-teaches-and-deletes ()
+  "A profile edited invalid while paused surfaces the teaching error."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (org-gtd-review-pause)))
+  ;; Same shape (state stays index-valid) but a step lost its :type.
+  (let ((org-gtd-review-profiles
+         '(("Tiny"
+            ("Phase A"
+             (:title "Step one" :type prompt)
+             (:title "No type here"))
+            ("Phase B"
+             (:title "Step three" :type prompt))))))
+    (let ((err (condition-case e
+                   (progn
+                     (cl-letf (((symbol-function 'y-or-n-p)
+                                (lambda (_prompt) t)))
+                       (org-gtd-review))
+                     nil)
+                 (user-error e))))
+      (assert-true err)
+      (assert-match ":type" (cadr err)))
+    (assert-nil (file-exists-p (org-gtd-review--state-file)))
+    (assert-nil org-gtd-review--state)))
 
 (provide 'review-test)
 

--- a/test/unit/review-test.el
+++ b/test/unit/review-test.el
@@ -235,6 +235,37 @@
       (org-gtd-review-next)
       (assert-match "After" (buffer-string)))))
 
+;;; Checklist Walk Step Tests
+
+(defvar review-test--walk-profile
+  '(("Walk"
+     ("P"
+      (:title "Sweep" :type checklist :checklist "Mind sweep prompts")
+      (:title "After" :type prompt)))))
+
+(deftest review/checklist-step-walks-items-one-at-a-time ()
+  "n loads the walk, then advances item by item, then leaves the step."
+  (let ((org-gtd-review-profiles review-test--walk-profile))
+    (org-gtd-review "Walk")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)                       ; load walk, show item 1
+      (assert-match "Boss, partners, colleagues\\?" (buffer-string))
+      (assert-match "(1/8)" (buffer-string))
+      (org-gtd-review-next)                       ; item 2
+      (assert-match "(2/8)" (buffer-string))
+      (dotimes (_ 7) (org-gtd-review-next))       ; through item 8 and out
+      (assert-match "After" (buffer-string)))))
+
+(deftest review/checklist-step-missing-template-auto-advances ()
+  "A missing/empty checklist self-satisfies instead of erroring."
+  (let ((org-gtd-review-profiles
+         '(("W" ("P" (:title "Sweep" :type checklist :checklist "Nope")
+                     (:title "After" :type prompt))))))
+    (org-gtd-review "W")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (assert-match "After" (buffer-string)))))
+
 (provide 'review-test)
 
 ;;; review-test.el ends here

--- a/test/unit/review-test.el
+++ b/test/unit/review-test.el
@@ -190,6 +190,51 @@
     (kill-buffer org-gtd-review--buffer-name)
     (assert-nil org-gtd-review--state)))
 
+;;; Command and View Step Tests
+
+(defvar review-test--command-calls 0)
+(defun review-test--command ()
+  "Test command that records invocations."
+  (interactive)
+  (setq review-test--command-calls (1+ review-test--command-calls)))
+
+(deftest review/command-step-runs-command-then-advances ()
+  "First n invokes :command; second n advances."
+  (setq review-test--command-calls 0)
+  (let ((org-gtd-review-profiles
+         '(("T" ("P" (:title "Run it" :type command :command review-test--command)
+                     (:title "After" :type prompt))))))
+    (org-gtd-review "T")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (assert-equal 1 review-test--command-calls)
+      (assert-match "Run it" (buffer-string))   ; still on the step
+      (org-gtd-review-next)
+      (assert-match "After" (buffer-string)))))
+
+(deftest review/view-step-shows-view-then-advances ()
+  "First n calls :view (other window); second n advances."
+  (let ((org-gtd-review-profiles
+         '(("T" ("P" (:title "Look" :type view :view review-test--command)
+                     (:title "After" :type prompt))))))
+    (setq review-test--command-calls 0)
+    (org-gtd-review "T")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (assert-equal 1 review-test--command-calls)
+      (org-gtd-review-next)
+      (assert-match "After" (buffer-string)))))
+
+(deftest review/unknown-step-type-skips-with-message ()
+  "An unknown :type never errors; it advances."
+  (let ((org-gtd-review-profiles
+         '(("T" ("P" (:title "Weird" :type frobnicate)
+                     (:title "After" :type prompt))))))
+    (org-gtd-review "T")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (assert-match "After" (buffer-string)))))
+
 (provide 'review-test)
 
 ;;; review-test.el ends here

--- a/test/unit/review-test.el
+++ b/test/unit/review-test.el
@@ -391,7 +391,7 @@ single press when the checklist is empty or missing."
     ('prompt 1)
     ((or 'command 'view) 2)
     ('checklist
-     (let ((items (org-gtd-checklist--items (plist-get step :checklist))))
+     (let ((items (org-gtd-checklist-template--items (plist-get step :checklist))))
        (if items (1+ (length items)) 1)))))
 
 (deftest review/default-weekly-profile-runs-end-to-end ()

--- a/test/unit/review-test.el
+++ b/test/unit/review-test.el
@@ -11,6 +11,7 @@
 ;;
 ;; Test Coverage:
 ;; - Default Weekly Review profile shape (2 tests)
+;; - Session lifecycle: start, advance, complete, skip (4 tests)
 ;;
 ;;; Code:
 
@@ -41,6 +42,58 @@
          (sweep (seq-find (lambda (s) (eq (plist-get s :type) 'checklist))
                           get-clear)))
     (assert-equal "Weekly Review triggers" (plist-get sweep :checklist))))
+
+;;; Session Engine Tests
+
+(defvar review-test--tiny-profile
+  '(("Tiny"
+     ("Phase A"
+      (:title "Step one" :type prompt :instruction "Do one.")
+      (:title "Step two" :type prompt))
+     ("Phase B"
+      (:title "Step three" :type prompt))))
+  "Minimal all-prompt profile for engine tests.")
+
+(deftest review/start-opens-session-buffer-on-first-step ()
+  "Starting a session renders profile, phase, and step 1."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (assert-match "Tiny" (buffer-string))
+      (assert-match "Phase A" (buffer-string))
+      (assert-match "step 1/2" (buffer-string))
+      (assert-match "Step one" (buffer-string)))))
+
+(deftest review/n-advances-through-steps-and-phases ()
+  "n on prompt steps advances; crossing a phase boundary re-renders."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (assert-match "Step two" (buffer-string))
+      (org-gtd-review-next)
+      (assert-match "Phase B" (buffer-string))
+      (assert-match "Step three" (buffer-string)))))
+
+(deftest review/completing-last-step-ends-session ()
+  "Finishing the last step tears the session down."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (org-gtd-review-next)
+      (org-gtd-review-next))
+    (assert-nil org-gtd-review--state)
+    (assert-nil (get-buffer org-gtd-review--buffer-name))))
+
+(deftest review/skip-counts-separately ()
+  "s advances but tallies into :skipped."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-skip))
+    (assert-equal 1 (plist-get org-gtd-review--state :skipped))
+    (assert-equal 0 (plist-get org-gtd-review--state :done))))
 
 (provide 'review-test)
 

--- a/test/unit/review-test.el
+++ b/test/unit/review-test.el
@@ -12,7 +12,7 @@
 ;; Test Coverage:
 ;; - Default Weekly Review profile shape (2 tests)
 ;; - Session lifecycle: start, advance, complete, skip (4 tests)
-;; - Entry guards, profile validation, teardown safety (7 tests)
+;; - Entry guards, profile validation, teardown safety (9 tests)
 ;;
 ;;; Code:
 
@@ -132,6 +132,27 @@
       (assert-true err))
     (assert-nil org-gtd-review--state)
     (assert-nil (get-buffer org-gtd-review--buffer-name))))
+
+(deftest review/dotted-phase-errors-cleanly ()
+  "A dotted phase list user-errors instead of crashing."
+  (let ((org-gtd-review-profiles '(("Broken" ("Phase" . :notalist)))))
+    (let ((err (condition-case e
+                   (progn (org-gtd-review "Broken") nil)
+                 (user-error e))))
+      (assert-true err)
+      (assert-match "should be a list starting with a name string"
+                    (cadr err)))
+    (assert-nil org-gtd-review--state)))
+
+(deftest review/zero-step-phase-errors-cleanly ()
+  "A named phase with no steps user-errors instead of rendering junk."
+  (let ((org-gtd-review-profiles '(("EmptySteps" ("Nothing here")))))
+    (let ((err (condition-case e
+                   (progn (org-gtd-review "EmptySteps") nil)
+                 (user-error e))))
+      (assert-true err)
+      (assert-match "has no steps" (cadr err)))
+    (assert-nil org-gtd-review--state)))
 
 (deftest review/step-missing-type-errors-cleanly ()
   "A step without :type user-errors in teaching voice."

--- a/test/unit/review-test.el
+++ b/test/unit/review-test.el
@@ -87,6 +87,38 @@
       (assert-match "Phase B" (buffer-string))
       (assert-match "Step three" (buffer-string)))))
 
+(deftest review/phase-tracker-arrows-current-checks-done-dots-pending ()
+  "The tracker brackets every phase: arrow current, check done, dot pending."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (assert-match "\\[→ Phase A\\]" (buffer-string))
+      (assert-match "\\[· Phase B\\]" (buffer-string))
+      (org-gtd-review-next)
+      (org-gtd-review-next)
+      (assert-match "\\[✓ Phase A\\]" (buffer-string))
+      (assert-match "\\[→ Phase B\\]" (buffer-string)))))
+
+(deftest review/command-step-explains-two-press-flow ()
+  "A command step tells the user advancing runs it and to return to continue."
+  (let ((org-gtd-review-profiles
+         '(("Cmd"
+            ("Only phase"
+             (:title "Process the inbox" :type command :command ignore))))))
+    (org-gtd-review "Cmd")
+    (with-current-buffer org-gtd-review--buffer-name
+      (assert-match "press n again" (buffer-string)))))
+
+(deftest review/view-step-explains-two-press-flow ()
+  "A view step tells the user advancing opens it and to return to continue."
+  (let ((org-gtd-review-profiles
+         '(("View"
+            ("Only phase"
+             (:title "Look at next actions" :type view :view ignore))))))
+    (org-gtd-review "View")
+    (with-current-buffer org-gtd-review--buffer-name
+      (assert-match "press n again" (buffer-string)))))
+
 (deftest review/completing-last-step-ends-session ()
   "Finishing the last step tears the session down."
   (let ((org-gtd-review-profiles review-test--tiny-profile))

--- a/test/unit/review-test.el
+++ b/test/unit/review-test.el
@@ -12,7 +12,8 @@
 ;; Test Coverage:
 ;; - Default Weekly Review profile shape (2 tests)
 ;; - Session lifecycle: start, advance, complete, skip (4 tests)
-;; - Entry guards, profile validation, teardown safety (9 tests)
+;; - Entry guards, profile validation, teardown safety (10 tests)
+;; - Pause / resume / quit persistence (6 tests)
 ;;
 ;;; Code:
 
@@ -28,6 +29,11 @@
           org-gtd-review--window-config nil)
     (when (get-buffer org-gtd-review--buffer-name)
       (kill-buffer org-gtd-review--buffer-name))
+    ;; Inlined path (rather than org-gtd-review--state-file) so cleanup
+    ;; works even before the persistence code exists.
+    (let ((state-file (f-join org-gtd-directory "review-state.eld")))
+      (when (file-exists-p state-file)
+        (delete-file state-file)))
     (funcall proceed context)))
 
 ;;; Default Profile Tests
@@ -287,6 +293,17 @@
       (assert-match ":view" (cadr err)))
     (assert-nil org-gtd-review--state)))
 
+(deftest review/checklist-step-missing-checklist-errors-cleanly ()
+  "A checklist step without :checklist is rejected at session start."
+  (let ((org-gtd-review-profiles
+         '(("Bad" ("P" (:title "Sweep what?" :type checklist))))))
+    (let ((err (condition-case e
+                   (progn (org-gtd-review "Bad") nil)
+                 (user-error e))))
+      (assert-true err)
+      (assert-match ":checklist" (cadr err)))
+    (assert-nil org-gtd-review--state)))
+
 (deftest review/unknown-step-type-skips-with-message ()
   "An unknown :type never errors; it advances."
   (let ((org-gtd-review-profiles
@@ -341,6 +358,83 @@
     (with-current-buffer org-gtd-review--buffer-name
       (org-gtd-review-next)
       (assert-match "After" (buffer-string)))))
+
+;;; Pause / Resume / Quit Tests
+
+(deftest review/pause-persists-state-and-tears-down ()
+  "p writes review-state.eld and closes the session."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (org-gtd-review-pause))
+    (assert-nil org-gtd-review--state)
+    (assert-true (file-exists-p (org-gtd-review--state-file)))))
+
+(deftest review/resume-restores-position ()
+  "Starting again after a pause offers resume and restores the step."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (org-gtd-review-pause))
+    ;; y-or-n-p is stubbed, not fed keys: batch-mode y-or-n-p does not
+    ;; reliably consume simulated input (suite-wide convention).
+    (cl-letf (((symbol-function 'y-or-n-p) (lambda (_prompt) t)))
+      (org-gtd-review))
+    (with-current-buffer org-gtd-review--buffer-name
+      (assert-match "Step two" (buffer-string)))))
+
+(deftest review/resume-with-changed-profile-starts-over ()
+  "Out-of-range saved state falls back to a fresh session."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (org-gtd-review-pause)))
+  (let ((org-gtd-review-profiles
+         '(("Tiny" ("Only" (:title "Sole" :type prompt))))))
+    (org-gtd-review)                       ; no resume prompt: state invalid
+    (with-current-buffer org-gtd-review--buffer-name
+      (assert-match "Sole" (buffer-string)))
+    (assert-nil (file-exists-p (org-gtd-review--state-file)))))
+
+(deftest review/completion-deletes-state-file ()
+  "Finishing a resumed session removes review-state.eld."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-pause))
+    (cl-letf (((symbol-function 'y-or-n-p) (lambda (_prompt) t)))
+      (org-gtd-review))
+    (with-current-buffer org-gtd-review--buffer-name
+      (dotimes (_ 3) (org-gtd-review-next)))
+    (assert-nil (file-exists-p (org-gtd-review--state-file)))))
+
+(deftest review/quit-keeping-progress-pauses ()
+  "q answered y keeps a state file, like a pause."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)
+      (cl-letf (((symbol-function 'y-or-n-p) (lambda (_prompt) t)))
+        (org-gtd-review-quit)))
+    (assert-nil org-gtd-review--state)
+    (assert-true (file-exists-p (org-gtd-review--state-file)))))
+
+(deftest review/quit-abandoning-deletes-state-file ()
+  "q answered n abandons: no state file survives, session gone."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-pause))            ; leaves a state file behind
+    (cl-letf (((symbol-function 'y-or-n-p) (lambda (_prompt) t)))
+      (org-gtd-review))                  ; resume the paused session
+    (with-current-buffer org-gtd-review--buffer-name
+      (cl-letf (((symbol-function 'y-or-n-p) (lambda (_prompt) nil)))
+        (org-gtd-review-quit)))
+    (assert-nil org-gtd-review--state)
+    (assert-nil (file-exists-p (org-gtd-review--state-file)))))
 
 (provide 'review-test)
 

--- a/test/unit/review-test.el
+++ b/test/unit/review-test.el
@@ -12,7 +12,9 @@
 ;; Test Coverage:
 ;; - Default Weekly Review profile shape (2 tests)
 ;; - Session lifecycle: start, advance, complete, skip (4 tests)
-;; - Entry guards, profile validation, teardown safety (10 tests)
+;; - Entry guards, profile validation, teardown safety (12 tests)
+;; - Checklist walks and mid-walk capture (4 tests)
+;; - Full default-profile end-to-end run (1 test)
 ;; - Pause / resume / quit persistence and checkpointing (14 tests)
 ;;
 ;;; Code:
@@ -349,6 +351,24 @@
     (assert-nil (plist-get org-gtd-review--state :walk-items))
     (assert-nil (plist-get org-gtd-review--state :acted))))
 
+(deftest review/capture-mid-walk-keeps-position ()
+  "c mid-walk fires capture without moving the walk position."
+  (let ((org-gtd-review-profiles review-test--walk-profile)
+        (captures 0))
+    (cl-letf (((symbol-function 'org-gtd-capture)
+               (lambda (&rest _)
+                 (interactive)
+                 (setq captures (1+ captures)))))
+      (org-gtd-review "Walk")
+      (with-current-buffer org-gtd-review--buffer-name
+        (org-gtd-review-next)              ; load walk, item 1
+        (org-gtd-review-next)              ; item 2
+        (org-gtd-review-capture)
+        (assert-equal 1 captures)
+        ;; The walk did not move: still on item 2, same step.
+        (assert-equal 1 (plist-get org-gtd-review--state :walk-pos))
+        (assert-match "(2/8)" (buffer-string))))))
+
 (deftest review/checklist-step-missing-template-auto-advances ()
   "A missing/empty checklist self-satisfies instead of erroring."
   (let ((org-gtd-review-profiles
@@ -358,6 +378,46 @@
     (with-current-buffer org-gtd-review--buffer-name
       (org-gtd-review-next)
       (assert-match "After" (buffer-string)))))
+
+;;; Default Profile Integration Test
+
+(defun review-test--step-presses (step)
+  "Return how many presses of n STEP consumes in a session.
+A prompt advances on one press; command and view steps take one
+press to act and one to confirm; a checklist walk takes one press
+to load plus one per item after the first plus one to leave — or a
+single press when the checklist is empty or missing."
+  (pcase (plist-get step :type)
+    ('prompt 1)
+    ((or 'command 'view) 2)
+    ('checklist
+     (let ((items (org-gtd-checklist--items (plist-get step :checklist))))
+       (if items (1+ (length items)) 1)))))
+
+(deftest review/default-weekly-profile-runs-end-to-end ()
+  "The shipped Weekly Review profile completes under n alone.
+The profile's command and view symbols are stubbed to interactive
+no-ops so the run is deterministic; the press count is derived from
+the profile structure, not hardcoded."
+  (let* ((phases (cdr (assoc "Weekly Review" org-gtd-review-profiles)))
+         (steps (apply #'append (mapcar #'cdr phases)))
+         (actions (delq nil (mapcar (lambda (s)
+                                      (or (plist-get s :command)
+                                          (plist-get s :view)))
+                                    steps)))
+         (originals (mapcar #'symbol-function actions))
+         (presses (apply #'+ (mapcar #'review-test--step-presses steps))))
+    (unwind-protect
+        (progn
+          (dolist (action actions)
+            (fset action (lambda () (interactive))))
+          (org-gtd-review "Weekly Review")
+          (with-current-buffer org-gtd-review--buffer-name
+            (dotimes (_ presses) (org-gtd-review-next)))
+          (assert-nil org-gtd-review--state)
+          (assert-nil (get-buffer org-gtd-review--buffer-name))
+          (assert-nil (file-exists-p (org-gtd-review--state-file))))
+      (cl-mapc #'fset actions originals))))
 
 ;;; Pause / Resume / Quit Tests
 
@@ -451,6 +511,22 @@
                  (user-error e))))
       (assert-true err))
     (assert-equal 1 (plist-get (org-gtd-review--load-state) :step))))
+
+(deftest review/next-without-session-teaches ()
+  "A stray M-x next with no session user-errors instead of crashing."
+  (let ((err (condition-case e
+                 (progn (org-gtd-review-next) nil)
+               (user-error e))))
+    (assert-true err)
+    (assert-match "No review session is active" (cadr err))))
+
+(deftest review/skip-without-session-teaches ()
+  "A stray M-x skip with no session user-errors instead of crashing."
+  (let ((err (condition-case e
+                 (progn (org-gtd-review-skip) nil)
+               (user-error e))))
+    (assert-true err)
+    (assert-match "No review session is active" (cadr err))))
 
 (deftest review/quit-without-session-errors-and-preserves-save ()
   "A stray M-x quit with no session must not delete a saved pause."

--- a/test/unit/review-test.el
+++ b/test/unit/review-test.el
@@ -198,6 +198,18 @@
   (interactive)
   (setq review-test--command-calls (1+ review-test--command-calls)))
 
+(defun review-test--failing-command ()
+  "Test command that records the invocation, then signals."
+  (interactive)
+  (setq review-test--command-calls (1+ review-test--command-calls))
+  (error "Boom"))
+
+(defun review-test--popping-view ()
+  "Test view that records the invocation and pops another buffer."
+  (interactive)
+  (setq review-test--command-calls (1+ review-test--command-calls))
+  (pop-to-buffer (get-buffer-create "*review-test-view*")))
+
 (deftest review/command-step-runs-command-then-advances ()
   "First n invokes :command; second n advances."
   (setq review-test--command-calls 0)
@@ -212,18 +224,68 @@
       (org-gtd-review-next)
       (assert-match "After" (buffer-string)))))
 
-(deftest review/view-step-shows-view-then-advances ()
-  "First n calls :view (other window); second n advances."
+(deftest review/command-step-error-leaves-step-retryable ()
+  "A :command that signals leaves the step un-acted so n retries it."
+  (setq review-test--command-calls 0)
   (let ((org-gtd-review-profiles
-         '(("T" ("P" (:title "Look" :type view :view review-test--command)
+         '(("T" ("P" (:title "Flaky" :type command :command review-test--failing-command)
+                     (:title "After" :type prompt))))))
+    (org-gtd-review "T")
+    (with-current-buffer org-gtd-review--buffer-name
+      ;; First n: the command signals; the error propagates.
+      (assert-true (condition-case e
+                       (progn (org-gtd-review-next) nil)
+                     (error e)))
+      ;; The step must not count as acted or done.
+      (assert-nil (plist-get org-gtd-review--state :acted))
+      (assert-equal 0 (plist-get org-gtd-review--state :done))
+      ;; Second n retries the command instead of silently advancing.
+      (assert-true (condition-case e
+                       (progn (org-gtd-review-next) nil)
+                     (error e)))
+      (assert-equal 2 review-test--command-calls)
+      (assert-match "Flaky" (buffer-string)))))
+
+(deftest review/view-step-shows-view-then-advances ()
+  "First n calls :view without stealing the window; second n advances."
+  (let ((org-gtd-review-profiles
+         '(("T" ("P" (:title "Look" :type view :view review-test--popping-view)
                      (:title "After" :type prompt))))))
     (setq review-test--command-calls 0)
     (org-gtd-review "T")
-    (with-current-buffer org-gtd-review--buffer-name
-      (org-gtd-review-next)
-      (assert-equal 1 review-test--command-calls)
-      (org-gtd-review-next)
-      (assert-match "After" (buffer-string)))))
+    (unwind-protect
+        (with-current-buffer org-gtd-review--buffer-name
+          (org-gtd-review-next)
+          (assert-equal 1 review-test--command-calls)
+          ;; The review console must stay the selected window.
+          (assert-equal org-gtd-review--buffer-name
+                        (buffer-name (window-buffer (selected-window))))
+          (org-gtd-review-next)
+          (assert-match "After" (buffer-string)))
+      (when (get-buffer "*review-test-view*")
+        (kill-buffer "*review-test-view*")))))
+
+(deftest review/command-step-missing-command-errors-cleanly ()
+  "A command step without :command is rejected at session start."
+  (let ((org-gtd-review-profiles
+         '(("Bad" ("P" (:title "Run what?" :type command))))))
+    (let ((err (condition-case e
+                   (progn (org-gtd-review "Bad") nil)
+                 (user-error e))))
+      (assert-true err)
+      (assert-match ":command" (cadr err)))
+    (assert-nil org-gtd-review--state)))
+
+(deftest review/view-step-missing-view-errors-cleanly ()
+  "A view step without :view is rejected at session start."
+  (let ((org-gtd-review-profiles
+         '(("Bad" ("P" (:title "Look at what?" :type view))))))
+    (let ((err (condition-case e
+                   (progn (org-gtd-review "Bad") nil)
+                 (user-error e))))
+      (assert-true err)
+      (assert-match ":view" (cadr err)))
+    (assert-nil org-gtd-review--state)))
 
 (deftest review/unknown-step-type-skips-with-message ()
   "An unknown :type never errors; it advances."
@@ -255,6 +317,20 @@
       (assert-match "(2/8)" (buffer-string))
       (dotimes (_ 7) (org-gtd-review-next))       ; through item 8 and out
       (assert-match "After" (buffer-string)))))
+
+(deftest review/skip-mid-walk-exits-whole-step ()
+  "s in the middle of a walk leaves the step, tallied as skipped."
+  (let ((org-gtd-review-profiles review-test--walk-profile))
+    (org-gtd-review "Walk")
+    (with-current-buffer org-gtd-review--buffer-name
+      (org-gtd-review-next)                       ; load walk, item 1
+      (org-gtd-review-next)                       ; item 2
+      (org-gtd-review-skip)
+      (assert-match "After" (buffer-string)))
+    (assert-equal 1 (plist-get org-gtd-review--state :skipped))
+    (assert-equal 0 (plist-get org-gtd-review--state :done))
+    (assert-nil (plist-get org-gtd-review--state :walk-items))
+    (assert-nil (plist-get org-gtd-review--state :acted))))
 
 (deftest review/checklist-step-missing-template-auto-advances ()
   "A missing/empty checklist self-satisfies instead of erroring."

--- a/test/unit/review-test.el
+++ b/test/unit/review-test.el
@@ -12,11 +12,13 @@
 ;; Test Coverage:
 ;; - Default Weekly Review profile shape (2 tests)
 ;; - Session lifecycle: start, advance, complete, skip (4 tests)
+;; - Entry guards, profile validation, teardown safety (7 tests)
 ;;
 ;;; Code:
 
 (require 'ogt-eunit-prelude "test/helpers/prelude.el")
 (require 'org-gtd-review)
+(require 'cl-lib)
 
 (e-unit-initialize)
 
@@ -24,6 +26,8 @@
   (ogt-eunit-with-mock-gtd
     (setq org-gtd-review--state nil
           org-gtd-review--window-config nil)
+    (when (get-buffer org-gtd-review--buffer-name)
+      (kill-buffer org-gtd-review--buffer-name))
     (funcall proceed context)))
 
 ;;; Default Profile Tests
@@ -94,6 +98,76 @@
       (org-gtd-review-skip))
     (assert-equal 1 (plist-get org-gtd-review--state :skipped))
     (assert-equal 0 (plist-get org-gtd-review--state :done))))
+
+;;; Entry Guard and Validation Tests
+
+(deftest review/second-invocation-signals-user-error ()
+  "Starting a review while one is active errors, keeping the session."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (let ((err (condition-case e
+                   (progn (org-gtd-review "Tiny") nil)
+                 (user-error e))))
+      (assert-true err)
+      (assert-match "already active" (cadr err)))
+    (assert-equal "Tiny" (plist-get org-gtd-review--state :profile))
+    (assert-equal 0 (plist-get org-gtd-review--state :step))))
+
+(deftest review/no-profiles-configured-errors ()
+  "An empty profiles alist signals a clean user-error."
+  (let ((org-gtd-review-profiles nil))
+    (let ((err (condition-case e
+                   (progn (org-gtd-review) nil)
+                 (user-error e))))
+      (assert-true err)
+      (assert-match "No review profiles configured" (cadr err))))
+  (assert-nil org-gtd-review--state))
+
+(deftest review/malformed-phase-errors-cleanly ()
+  "A non-list phase user-errors; no session or buffer is left behind."
+  (let ((org-gtd-review-profiles '(("Bad" "not-a-phase-list"))))
+    (let ((err (condition-case e
+                   (progn (org-gtd-review "Bad") nil)
+                 (user-error e))))
+      (assert-true err))
+    (assert-nil org-gtd-review--state)
+    (assert-nil (get-buffer org-gtd-review--buffer-name))))
+
+(deftest review/step-missing-type-errors-cleanly ()
+  "A step without :type user-errors in teaching voice."
+  (let ((org-gtd-review-profiles
+         '(("Bad" ("P" (:title "No type here"))))))
+    (let ((err (condition-case e
+                   (progn (org-gtd-review "Bad") nil)
+                 (user-error e))))
+      (assert-true err)
+      (assert-match ":type" (cadr err)))
+    (assert-nil org-gtd-review--state)))
+
+(deftest review/render-error-still-tears-down ()
+  "An unexpected error during session start restores a clean slate."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (cl-letf (((symbol-function 'org-gtd-review--render)
+               (lambda () (error "Boom"))))
+      (condition-case nil (org-gtd-review "Tiny") (error nil)))
+    (assert-nil org-gtd-review--state)
+    (assert-nil org-gtd-review--window-config)))
+
+;;; Teardown Safety Tests
+
+(deftest review/capture-advertised-on-every-step ()
+  "The header line offers c on prompt steps, not only checklist walks."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (with-current-buffer org-gtd-review--buffer-name
+      (assert-match "\\[c\\] Capture" (format "%s" header-line-format)))))
+
+(deftest review/killing-buffer-ends-session ()
+  "Killing *GTD Review* directly clears the session state."
+  (let ((org-gtd-review-profiles review-test--tiny-profile))
+    (org-gtd-review "Tiny")
+    (kill-buffer org-gtd-review--buffer-name)
+    (assert-nil org-gtd-review--state)))
 
 (provide 'review-test)
 

--- a/test/unit/review-test.el
+++ b/test/unit/review-test.el
@@ -1,0 +1,47 @@
+;;; review-test.el --- Tests for the guided review engine -*- lexical-binding: t; coding: utf-8 -*-
+
+;; Copyright (C) 2026 Aldric Giacomoni
+
+;; Author: Aldric Giacomoni <trevoke@gmail.com>
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+;;
+;; Unit tests for the guided, profile-driven review session engine.
+;;
+;; Test Coverage:
+;; - Default Weekly Review profile shape (2 tests)
+;;
+;;; Code:
+
+(require 'ogt-eunit-prelude "test/helpers/prelude.el")
+(require 'org-gtd-review)
+
+(e-unit-initialize)
+
+(around-each (proceed context)
+  (ogt-eunit-with-mock-gtd
+    (setq org-gtd-review--state nil
+          org-gtd-review--window-config nil)
+    (funcall proceed context)))
+
+;;; Default Profile Tests
+
+(deftest review/default-profile-is-weekly-three-phase ()
+  "The shipped default is a Weekly Review with the three GTD phases."
+  (let ((profile (assoc "Weekly Review" org-gtd-review-profiles)))
+    (assert-true profile)
+    (assert-equal '("Get Clear" "Get Current" "Get Creative")
+                  (mapcar #'car (cdr profile)))))
+
+(deftest review/default-mind-sweep-references-starter-checklist ()
+  "The Get Clear phase walks the bundled trigger list."
+  (let* ((phases (cdr (assoc "Weekly Review" org-gtd-review-profiles)))
+         (get-clear (cdr (assoc "Get Clear" phases)))
+         (sweep (seq-find (lambda (s) (eq (plist-get s :type) 'checklist))
+                          get-clear)))
+    (assert-equal "Weekly Review triggers" (plist-get sweep :checklist))))
+
+(provide 'review-test)
+
+;;; review-test.el ends here

--- a/test/unit/review-test.el
+++ b/test/unit/review-test.el
@@ -543,7 +543,9 @@
       (assert-nil (org-gtd-review--state-valid-p
                    (mangle :walk-items "not-a-list")))
       (assert-nil (org-gtd-review--state-valid-p
-                   (plist-put (mangle :walk-items '("a")) :walk-pos -1))))))
+                   (plist-put (mangle :walk-items '("a")) :walk-pos -1)))
+      ;; :walk-pos must be an integer even when :walk-items is empty.
+      (assert-nil (org-gtd-review--state-valid-p (mangle :walk-pos "x"))))))
 
 (deftest review/explicit-profile-arg-skips-resume-offer ()
   "An explicit different PROFILE-NAME starts fresh with no resume offer."

--- a/test/unit/todo-filter-test.el
+++ b/test/unit/todo-filter-test.el
@@ -16,9 +16,20 @@
 
 (require 'e-unit)
 (require 'org)
+;; `org-gtd-pred--todo-matches' lives in org-gtd-skip; require it so these
+;; tests do not depend on another test file having loaded org-gtd first.
+(require 'org-gtd-skip)
 
 ;; Initialize e-unit short syntax
 (e-unit-initialize)
+
+;; `org-mode' reads `org-todo-keywords' (global) to decide which words are TODO
+;; states.  Set the GTD sequence before each test so "* NEXT Task" parses as a
+;; NEXT item -- otherwise these tests only pass by inheriting keyword config
+;; leaked from an earlier test (order-dependent flake).
+(setup-each
+ (setq org-todo-keywords '((sequence "TODO" "NEXT" "WAIT" "|" "DONE" "CNCL"))
+       org-done-keywords '("DONE")))
 
 ;;; Predicate Unit Tests
 

--- a/test/unit/upgrades-test.el
+++ b/test/unit/upgrades-test.el
@@ -838,6 +838,62 @@ SCHEDULED: <2023-12-23 Sat 19:00 ++1d>
     (org-back-to-heading t)
     (assert-equal "Habit" (org-entry-get (point) "ORG_GTD"))))
 
+;;; v4 -> v5: detect existing repeating headings with checkboxes
+
+(deftest upgrade-v4-v5/detects-only-live-repeating-checkbox-headings ()
+  "Detection flags a live-repeating heading with checkboxes, and nothing else."
+  (with-current-buffer (org-gtd--default-file)
+    (insert "
+* TODO Water plants
+SCHEDULED: <2026-01-01 Mon .+1w>
+- [ ] living room
+- [ ] balcony
+
+* TODO Pay rent
+SCHEDULED: <2026-01-01 Mon .+1m>
+just a note, no checkboxes
+
+* One-off with boxes
+- [ ] a
+- [ ] b
+
+* TODO Finished for good
+SCHEDULED: <2026-01-01 Mon .+0w>
+- [ ] x
+")
+    (basic-save-buffer))
+  (let ((found (org-gtd-upgrade--repeating-checkbox-headings)))
+    (assert-equal 1 (length found))
+    (assert-match "Water plants" (plist-get (car found) :heading))))
+
+(deftest upgrade-v4-v5/detection-empty-when-no-matches ()
+  "No live-repeating heading with checkboxes means an empty result."
+  (with-current-buffer (org-gtd--default-file)
+    (insert "
+* TODO Pay rent
+SCHEDULED: <2026-01-01 Mon .+1m>
+no boxes here
+")
+    (basic-save-buffer))
+  (assert-nil (org-gtd-upgrade--repeating-checkbox-headings)))
+
+(deftest upgrade-v4-v5/command-reports-affected-headings ()
+  "The command lists affected headings in a report buffer, changing nothing."
+  (with-current-buffer (org-gtd--default-file)
+    (insert "
+* TODO Water plants
+SCHEDULED: <2026-01-01 Mon .+1w>
+- [ ] living room
+")
+    (basic-save-buffer))
+  (org-gtd-upgrade-v4-to-v5)
+  (assert-true (get-buffer "*org-gtd v5 upgrade*"))
+  (with-current-buffer "*org-gtd v5 upgrade*"
+    (assert-match "Water plants" (buffer-string)))
+  ;; The heading's checkbox is untouched (detection is read-only).
+  (with-current-buffer (org-gtd--default-file)
+    (assert-match "- \\[ \\] living room" (buffer-string))))
+
 (provide 'upgrades-test)
 
 ;;; upgrades-test.el ends here


### PR DESCRIPTION
Implements REC-CHK-01 (reusable checklists / trigger lists) and REC-REF-02 (guided three-phase Weekly Review), per the design and implementation plan in `docs/plans/2026-07-06-checklists-and-guided-review-{design,plan}.md`.

## What's in here

**Checklists** (`org-gtd-checklist.el`)
- `checklists.org` in `org-gtd-directory`: plain org headings + `- [ ]` items are reusable templates; seeded on first touch with Weekly Review trigger lists
- `org-gtd-checklist-insert`: spawn a template instance anywhere (plain org copy, level-adapting)
- Checkbox reset when a repeating heading re-arms — guard mirrors org's own re-arm rule exactly (no reset on plain DONE, finish-for-good `.+0w`, or done→done transitions)

**Guided review** (`org-gtd-review.el`)
- `org-gtd-review`: profile-driven session console (`*GTD Review*`) — Weekly Review (Get Clear / Get Current / Get Creative) ships as the default of the `org-gtd-review-profiles` defcustom
- Step types: prompt, command (two-press, retryable on error), view, checklist walk with mid-walk capture
- Continuous checkpointing to `review-state.eld`: pause/resume, crash/kill recovery, validated resume with teaching-voice recovery
- `org-gtd-review-schedule`: creates the recurring reminder habit (repeater validation, duplicate guard)

**Install** (`org-gtd-init.el`)
- `org-gtd-init-system`: idempotent first-run setup (files + optional review reminder)
- Command center: `w` Weekly Review (guided), `l` Checklists

**Docs**: manual sections (Checklists; Weekly Review (guided)), reference chapter entries, CHANGELOG; info manual regenerated.

## Process

Built task-by-task via subagent-driven development: 15 plan tasks, each TDD (red→green), each through a two-stage review (spec compliance, then adversarial code quality with empirical probes), every finding fixed and re-verified, plus a final whole-implementation review. 84 new tests (1276 → 1360); `eldev compile --warnings-as-errors` and lint clean.

## Test plan
- [x] Full suite green (1360 tests, multiple consecutive runs)
- [x] Batch-Emacs end-to-end probe: init → schedule → full default Weekly Review completes; composition pattern (insert → habit → reset on repeat)
- [ ] Manual smoke test in a live Emacs session