### PR TITLE
feat(inbox): save in-progress edits back to inbox on quit

### DIFF
--- a/docs/v5-journal.org
+++ b/docs/v5-journal.org
@@ -213,23 +213,44 @@ first; they unlock clusters.
 
 ** BUILD-V5 (foundational) — generalize the item-walk engine            :foundational:
 :PROPERTIES:
-:STATUS:      partially built (someday-review is a coupled instance)
-:DISPOSITION: BUILD-V5 (design-gated)
+:STATUS:      BUILT (org-gtd-5) — engine + 4 consumers migrated
+:DISPOSITION: BUILD-V5 (done)
 :DECIDED:     2026-07-15
+:COMPLETED:   2026-07-18
 :END:
-The item-by-item *walk* engine already exists — =org-gtd-someday-review= has the
-whole thing: a session with =:queue= of org-ids + =:position=, =--advance= to the
-next item, a review major-mode with =d=/=c=/=q= keys, and LOGBOOK stamping. It's
-just *coupled to someday/maybe*: =--find-items= hardcodes =ORG_GTD == someday=
-and the actions are defer/clarify.
+*DONE (2026-07-18, on =org-gtd-5=).* The generalized item-walk engine is built
+and all four in-repo consumers run on it. See
+=docs/plans/2026-07-17-walk-engine-design.md= and the phase-0/1/2/4 plans.
 
-*Decision*: BUILD-V5 — *generalize* it into a reusable item-walk: parameterize
-(a) which items it finds and (b) which actions apply per walk. This is the
-design-§8 "=walk= step type" — but a refactor-and-reuse, not net-new. Needs a
-short design for the generalization seam (find-fn + action-set + optional review
-step integration).
+Shipped:
+- =org-gtd-walk-model.el= — pure, headless model: entries (opaque serializable
+  handles) + cursor + meta; enqueue =top=/=bottom= (both after cursor); serialize/
+  deserialize with validation. No per-entry status (cursor separates handled/
+  pending — status is *upstream* filtering that feeds =:entries=).
+- =org-gtd-walk.el= — registry (=org-gtd-walks= alist of specs =(:name :find
+  :render :actions :on-finish :resumable :resolve :scope)=), per-*scope*
+  concurrency lock (scope = the org container: file-set or subtree org-id),
+  opt-in checkpoint (md5 of scope-key), and the session driver
+  (=org-gtd-walk-start/-advance/-enqueue/-quit/-finish=). =org-gtd-walk--active=
+  is =permanent-local= so a mode switch's =kill-all-local-variables= can't wipe it.
+- Consumers migrated: (1) =someday-review= (Phase 1); (2) the review checklist
+  walk + a generic =walk= review step type (Phase 2 — the design-§8 seam, now
+  real); (3) inbox processing (Phase 4 — the north-star: multi-source find, the
+  async organize→advance seam, duplicate-queue as dynamic enqueue with
+  FIFO-immediate ordering). Three stacked ad-hoc inbox queues collapsed into one.
 
-*Unlocks* (consumers): [[*BUILD-V5 REC-UI-04 — consent-based migrate overdue calendar → next-action][REC-UI-04]] (walk missed calendar → migrate), the guided
+Verified: compile clean (=--warnings-as-errors=); full suite 1593 pass, 0 errors.
+
+*Still design-gated (not built — need a collaborative UX pass, not a straight
+build):*
+- [[*BUILD-V5 REC-UI-04 — consent-based migrate overdue calendar → next-action][REC-UI-04]] — first *net-new* actionable walk (walk missed calendar → migrate).
+- A real *heading-walk-in-console* review step (e.g. stuck-projects) — someday's
+  own render is region-incompatible, so an in-review heading walk needs its own UX.
+- Inbox *resume* — engine supports =:resumable=; inbox ships =:resumable nil=
+  pending the "what happens to a half-clarified item's unsaved WIP edits on
+  resume" question.
+
+*Unlocks* (consumers): REC-UI-04 (walk missed calendar → migrate), the guided
 review's walk-over-headings (projects / missed items), and the =may= items
 REC-X-15 (completeness walk) and REC-CAP-09 (themed sweep) if built.
 
@@ -1570,7 +1591,7 @@ explanations), and adaptive coaching, if ever, rides the opt-in LLM direction.
 *** BUILD-V5 REC-UI-04 — consent-based migrate overdue calendar → next-action :should:ui:
 :PROPERTIES:
 :REC_ID:      REC-UI-04
-:STATUS:      Not-implemented → BUILD on the generalized walk engine
+:STATUS:      Not-implemented — walk-engine dependency now READY (unblocked 2026-07-18)
 :STRENGTH:    should
 :TYPE:        tool
 :DISPOSITION: BUILD-V5 (rides the generalized item-walk foundation)
@@ -1583,7 +1604,8 @@ migrate it into a next action — consent-only, no auto-action, no forced agenda
 *Decision*: BUILD-V5 as the first real consumer of the generalized item-walk
 (see [[*BUILD-V5 (foundational) — generalize the item-walk engine][Foundations]]): walk the missed calendar items one at a time with a
 "retype to next-action" action (reuses reactivate/retype infra in
-=org-gtd-reactivate.el=). Gated on the walk-engine generalization.
+=org-gtd-reactivate.el=). The walk-engine generalization it was gated on is now
+built — this is the *next* piece to design/build (first net-new actionable walk).
 
 *** BUILD-V5 REC-UI-05 — mark-done closure prompt ("what's next?")     :should:ui:
 :PROPERTIES:

--- a/org-gtd-clarify.el
+++ b/org-gtd-clarify.el
@@ -311,6 +311,11 @@ before cleanup so the save/discard prompt never fired."
       (org-gtd-walk-advance)
     (let ((window-config org-gtd-clarify--window-config)
           (task-id org-gtd-clarify--clarify-id))
+      ;; Save-on-quit safety net: if the current item was edited, write
+      ;; those edits back over its source inbox heading so re-running
+      ;; `org-gtd-process-inbox' resumes it in edited form (issue: quit
+      ;; used to silently discard in-progress edits).
+      (org-gtd-clarify--save-current-item-to-inbox)
       ;; Belt-and-suspenders: with immediate-after-parent ordering there
       ;; is no pending duplicate on this branch, but if one ever were
       ;; stranded it must not vanish -- save it back to the inbox.
@@ -840,6 +845,64 @@ Returns \\='discard, \\='save, or \\='cancel."
       (?s 'save)
       (?c 'cancel))))
 
+;;;;; Save-on-quit safety net
+
+(defun org-gtd-clarify--overwrite-source-with-wip ()
+  "Replace the source heading with the current WIP buffer's subtree.
+Copies the subtree from the current (WIP) buffer and pastes it over the
+heading at `org-gtd-clarify--source-heading-marker', re-leveling to the
+source heading's outline level (the WIP subtree is always pasted at
+level 1, so raw insertion would flatten it -- issue #291) and saving the
+source file.  A dead/missing source marker is a no-op.
+
+Shared by the organize \"update in place\" action
+\(`org-gtd-organize--update-in-place') and the inbox save-on-quit safety
+net (`org-gtd-clarify--save-current-item-to-inbox')."
+  (let ((new-content (save-excursion
+                       (goto-char (point-min))
+                       (when (org-before-first-heading-p)
+                         (org-next-visible-heading 1))
+                       (org-gtd--without-kill-merge
+                         (org-copy-subtree))
+                       (current-kill 0)))
+        (source-marker org-gtd-clarify--source-heading-marker))
+    (when (and source-marker
+               (markerp source-marker)
+               (marker-buffer source-marker))
+      (with-current-buffer (marker-buffer source-marker)
+        (goto-char source-marker)
+        (org-back-to-heading t)
+        (let ((level (org-outline-level)))
+          (org-gtd--without-kill-merge
+            (org-cut-subtree))
+          (org-paste-subtree level new-content))
+        (save-buffer)))))
+
+(defun org-gtd-clarify--save-current-item-to-inbox ()
+  "Write in-progress edits to the current item back to its source heading.
+The save-on-quit safety net: when a walk-driven inbox clarify is
+abandoned mid-item, an *edited* WIP surface (`buffer-modified-p') whose
+source heading still exists is written back over that heading (via
+`org-gtd-clarify--overwrite-source-with-wip'), so re-running
+`org-gtd-process-inbox' picks the item up in its edited form rather than
+discarding what was typed.  A merely glanced item (unmodified surface,
+per the flag reset in `org-gtd-inbox-walk--render-marker') is left
+untouched -- no needless rewrite.
+
+Idempotent: clears the modified flag after saving so a following
+kill-buffer teardown does not save a second time.
+
+Caveat: the signal is `buffer-modified-p', so a user who manually saves
+the temp-file-backed surface (`C-x C-s') before quitting clears the flag
+and their edits are then discarded -- inherent to a modified-flag gate,
+and an unusual action on a WIP buffer."
+  (when (and (buffer-modified-p)
+             org-gtd-clarify--source-heading-marker
+             (markerp org-gtd-clarify--source-heading-marker)
+             (marker-buffer org-gtd-clarify--source-heading-marker))
+    (org-gtd-clarify--overwrite-source-with-wip)
+    (set-buffer-modified-p nil)))
+
 ;;;;; Kill-Emacs Safety
 
 (defun org-gtd-clarify--buffer-has-pending-duplicates-p ()
@@ -934,6 +997,12 @@ Added to `kill-buffer-hook' buffer-locally."
   ;; scope ...".  `org-gtd-walk-quit' unlocks and clears the (about to
   ;; die) buffer-local session.
   (when (bound-and-true-p org-gtd-walk--active)
+    ;; Killing a live inbox-walk surface (e.g. C-x k) is also an
+    ;; abandonment: apply the same save-on-quit safety net as the `q'
+    ;; quit path before releasing the session.  The gate
+    ;; (`buffer-modified-p' + a live source marker) makes this a no-op for
+    ;; unedited items and for walk surfaces with no source heading.
+    (org-gtd-clarify--save-current-item-to-inbox)
     (org-gtd-walk-quit))
   (unless (org-gtd-clarify--other-clarify-buffers-exist-p)
     ;; Clean up all side windows

--- a/org-gtd-inbox-walk.el
+++ b/org-gtd-inbox-walk.el
@@ -235,7 +235,12 @@ multi-project readiness computed via `org-id-find')."
           (org-gtd-clarify-mode))
         (setq-local org-gtd-clarify--clarify-id new-id
                     org-gtd-clarify--source-heading-marker marker
-                    org-gtd-clarify--skip-refile nil)))))
+                    org-gtd-clarify--skip-refile nil)
+        ;; Freshly rendered, untouched: mark unmodified so a later quit
+        ;; can tell an *edited* item (save its edits back to the inbox --
+        ;; the save-on-quit safety net) from a merely glanced one (discard,
+        ;; no rewrite).  See `org-gtd-clarify--save-current-item-to-inbox'.
+        (set-buffer-modified-p nil)))))
 
 (defun org-gtd-inbox-walk--render (token surface)
   "Render inbox TOKEN into SURFACE, the walk `:render' contract.

--- a/org-gtd-organize-core.el
+++ b/org-gtd-organize-core.el
@@ -90,30 +90,12 @@ Once you have your ground items managed, you might like to set the variable
 
 (defun org-gtd-organize--update-in-place ()
   "Replace original heading with configured content from WIP buffer.
-Uses `org-gtd-clarify--source-heading-marker' to find the original location."
-  (let ((new-content (save-excursion
-                       (goto-char (point-min))
-                       (when (org-before-first-heading-p)
-                         (org-next-visible-heading 1))
-                       (org-gtd--without-kill-merge
-                         (org-copy-subtree))
-                       (current-kill 0)))
-        ;; Capture marker value while still in WIP buffer
-        (source-marker org-gtd-clarify--source-heading-marker))
-    (when (and source-marker
-               (markerp source-marker)
-               (marker-buffer source-marker))
-      (with-current-buffer (marker-buffer source-marker)
-        (goto-char source-marker)
-        (org-back-to-heading t)
-        ;; Capture the original outline level: the WIP subtree is always
-        ;; pasted at level 1, so re-level it to match the source heading
-        ;; instead of inserting raw level-1 text (issue #291).
-        (let ((level (org-outline-level)))
-          (org-gtd--without-kill-merge
-            (org-cut-subtree))
-          (org-paste-subtree level new-content))
-        (save-buffer)))))
+Uses `org-gtd-clarify--source-heading-marker' to find the original
+location.  Thin wrapper over the shared write-back primitive
+`org-gtd-clarify--overwrite-source-with-wip' (also used by the inbox
+save-on-quit safety net), which keeps the re-leveling logic in one
+place (issue #291)."
+  (org-gtd-clarify--overwrite-source-with-wip))
 
 (defun org-gtd-organize--call (func)
   "Wrap FUNC, which does the real work, to keep Emacs clean.

--- a/test/unit/inbox-walk-test.el
+++ b/test/unit/inbox-walk-test.el
@@ -264,6 +264,104 @@ via org-gtd-walk-advance instead of erroring (D2 durability guard)."
         (setq clarify-id org-gtd-clarify--clarify-id))
       (org-gtd-wip--cleanup-temp-file clarify-id))))
 
+;;; Save-on-quit safety net (in-progress edits)
+
+(deftest inbox-walk/render-leaves-surface-unmodified ()
+  "After rendering an inbox item, the surface reports unmodified so a
+later quit can distinguish an edited item (save its edits back) from an
+untouched one (discard, no churn)."
+  (capture-inbox-item "Glance and quit")
+  (let* ((model (org-gtd-inbox-walk--build-model))
+         (token (car (plist-get model :entries)))
+         (surface (org-gtd-inbox-walk--surface))
+         clarify-id)
+    (with-current-buffer surface
+      (setq-local org-gtd-walk--active (list :model model)))
+    (org-gtd-inbox-walk--render token surface)
+    (with-current-buffer surface
+      (assert-nil (buffer-modified-p))
+      (setq clarify-id org-gtd-clarify--clarify-id))
+    (org-gtd-wip--cleanup-temp-file clarify-id)))
+
+(deftest inbox-walk/quit-after-edit-saves-changes-back-to-inbox ()
+  "Quitting inbox processing while mid-clarify on an edited item writes
+the in-progress edits back over the source inbox heading, so re-running
+picks the item up in its edited form (the save-on-quit safety net)."
+  (capture-inbox-item "Buy milk")
+  (let* ((model (org-gtd-inbox-walk--build-model))
+         (surface (org-gtd-inbox-walk--surface)))
+    (org-gtd-walk-start (org-gtd-inbox-walk--spec) surface model)
+    (with-current-buffer surface
+      ;; Simulate the user editing the item before deciding on it.
+      (goto-char (point-min))
+      (search-forward "Buy milk")
+      (replace-match "Buy oat milk")
+      (assert-true (buffer-modified-p))
+      (org-gtd-clarify--stop-walk))
+    (with-current-buffer (find-file-noselect (org-gtd-inbox-path))
+      (assert-match "Buy oat milk" (buffer-string)))))
+
+(deftest inbox-walk/quit-without-edit-leaves-inbox-heading-intact ()
+  "Quitting without touching the item leaves the source inbox heading
+exactly as captured (the gate: no needless rewrite of a glanced item)."
+  (capture-inbox-item "Untouched item")
+  (let* ((model (org-gtd-inbox-walk--build-model))
+         (surface (org-gtd-inbox-walk--surface)))
+    (org-gtd-walk-start (org-gtd-inbox-walk--spec) surface model)
+    (with-current-buffer surface
+      (org-gtd-clarify--stop-walk))
+    (with-current-buffer (find-file-noselect (org-gtd-inbox-path))
+      (goto-char (point-min))
+      (assert-equal 1 (length (org-map-entries #'point-marker "LEVEL=1")))
+      (assert-match "Untouched item" (buffer-string)))))
+
+(deftest inbox-walk/kill-buffer-after-edit-saves-changes-back-to-inbox ()
+  "Killing the surface buffer directly (C-x k) is also an abandonment:
+in-progress edits are written back over the source inbox heading and the
+walk's scope lock is released."
+  (capture-inbox-item "Kill me")
+  (let* ((model (org-gtd-inbox-walk--build-model))
+         (surface (org-gtd-inbox-walk--surface))
+         (spec (org-gtd-inbox-walk--spec)))
+    (org-gtd-walk-start spec surface model)
+    (with-current-buffer surface
+      (goto-char (point-min))
+      (search-forward "Kill me")
+      (replace-match "Kill me EDITED"))
+    ;; Directly killing the surface fires the buffer-local kill-buffer
+    ;; hooks (query then cleanup), the non-`q' abandonment route.
+    (kill-buffer surface)
+    (assert-false (org-gtd-walk--scope-locked-p (plist-get spec :scope)))
+    (with-current-buffer (find-file-noselect (org-gtd-inbox-path))
+      (assert-match "Kill me EDITED" (buffer-string)))))
+
+(deftest inbox-walk/skip-to-duplicate-does-not-save-current-edits ()
+  "Stopping while a duplicate is pending SKIPS the current item to the
+duplicate (an explicit discard of the current item), so edits to the
+current item are NOT written back to the inbox."
+  (capture-inbox-item "Parent item")
+  (let* ((base (org-gtd-inbox-walk--build-model))
+         (dup-token (org-gtd-inbox-walk--token))
+         (with-dup (org-gtd-inbox-walk--meta-put-dup
+                    base dup-token "Dup" "* Dup\n"))
+         (model (org-gtd-walk-model-enqueue with-dup dup-token 'top))
+         (surface (org-gtd-inbox-walk--surface)))
+    (org-gtd-walk-start (org-gtd-inbox-walk--spec) surface model)
+    (with-current-buffer surface
+      (goto-char (point-min))
+      (search-forward "Parent item")
+      (replace-match "Parent item EDITED")
+      ;; A duplicate is pending after the cursor, so stop takes the
+      ;; skip-to-duplicate branch, not the quit-and-save branch.
+      (assert-true (org-gtd-clarify--walk-pending-duplicates))
+      (org-gtd-clarify--stop-walk)
+      ;; Tear down the now-active-on-the-duplicate walk.
+      (let ((org-gtd-clarify--source-heading-marker nil))
+        (org-gtd-walk-quit)))
+    (with-current-buffer (find-file-noselect (org-gtd-inbox-path))
+      (refute-match "EDITED" (buffer-string))
+      (assert-match "Parent item" (buffer-string)))))
+
 (provide 'inbox-walk-test)
 
 ;;; inbox-walk-test.el ends here


### PR DESCRIPTION
## Summary

Adds a **save-on-quit safety net** to inbox processing. When the user quits inbox clarification while mid-item, whatever they had typed into the WIP staging surface used to be silently discarded — the original, untouched inbox heading was reprocessed fresh on the next run. Now those in-progress edits are written back over the source inbox heading, so re-running `org-gtd-process-inbox` resumes the item in its edited form.

This closes the "inbox resume" follow-up. Investigation confirmed inbox resume **already works** at the item granularity — the inbox is a durable queue: un-processed items stay in `inbox.org` and re-running `process-inbox` continues (parity with 4.x). The engine `:resumable` checkpoint is the *wrong* tool here (it would only add a marker-serialization problem and a staleness risk). The one genuine gap was the *current* item's uncommitted edits on quit — which this PR closes.

## What changed

- **Gate on `buffer-modified-p`**, made meaningful by resetting the flag at the end of `org-gtd-inbox-walk--render-marker`: a glanced-but-untouched item is left alone (no needless rewrite), only edited items are saved.
- **Both abandonment routes** wired: `q`/stop (`org-gtd-clarify--stop-walk`, quit branch only — *not* the skip-to-duplicate branch) and `C-x k` (`org-gtd-clarify--kill-buffer-cleanup`). Both funnel through `org-gtd-walk-quit` (which nils the buffer-local session), so there is no double-save.
- **One-off clarify is unaffected** — the save is gated on an active walk, which `org-gtd-clarify-item` never sets.
- **DRY**: the subtree write-back was extracted into `org-gtd-clarify--overwrite-source-with-wip`, now shared with `org-gtd-organize--update-in-place`, so the issue #291 re-leveling logic lives in one place.

## Test Plan

- [x] 5 new tests in `test/unit/inbox-walk-test.el`: edit→quit saves; render leaves surface unmodified (the gate); untouched→quit leaves heading intact; edit→`C-x k` saves + releases the scope lock; skip-to-duplicate does **not** save current edits.
- [x] Full suite: **1598 pass, 0 failures**. Compile clean (`--warnings-as-errors`).
- [x] Independent code review (no correctness issues found).

Note: `test/unit/reactivate-test.el` has a pre-existing order-dependent flake ("State 'WAIT' not valid") that reproduces on the untouched base branch and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)