### PR TITLE
feat: overdue calendar review (REC-UI-04)

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -83,6 +83,14 @@ so pausing, killing the buffer, or crashing loses nothing.
 ~org-gtd-init-system~ is an idempotent first-run setup command that
 creates the GTD files and offers to schedule the review.
 
+*** Actionable overdue-calendar review
+New ~org-gtd-reflect-missed-calendar-review~ is the actionable counterpart
+to the read-only ~org-gtd-reflect-missed-calendar~ view: it walks each open
+Calendar item whose date has passed, one at a time, and lets you decide --
+with consent -- what it becomes now: done, migrate to a next action,
+reschedule, trash, clarify, or skip. Opens nothing when your hard landscape
+is clean.
+
 *** Command center: =w= and =l=
 The Reflect column gains =w= (guided Weekly Review) and =l= (visit the
 checklist templates file).

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -89,7 +89,11 @@ to the read-only ~org-gtd-reflect-missed-calendar~ view: it walks each open
 Calendar item whose date has passed, one at a time, and lets you decide --
 with consent -- what it becomes now: done, migrate to a next action,
 reschedule, trash, clarify, or skip. Opens nothing when your hard landscape
-is clean.
+is clean. The ~clarify~ disposition clarifies the item in place -- the
+review surface itself becomes the editable clarify buffer -- and the
+review automatically advances to the next overdue item once you finish
+organizing it; canceling the clarify (~C-c C-k~) returns to the item
+instead of ending the review.
 
 *** Command center: =w= and =l=
 The Reflect column gains =w= (guided Weekly Review) and =l= (visit the

--- a/docs/plans/2026-07-19-overdue-calendar-review-design.md
+++ b/docs/plans/2026-07-19-overdue-calendar-review-design.md
@@ -1,0 +1,190 @@
+# Overdue Calendar Review (REC-UI-04) — Design
+
+**Status:** Designed 2026-07-19 (co-designed with maintainer). Ready to plan/build.
+**Target:** v5 (`org-gtd-5`).
+**Depends on:** the generalized walk engine (`org-gtd-walk.el`, built) — this is its
+first *net-new actionable* consumer.
+**Supersedes:** the corpus sketch `docs/feature-analysis/ux-workflows/REC-UI-04.md`
+(written pre-engine; expansive). Where they differ, this document wins.
+
+---
+
+## 1. Goal & framing
+
+When a calendar appointment's date passes and the item is still open, it is no longer a
+hard-landscape commitment — it is undecided work masquerading as a past appointment. This
+feature is the **actionable counterpart of the read-only `org-gtd-reflect-missed-calendar`
+view**: it walks each overdue calendar item one at a time and lets the user decide, with
+consent, what each one *becomes now*. Nothing moves without a keypress.
+
+**This is a review operation** (the GTD "Get Current → review previous calendar data"
+pass), not a bulk "migrate." Migration to a next action is merely one of the dispositions
+offered per item. Naming and structure therefore join the `org-gtd-reflect-*` review
+family, alongside `org-gtd-reflect-someday-review`.
+
+## 2. Interaction model
+
+A **walk consumer**, structurally identical to `org-gtd-someday-review`:
+
+- A disposable, re-runnable, full-frame console showing **one overdue item at a time,
+  read-only**, with a header-line action bar.
+- The user presses a disposition key; the walk auto-advances to the next item.
+- `:resumable nil` — no checkpoint, no back-with-undo. Skipped/undecided items simply
+  reappear on the next run (a veto is "not now," not "never").
+- Concurrency: `:scope` = `(org-agenda-files)` (same as someday-review), so this review
+  and the someday review are mutually exclusive — you don't run both at once.
+- **No implicit mutating default on `RET`.** Every disposition is consequential (it
+  archives/refiles/retypes), so each requires its own explicit key. `s` skips, `q` stops.
+
+## 3. Disposition set (the action bar)
+
+Reviewing a passed appointment, the item either happened, still needs doing, needs a new
+date, is irrelevant, or needs rethinking:
+
+| key | disposition | meaning | mechanism |
+|-----|-------------|---------|-----------|
+| `d` | **done** | it happened — I just didn't check it off | `(org-todo (org-gtd-keywords--done))` + `(org-gtd-archive-item-at-point)` (the `done-and-archive` path) |
+| `m` | **migrate → Next Action** | didn't happen, still needs doing | `(org-gtd-process-heading marker 'next-action)` |
+| `r` | **reschedule** | didn't happen, needs a new date | `(org-gtd-process-heading marker 'calendar '((:when . "<NEW>")))` |
+| `t` | **trash** | didn't happen, irrelevant now | `(org-gtd-process-heading marker 'trash)` (its `cancel-and-archive` disposition) |
+| `c` | **clarify** | rethink it fully (project? delegate? etc.) | `org-gtd-clarify-item` on the item — the heavy escape hatch |
+| `s` | **skip** | decide later (not a change) | `org-gtd-walk-advance` |
+| `q` | **quit** | stop the review | `org-gtd-walk-quit` + teardown |
+
+The corpus's `keep` ("leave it overdue as-is") is intentionally **dropped**: an overdue
+hard-landscape item is by definition no longer a valid calendar entry, so "keep it
+rotting" is not a real disposition — it collapses into `skip`.
+
+### 3.1 Action mechanics — the key decision
+
+`m`, `r`, and `t` all reuse the **existing, headless, full-fidelity** organize pipeline
+`org-gtd-process-heading` (organize-core.el), which is exactly "clean up an item + set it
+as a type + file it":
+
+1. `org-gtd--clear-foreign-properties TYPE` — deletes the old type's properties that the
+   new type doesn't declare. For `migrate`, this **auto-drops the dead
+   `ORG_GTD_TIMESTAMP`** (a Calendar-only property; next-action declares none).
+2. the type's organize-fn (sets `ORG_GTD` + TODO state; reads CONFIG non-interactively).
+3. `org-gtd--run-disposition` — refiles to the type's home (Calendar → Actions for
+   migrate) or archives (trash).
+
+**Suppress the decoration hooks.** The item is *already clarified* — it carries its tags,
+effort, and area-of-focus. So each mutating action runs the pipeline with the user's
+classic `org-gtd-organize-hooks` bound off, to avoid re-prompting (`org-set-tags-command`
+etc.):
+
+```elisp
+(let ((org-gtd-organize-hooks nil))
+  (org-gtd-process-heading marker TYPE CONFIG))
+```
+
+The structural pipeline (property reconcile, organize-fn, disposition/refile, and the
+internal `:before/after-organize`/`:before/after-file` extension hooks — empty by
+default) still runs, so a migrated item is indistinguishable from a normally-organized
+next action *except* that it isn't re-decorated.
+
+`d` (done) does not go through `process-heading` because "done" is a disposition, not a
+type; it calls the two `done-and-archive` steps directly (no organize hooks are involved,
+so nothing to suppress). `c` (clarify) is the one action that opens the full interactive
+flow.
+
+Each action is wrapped in `org-gtd-walk-call-action` and calls `org-gtd-walk-advance` on
+success (the `someday-review--defer` template): resolve the current id → marker → act →
+bump counter → advance.
+
+## 4. Detection (`:find`)
+
+Mirrors `org-gtd-someday-review--find-items`: scan `org-agenda-files`, collect the
+`org-id` of every heading that satisfies the **same predicate the missed-calendar view
+uses**, composed from `org-gtd-skip.el` factory predicates:
+
+- `ORG_GTD = "Calendar"`, **and**
+- not done (`org-gtd-pred--not-done`), **and**
+- `ORG_GTD_TIMESTAMP` strictly before today (`org-gtd-pred--property-before-date` with
+  today as reference — a *today* appointment hasn't lapsed yet), **and**
+- **not an org-habit** (the view language's `not-habit` filter / `STYLE: habit`).
+
+Reusing the view predicate means the console shows exactly what the read-only
+`org-gtd-reflect-missed-calendar` view shows — one shared definition of "overdue calendar."
+
+**Repeaters:** repeating *Calendar* items (`<… +1w>`) **are included** (parity with the
+view). They are an edge case — genuinely recurring commitments belong to the Habit type,
+which the `not-habit` filter excludes. If one surfaces, the user handles it with
+`reschedule`/`clarify` rather than the `migrate` default; `migrate` is never forced.
+
+`:resolve` = `org-id-find`.
+
+## 5. Render (`:render`)
+
+Read-only detail pane (the `someday-review--render` pattern — read-only buffer, header-line
+action bar), showing per item:
+
+- the heading;
+- the lapsed date, humanized: `was: 2026-06-12 (37 days ago)`;
+- the body;
+- the area-of-focus, if any;
+- a one-line teaching framing (`This date has passed — decide what it is now.`).
+
+The header-line advertises the disposition keys. A dead/already-handled marker (e.g. the
+item was migrated in another buffer) **auto-skips** — the engine's stale-handle guard
+already does this via `org-gtd-walk-advance`.
+
+## 6. Counters, completion, empty state
+
+- Live counters (buffer-local, `someday-review--counters` pattern):
+  `reviewed N · done N · migrated N · rescheduled N · trashed N · skipped N`.
+- `:on-finish` — clean up the surface temp file and report the tally.
+- **Empty state**: if `:find` returns nothing, the console never opens; message
+  `No overdue calendar items — your hard landscape is clean.`
+
+## 7. Entry point & naming
+
+- **v1 = one standalone command: `org-gtd-reflect-missed-calendar-review`** (autoloaded).
+  The actionable review counterpart of the read-only `org-gtd-reflect-missed-calendar`.
+- Major mode `org-gtd-reflect-missed-calendar-review-mode` with its own keymap (the `d m r
+  t c s q` bindings); buffer `*Org GTD Missed Calendar Review*`.
+- Spec registered into `org-gtd-walks` under `'missed-calendar-review`.
+
+## 8. Edge cases & error handling
+
+- **Item changed under us** — `:resolve`/render re-check at act time; a dead marker
+  auto-skips (engine guard) rather than erroring.
+- **Reschedule to a past date** — `org-read-date`, then **re-prompt until the chosen date
+  is today-or-later** (`That date is also in the past — pick today or later.`). A past
+  reschedule is rejected, not silently accepted.
+- **Action fails soft** — a migration whose target is malformed leaves the item untouched
+  and reports to the header-line in org-gtd's teaching-error voice; the review continues.
+  Actions run inside `org-gtd-walk-call-action`, so an error releases the walk cleanly.
+- **Concurrency** — `:scope` lock refuses a second overlapping walk with the engine's
+  standard "a walk is already active over scope …" message.
+
+## 9. Testing plan
+
+Tier-3 adapter tests (the `inbox-walk-test.el` / `someday-review` harness), driving
+`:find`/`:render`/actions directly and via `org-gtd-walk-start`:
+
+- detection: includes overdue calendar; excludes today/future, done, non-calendar, and
+  org-habit items; **includes** a repeating calendar item.
+- each disposition at a marker produces the right end-state: `d` → archived done; `m` →
+  `ORG_GTD=Actions`, NEXT, timestamp dropped, filed under Actions; `r` → stays Calendar
+  with the new timestamp; `t` → archived canceled; `s` → advances, no change.
+- **hooks suppressed**: a migrate with a prompting `org-gtd-organize-hooks` value does not
+  fire it (bind a hook that would error/record, assert it didn't run).
+- reschedule rejects a past date (re-prompt loop).
+- empty state opens no console.
+- counters tally; `:on-finish` cleans up.
+
+## 10. Deferred (not in v1)
+
+- **Command-center row** and **embedding as a Weekly-Review step** — both are trivial once
+  the walk exists (register/point at the same spec); deferred to follow-ups.
+- **Resume / back-with-undo** — out of scope (disposable, re-runnable by design).
+- A first-class general `org-gtd-retype` abstraction — **not built** (YAGNI): `migrate`
+  rides the existing `org-gtd-process-heading`; extract a named retype primitive only if a
+  second real caller appears.
+
+## 11. Provenance
+
+REC-UI-04 (journal foundational consumer; walk-engine dependency now BUILT). GTD "review
+previous calendar data" (Get Current). Sibling of the read-only
+`org-gtd-reflect-missed-calendar` view and of `org-gtd-reflect-someday-review`.

--- a/docs/plans/2026-07-19-overdue-calendar-review-plan.md
+++ b/docs/plans/2026-07-19-overdue-calendar-review-plan.md
@@ -1,0 +1,1234 @@
+# Overdue Calendar Review (REC-UI-04) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build `org-gtd-reflect-missed-calendar-review`, an actionable walk-engine
+console that walks each overdue Calendar item one at a time and lets the user decide,
+with consent, what each one becomes now (done / migrate / reschedule / trash / clarify /
+skip).
+
+**Architecture:** A new module, `org-gtd-reflect-missed-calendar-review.el`, that is a
+*walk consumer* — structurally a clone of `org-gtd-someday-review.el`. It registers a spec
+into the `org-gtd-walks` registry and drives it through the generic engine
+(`org-gtd-walk.el`). Detection reuses the exact `org-gtd-skip.el` factory predicates the
+read-only missed-calendar view composes. Mutating dispositions reuse the headless
+`org-gtd-process-heading` pipeline with the decoration hooks bound off (the item is already
+clarified).
+
+**Tech Stack:** Emacs Lisp; the e-unit test framework (`deftest`, run **only** via the
+project `/test` skill); the walk engine (`org-gtd-walk.el`, `org-gtd-walk-model.el`); the
+organize pipeline (`org-gtd-organize-core.el`).
+
+---
+
+## Orientation for the executor (read before Task 1)
+
+You know Elisp but nothing about this codebase. Read these files first — the new module is
+modeled directly on them:
+
+- **`org-gtd-someday-review.el`** — the canonical walk-consumer template. Your new module
+  mirrors its shape: a fixed WIP surface key, buffer-local counters, a mode + keymap, a
+  `--find-items`/`--make-find`/`--resolve`/`--render`/`--surface`/`--bump`/`--on-finish`/`--spec`
+  set, a `(org-gtd-walk-register ...)` call, the mode, and an autoloaded entry command that
+  calls `org-gtd-walk-start`.
+- **`org-gtd-walk.el`** — the engine. Key entry points you will call: `org-gtd-walk-start`,
+  `org-gtd-walk-advance`, `org-gtd-walk-quit`, `org-gtd-walk-call-action`,
+  `org-gtd-walk-register`, `org-gtd-walk-get`, `org-gtd-walk-model-current`. Note the
+  `:scope` concurrency lock and the stale-handle auto-skip in `org-gtd-walk--settle` (a
+  `:resolve` that returns nil makes the engine skip that item automatically).
+- **`org-gtd-organize-core.el`** — `org-gtd-process-heading (pom type &optional config)` is
+  the headless organize pipeline. Step 4 of its pipeline runs `org-gtd-organize-apply-hooks`
+  which iterates the dynamic variable `org-gtd-organize-hooks`; binding it to nil at the
+  call site suppresses re-decoration.
+- **`org-gtd-skip.el`** — the predicate factories. Each returns a *closure*; capture the
+  closure once in an outer `let`, then `funcall` it per heading (do not rebuild it inside
+  the scan loop).
+- **`test/unit/someday-review-test.el`** — the harness you copy: `deftest`, the
+  `around-each` that wraps every test in `ogt-eunit-with-mock-gtd`, and the pattern of
+  starting a walk then driving commands inside `(with-current-buffer (car
+  (org-gtd-wip--get-buffers)) ...)`.
+
+### Verified facts (these override the design doc where they differ)
+
+The design doc (`docs/plans/2026-07-19-overdue-calendar-review-design.md`) names some
+functions loosely. Use these **verified** names/values instead:
+
+1. **Overdue predicate name.** The design's `org-gtd-pred--property-before-date` does **not
+   exist**. The real "timestamp before today" factory is
+   `org-gtd-pred--property-ts< (property reference-date)` and the view composes overdue as
+   `(org-gtd-pred--property-ts< "ORG_GTD_TIMESTAMP" "today")`. Use that.
+2. **The Calendar timestamp property** is `"ORG_GTD_TIMESTAMP"`. Get it via
+   `(org-gtd-type-property 'calendar :when)` (returns `"ORG_GTD_TIMESTAMP"`) for DRY, exactly
+   as the view language does.
+3. **The ORG_GTD value strings** come from `(org-gtd-type-org-gtd-value 'calendar)` →
+   `"Calendar"` and `(org-gtd-type-org-gtd-value 'habit)` → `"Habit"`. Do not hardcode.
+4. **`not-habit` filter.** The view language implements `not-habit` as
+   `(org-gtd-pred--property-not-equals "ORG_GTD" (org-gtd-type-org-gtd-value 'habit))`. Reuse
+   that. (Note: because the find already requires `ORG_GTD = "Calendar"`, this predicate is
+   logically redundant — an item can't be both Calendar and Habit — but we include it for
+   parity with the design's stated definition of "overdue calendar.")
+5. **Reschedule config value must include the angle brackets.**
+   `org-gtd-configure-as-type` writes the `:when` value verbatim into `ORG_GTD_TIMESTAMP`,
+   so the config must be `(list (cons :when (format "<%s>" date)))`, i.e. `"<2026-08-01>"`,
+   never a bare `"2026-08-01"`. This mirrors `org-gtd-calendar` in `org-gtd-calendar.el`.
+6. **Done path needs no manual subtree-kill guard.** `org-gtd-archive-item-at-point`
+   (`org-gtd-archive.el`) already wraps `org-archive-subtree` in `org-gtd--without-kill-merge`
+   internally. The `d` command just calls `(org-todo (org-gtd-keywords--done))` then
+   `(org-gtd-archive-item-at-point)`. The `--render` copy path, however, *does* need the
+   `org-gtd--without-kill-merge` wrapper around its `org-copy-subtree`, same as someday-review.
+
+### Testing protocol (applies to EVERY task)
+
+- **Never run `eldev` directly.** Run tests **only** through the project `/test` skill.
+- The test command in every task below is written as: **Run the /test skill on
+  `test/unit/missed-calendar-review-test.el`**. Do exactly that.
+- Framework is **e-unit**: use `deftest`, `assert-equal`, `assert-true`, `assert-nil`,
+  `assert-match`, `assert-same`. Not ERT.
+- All behavioral tests must run inside the `ogt-eunit-with-mock-gtd` context via the
+  `around-each` hook (copy it verbatim from `someday-review-test.el`).
+
+### Test fixture helper (used by many tasks)
+
+Because `make-task` (in `test/helpers/builders.el`) hardcodes `:ORG_GTD: Actions`, do **not**
+use it for Calendar fixtures. Instead add this small helper near the top of the test file
+(after the `around-each`) and use it to seed overdue Calendar items directly into the
+default GTD file:
+
+```elisp
+(defun mcr-test--make-calendar (title timestamp)
+  "Insert a Calendar item TITLE with ORG_GTD_TIMESTAMP TIMESTAMP into the GTD file.
+TIMESTAMP is a full org stamp string, e.g. \"<2020-01-01>\".  Returns the id."
+  (with-current-buffer (org-gtd--default-file)
+    (goto-char (point-max))
+    (let ((id (org-id-uuid)))
+      (insert (format "* %s\n:PROPERTIES:\n:ID: %s\n:ORG_GTD: Calendar\n:ORG_GTD_TIMESTAMP: %s\n:END:\n"
+                      title id timestamp))
+      (save-buffer)
+      id)))
+```
+
+A "past" stamp is any date before today, e.g. `"<2020-01-01>"`. A "future" stamp is e.g.
+`"<2099-01-01>"`. For "today", compute `(format-time-string "<%Y-%m-%d>")`.
+
+---
+
+## Task 1: Module skeleton + detection (`:find` / `:resolve`) + load wiring
+
+**Files:**
+- Create: `org-gtd-reflect-missed-calendar-review.el`
+- Modify: `org-gtd.el` (add one `require` after line 84)
+- Create: `test/unit/missed-calendar-review-test.el`
+
+**Step 1: Write the failing tests**
+
+Create `test/unit/missed-calendar-review-test.el`:
+
+```elisp
+;;; missed-calendar-review-test.el --- Tests for overdue calendar review -*- lexical-binding: t; coding: utf-8 -*-
+
+;; Copyright (C) 2026 Aldric Giacomoni
+
+;;; Commentary:
+;;
+;; Tests for the actionable overdue-calendar review walk (REC-UI-04).
+
+;;; Code:
+
+(require 'ogt-eunit-prelude "test/helpers/prelude.el")
+(require 'org-gtd-reflect-missed-calendar-review)
+(require 'org-gtd-walk)
+
+(e-unit-initialize)
+
+(around-each (proceed context)
+  (ogt-eunit-with-mock-gtd
+    (funcall proceed context)))
+
+(defun mcr-test--make-calendar (title timestamp)
+  "Insert a Calendar item TITLE with ORG_GTD_TIMESTAMP TIMESTAMP into the GTD file.
+Returns the id."
+  (with-current-buffer (org-gtd--default-file)
+    (goto-char (point-max))
+    (let ((id (org-id-uuid)))
+      (insert (format "* %s\n:PROPERTIES:\n:ID: %s\n:ORG_GTD: Calendar\n:ORG_GTD_TIMESTAMP: %s\n:END:\n"
+                      title id timestamp))
+      (save-buffer)
+      id)))
+
+;;; Detection
+
+(deftest mcr/find-includes-overdue-calendar ()
+  "An open Calendar item dated before today is detected."
+  (mcr-test--make-calendar "Dentist" "<2020-01-01>")
+  (assert-equal 1 (length (org-gtd-reflect-missed-calendar-review--find-items))))
+
+(deftest mcr/find-excludes-today-and-future ()
+  "A Calendar item dated today or in the future is not overdue."
+  (mcr-test--make-calendar "Today thing" (format-time-string "<%Y-%m-%d>"))
+  (mcr-test--make-calendar "Future thing" "<2099-01-01>")
+  (assert-equal 0 (length (org-gtd-reflect-missed-calendar-review--find-items))))
+
+(deftest mcr/find-excludes-done ()
+  "A done Calendar item is not detected."
+  (let ((id (mcr-test--make-calendar "Happened" "<2020-01-01>")))
+    (let ((m (org-id-find id 'marker)))
+      (org-with-point-at m
+        (let ((org-inhibit-logging t)) (org-todo (org-gtd-keywords--done)))
+        (save-buffer))))
+  (assert-equal 0 (length (org-gtd-reflect-missed-calendar-review--find-items))))
+
+(deftest mcr/find-excludes-non-calendar ()
+  "A non-Calendar heading with a past timestamp is not detected."
+  (with-current-buffer (org-gtd--default-file)
+    (goto-char (point-max))
+    (insert "* A next action\n:PROPERTIES:\n:ID: mcr-na-1\n:ORG_GTD: Actions\n:ORG_GTD_TIMESTAMP: <2020-01-01>\n:END:\n")
+    (save-buffer))
+  (assert-equal 0 (length (org-gtd-reflect-missed-calendar-review--find-items))))
+
+(deftest mcr/find-excludes-habit ()
+  "A Habit heading with a past timestamp is not detected."
+  (with-current-buffer (org-gtd--default-file)
+    (goto-char (point-max))
+    (insert "* A routine\n:PROPERTIES:\n:ID: mcr-hab-1\n:ORG_GTD: Habit\n:ORG_GTD_TIMESTAMP: <2020-01-01>\n:STYLE: habit\n:END:\n")
+    (save-buffer))
+  (assert-equal 0 (length (org-gtd-reflect-missed-calendar-review--find-items))))
+
+(deftest mcr/find-includes-repeating-calendar ()
+  "A repeating Calendar item with a past base date is included (view parity)."
+  (mcr-test--make-calendar "Weekly sync" "<2020-01-01 +1w>")
+  (assert-equal 1 (length (org-gtd-reflect-missed-calendar-review--find-items))))
+
+(deftest mcr/resolve-rejects-missing-id ()
+  "The :resolve predicate is nil for an unknown id, non-nil for a real one."
+  (let ((id (mcr-test--make-calendar "Real" "<2020-01-01>")))
+    (assert-true (org-gtd-reflect-missed-calendar-review--resolve id))
+    (assert-nil (org-gtd-reflect-missed-calendar-review--resolve "no-such-id-xyz"))))
+
+(provide 'missed-calendar-review-test)
+
+;;; missed-calendar-review-test.el ends here
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run the /test skill on `test/unit/missed-calendar-review-test.el`.
+Expected: FAIL — `Cannot open load file: org-gtd-reflect-missed-calendar-review` (the module
+does not exist yet).
+
+**Step 3: Write the module skeleton + detection**
+
+Create `org-gtd-reflect-missed-calendar-review.el`:
+
+```elisp
+;;; org-gtd-reflect-missed-calendar-review.el --- Actionable overdue-calendar review -*- lexical-binding: t; coding: utf-8 -*-
+;;
+;; Copyright © 2026 Aldric Giacomoni
+
+;; Author: Aldric Giacomoni <trevoke@gmail.com>
+;; This file is not part of GNU Emacs.
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; The actionable counterpart of the read-only `org-gtd-reflect-missed-calendar'
+;; view: a walk that shows each overdue Calendar item one at a time and lets the
+;; user decide -- with consent -- what each one becomes now (done, migrate to a
+;; next action, reschedule, trash, clarify, or skip).  A walk consumer,
+;; structurally identical to `org-gtd-someday-review'.  See
+;; docs/plans/2026-07-19-overdue-calendar-review-design.md.
+;;
+;;; Code:
+
+;;;; Requirements
+
+(require 'org)
+(require 'org-id)
+(require 'org-gtd-core)
+(require 'org-gtd-wip)
+(require 'org-gtd-skip)
+(require 'org-gtd-types)
+(require 'org-gtd-organize-core)
+(require 'org-gtd-archive)
+(require 'org-gtd-clarify)
+(require 'org-gtd-walk-model)
+(require 'org-gtd-walk)
+
+;;;; External Function Declarations
+
+;; Evil functions (only called inside with-eval-after-load 'evil)
+(declare-function evil-set-initial-state "evil-core")
+(declare-function evil-emacs-state "evil-states")
+
+;;;; Variables
+
+(defconst org-gtd-reflect-missed-calendar-review--surface-key "missed-calendar-review"
+  "Fixed WIP key for the single missed-calendar-review surface buffer.")
+
+;;;; Detection
+
+(defun org-gtd-reflect-missed-calendar-review--find-items ()
+  "Return the org-ids of every overdue Calendar item across `org-agenda-files'.
+
+Composes the SAME `org-gtd-skip.el' predicates the read-only
+`org-gtd-reflect-missed-calendar' view uses: ORG_GTD = Calendar, not
+done, ORG_GTD_TIMESTAMP strictly before today, and not an org-gtd habit.
+The predicate factories are captured once in the outer `let' and
+`funcall'ed per heading."
+  (let ((calendar-p (org-gtd-pred--property-equals
+                     "ORG_GTD" (org-gtd-type-org-gtd-value 'calendar)))
+        (not-done-p (org-gtd-pred--not-done))
+        (overdue-p (org-gtd-pred--property-ts<
+                    (org-gtd-type-property 'calendar :when) "today"))
+        (not-habit-p (org-gtd-pred--property-not-equals
+                      "ORG_GTD" (org-gtd-type-org-gtd-value 'habit)))
+        (items '()))
+    (dolist (file (org-agenda-files))
+      (when (file-exists-p file)
+        (with-current-buffer (find-file-noselect file)
+          (org-with-wide-buffer
+           (goto-char (point-min))
+           (while (re-search-forward "^\\*+ " nil t)
+             (when (and (funcall calendar-p)
+                        (funcall not-done-p)
+                        (funcall overdue-p)
+                        (funcall not-habit-p))
+               (push (org-id-get-create) items)))))))
+    (nreverse items)))
+
+(defun org-gtd-reflect-missed-calendar-review--resolve (id)
+  "Return non-nil when ID still resolves to a live heading marker."
+  (org-id-find id 'marker))
+
+;;;; Footer
+
+(provide 'org-gtd-reflect-missed-calendar-review)
+
+;;; org-gtd-reflect-missed-calendar-review.el ends here
+```
+
+**Step 4: Wire the require into `org-gtd.el`**
+
+In `org-gtd.el`, immediately after the line `(require 'org-gtd-someday-review)` (line 84),
+add:
+
+```elisp
+(require 'org-gtd-reflect-missed-calendar-review)
+```
+
+**Step 5: Run tests to verify they pass**
+
+Run the /test skill on `test/unit/missed-calendar-review-test.el`.
+Expected: PASS (all 7 detection/resolve tests green).
+
+**Step 6: Commit**
+
+```bash
+git add org-gtd-reflect-missed-calendar-review.el org-gtd.el test/unit/missed-calendar-review-test.el
+git commit -m "feat: add overdue-calendar-review module skeleton + detection"
+```
+
+---
+
+## Task 2: Mode, keymap, and read-only render
+
+**Files:**
+- Modify: `org-gtd-reflect-missed-calendar-review.el`
+- Test: `test/unit/missed-calendar-review-test.el`
+
+**Step 1: Write the failing tests**
+
+Append to the test file (before the `(provide ...)` line):
+
+```elisp
+;;; Mode + keymap
+
+(deftest mcr/mode-is-derived-from-org-mode ()
+  "Review mode is derived from org-mode."
+  (with-temp-buffer
+    (org-gtd-reflect-missed-calendar-review-mode)
+    (assert-true (derived-mode-p 'org-mode))))
+
+(deftest mcr/mode-has-disposition-keybindings ()
+  "The mode keymap binds every disposition key to its command."
+  (let ((map org-gtd-reflect-missed-calendar-review-mode-map))
+    (assert-equal 'org-gtd-reflect-missed-calendar-review-done
+                  (lookup-key map (kbd "d")))
+    (assert-equal 'org-gtd-reflect-missed-calendar-review-migrate
+                  (lookup-key map (kbd "m")))
+    (assert-equal 'org-gtd-reflect-missed-calendar-review-reschedule
+                  (lookup-key map (kbd "r")))
+    (assert-equal 'org-gtd-reflect-missed-calendar-review-trash
+                  (lookup-key map (kbd "t")))
+    (assert-equal 'org-gtd-reflect-missed-calendar-review-clarify
+                  (lookup-key map (kbd "c")))
+    (assert-equal 'org-gtd-reflect-missed-calendar-review-skip
+                  (lookup-key map (kbd "s")))
+    (assert-equal 'org-gtd-reflect-missed-calendar-review-quit
+                  (lookup-key map (kbd "q")))))
+
+;;; Render
+
+(deftest mcr/render-fills-surface-read-only ()
+  "Render draws the item, activates review mode read-only, humanizes the
+lapse, and advertises the disposition keys."
+  (let* ((id (mcr-test--make-calendar "Overdue thing" "<2020-01-01>"))
+         (surface (org-gtd-wip--get-buffer
+                   org-gtd-reflect-missed-calendar-review--surface-key)))
+    (with-current-buffer surface
+      (setq-local org-gtd-walk--active
+                  (list :model (org-gtd-walk-model-create (list id))))
+      (org-gtd-reflect-missed-calendar-review--render id surface)
+      (assert-true (eq major-mode 'org-gtd-reflect-missed-calendar-review-mode))
+      (assert-true buffer-read-only)
+      (assert-match "Overdue thing" (buffer-string))
+      (assert-match "days ago" (buffer-string))
+      (assert-match "\\[d\\] Done" header-line-format)
+      (assert-match "\\[r\\] Reschedule" header-line-format)
+      (assert-match "(1/1)" header-line-format))
+    (org-gtd-wip--cleanup-temp-file
+     org-gtd-reflect-missed-calendar-review--surface-key)))
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run the /test skill on `test/unit/missed-calendar-review-test.el`.
+Expected: FAIL — the mode, keymap, and render function are undefined.
+
+**Step 3: Implement mode, keymap, humanize helper, and render**
+
+In `org-gtd-reflect-missed-calendar-review.el`, add a `;;;; Keymaps` section after the
+`;;;; Variables` section:
+
+```elisp
+;;;; Keymaps
+
+(defvar org-gtd-reflect-missed-calendar-review-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map org-mode-map)
+    (define-key map (kbd "d") #'org-gtd-reflect-missed-calendar-review-done)
+    (define-key map (kbd "m") #'org-gtd-reflect-missed-calendar-review-migrate)
+    (define-key map (kbd "r") #'org-gtd-reflect-missed-calendar-review-reschedule)
+    (define-key map (kbd "t") #'org-gtd-reflect-missed-calendar-review-trash)
+    (define-key map (kbd "c") #'org-gtd-reflect-missed-calendar-review-clarify)
+    (define-key map (kbd "s") #'org-gtd-reflect-missed-calendar-review-skip)
+    (define-key map (kbd "q") #'org-gtd-reflect-missed-calendar-review-quit)
+    map)
+  "Keymap for `org-gtd-reflect-missed-calendar-review-mode'.")
+```
+
+Add a `;;;; Render` section after the `;;;; Detection` section:
+
+```elisp
+;;;; Render
+
+(defun org-gtd-reflect-missed-calendar-review--humanize-lapse (ts-string)
+  "Return a humanized description of the lapsed date TS-STRING.
+E.g. \"was: 2026-06-12 (37 days ago)\".  Returns \"date unknown\" when
+TS-STRING cannot be parsed."
+  (let ((ts (org-gtd--parse-timestamp ts-string)))
+    (if (null ts)
+        "date unknown"
+      (let ((days (- (org-today) (time-to-days ts))))
+        (format "was: %s (%d day%s ago)"
+                (format-time-string "%F" ts)
+                days
+                (if (= days 1) "" "s"))))))
+
+(defun org-gtd-reflect-missed-calendar-review--render (id surface)
+  "Render the overdue Calendar item ID into SURFACE (the walk :render contract).
+Resolves ID to a marker, refills SURFACE read-only with the teaching
+framing, the humanized lapse, an optional area-of-focus line, and the
+subtree body, then sets review mode, the header-line action bar, and
+displays the buffer."
+  (let ((marker (org-id-find id 'marker)))
+    (when marker
+      (let ((ts (org-with-point-at marker
+                  (org-entry-get (point) (org-gtd-type-property 'calendar :when))))
+            (aof (org-with-point-at marker
+                   (org-entry-get (point) org-gtd-prop-area-of-focus))))
+        (with-current-buffer surface
+          (let ((inhibit-read-only t)
+                ;; SURFACE is a disposable read-only review copy; suppress
+                ;; org-paste-subtree's id tracking so it never re-registers
+                ;; the pasted :ID: against this copy's temp file (mirrors
+                ;; someday-review--render).
+                (org-id-track-globally nil))
+            (erase-buffer)
+            (insert "# This date has passed -- decide what it is now.\n")
+            (insert (format "# %s\n"
+                            (org-gtd-reflect-missed-calendar-review--humanize-lapse ts)))
+            (when (and aof (not (string-empty-p aof)))
+              (insert (format "# Area of focus: %s\n" aof)))
+            (insert "\n")
+            (org-gtd--without-kill-merge
+              (org-with-point-at marker (org-copy-subtree)))
+            (org-paste-subtree)
+            (goto-char (point-min)))
+          (unless (eq major-mode 'org-gtd-reflect-missed-calendar-review-mode)
+            (org-gtd-reflect-missed-calendar-review-mode))
+          (setq buffer-read-only t)
+          (let* ((model (plist-get org-gtd-walk--active :model))
+                 (pos (1+ (plist-get model :cursor)))
+                 (total (length (plist-get model :entries))))
+            (setq header-line-format
+                  (format (concat "[d] Done  [m] Migrate  [r] Reschedule  "
+                                  "[t] Trash  [c] Clarify  [s] Skip  [q] Quit  (%d/%d)")
+                          pos total)))
+          (pop-to-buffer surface))))))
+```
+
+Add a `;;;; Modes` section just before the `;;;; Footer`:
+
+```elisp
+;;;; Modes
+
+;;;###autoload
+(define-derived-mode org-gtd-reflect-missed-calendar-review-mode org-mode "GTD-MissedCal"
+  "Major mode for reviewing overdue calendar items one at a time.
+Derived from `org-mode'; the buffer is read-only (set in the render
+function) and offers disposition keys.
+
+\\{org-gtd-reflect-missed-calendar-review-mode-map}"
+  :group 'org-gtd)
+
+;;;; Evil-mode Integration
+
+(with-eval-after-load 'evil
+  (evil-set-initial-state 'org-gtd-reflect-missed-calendar-review-mode 'emacs)
+  (add-hook 'org-gtd-reflect-missed-calendar-review-mode-hook #'evil-emacs-state))
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run the /test skill on `test/unit/missed-calendar-review-test.el`.
+Expected: PASS (mode, keymap, and render tests green; Task 1 tests still green).
+
+**Step 5: Commit**
+
+```bash
+git add org-gtd-reflect-missed-calendar-review.el test/unit/missed-calendar-review-test.el
+git commit -m "feat: add overdue-calendar-review mode, keymap, and render"
+```
+
+---
+
+## Task 3: Counters, surface, spec + registration, entry command, quit, empty state
+
+**Files:**
+- Modify: `org-gtd-reflect-missed-calendar-review.el`
+- Test: `test/unit/missed-calendar-review-test.el`
+
+**Step 1: Write the failing tests**
+
+Append to the test file:
+
+```elisp
+;;; Spec registration + entry + empty state
+
+(deftest mcr/registers-a-walk-consumer ()
+  "Loading the module registers a `missed-calendar-review' walk."
+  (let ((spec (org-gtd-walk-get 'missed-calendar-review)))
+    (assert-true spec)
+    (assert-same 'missed-calendar-review (plist-get spec :name))
+    (assert-true (org-gtd-walk--callable-p (plist-get spec :render)))
+    (assert-true (org-gtd-walk--callable-p (plist-get spec :find)))))
+
+(deftest mcr/entry-opens-console-when-items-exist ()
+  "The entry command opens a read-only review surface for the item."
+  (mcr-test--make-calendar "Review me" "<2020-01-01>")
+  (org-gtd-reflect-missed-calendar-review)
+  (let ((bufs (org-gtd-wip--get-buffers)))
+    (assert-true (> (length bufs) 0))
+    (with-current-buffer (car bufs)
+      (assert-true (eq major-mode 'org-gtd-reflect-missed-calendar-review-mode))
+      (assert-true buffer-read-only)
+      (assert-match "Review me" (buffer-string))
+      (org-gtd-reflect-missed-calendar-review-quit))))
+
+(deftest mcr/entry-empty-state-opens-no-console ()
+  "With no overdue calendar items, the console never opens."
+  (org-gtd-reflect-missed-calendar-review)
+  (assert-equal 0 (length (org-gtd-wip--get-buffers))))
+
+(deftest mcr/quit-cleans-up-surface ()
+  "Quit tears down the walk and cleans up the surface buffer."
+  (mcr-test--make-calendar "Item" "<2020-01-01>")
+  (org-gtd-reflect-missed-calendar-review)
+  (assert-true (> (length (org-gtd-wip--get-buffers)) 0))
+  (with-current-buffer (car (org-gtd-wip--get-buffers))
+    (org-gtd-reflect-missed-calendar-review-quit))
+  (assert-equal 0 (length (org-gtd-wip--get-buffers))))
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run the /test skill on `test/unit/missed-calendar-review-test.el`.
+Expected: FAIL — the spec, registration, entry command, and quit command are undefined.
+
+**Step 3: Implement counters, surface, spec, registration, entry, quit**
+
+Add a `defvar-local` in the `;;;; Variables` section (after the surface-key const):
+
+```elisp
+(defvar-local org-gtd-reflect-missed-calendar-review--counters nil
+  "Buffer-local plist of tallies for the active surface:
+\(:reviewed N :done N :migrated N :rescheduled N :trashed N :skipped N).")
+```
+
+Add a `;;;; Walk Surface` section after `;;;; Render`:
+
+```elisp
+;;;; Walk Surface
+
+(defun org-gtd-reflect-missed-calendar-review--surface ()
+  "Return the fresh WIP surface buffer for a missed-calendar-review walk.
+Activates the mode and initializes the buffer-local counters before the
+walk starts, so :render's own mode-activation guard never fires and the
+counters survive the whole walk (mirrors `org-gtd-someday-review--surface')."
+  (let ((buf (org-gtd-wip--get-buffer
+              org-gtd-reflect-missed-calendar-review--surface-key)))
+    (with-current-buffer buf
+      (org-gtd-reflect-missed-calendar-review-mode)
+      (setq-local org-gtd-reflect-missed-calendar-review--counters
+                  (list :reviewed 0 :done 0 :migrated 0
+                        :rescheduled 0 :trashed 0 :skipped 0)))
+    buf))
+
+(defun org-gtd-reflect-missed-calendar-review--bump (key)
+  "Increment counter KEY on the surface buffer's counters plist."
+  (setq org-gtd-reflect-missed-calendar-review--counters
+        (plist-put org-gtd-reflect-missed-calendar-review--counters key
+                   (1+ (plist-get
+                        org-gtd-reflect-missed-calendar-review--counters key)))))
+
+(defun org-gtd-reflect-missed-calendar-review--summary ()
+  "Return the human-readable tally string for the active surface."
+  (let ((c org-gtd-reflect-missed-calendar-review--counters))
+    (format "reviewed %d - done %d - migrated %d - rescheduled %d - trashed %d - skipped %d"
+            (or (plist-get c :reviewed) 0)
+            (or (plist-get c :done) 0)
+            (or (plist-get c :migrated) 0)
+            (or (plist-get c :rescheduled) 0)
+            (or (plist-get c :trashed) 0)
+            (or (plist-get c :skipped) 0))))
+
+(defun org-gtd-reflect-missed-calendar-review--on-finish ()
+  "End-of-walk: report the tally and clean up the surface buffer.
+Runs in the surface buffer after the engine has cleared its session."
+  (let ((summary (org-gtd-reflect-missed-calendar-review--summary)))
+    (org-gtd-wip--cleanup-temp-file
+     org-gtd-reflect-missed-calendar-review--surface-key)
+    (message "Missed-calendar review complete. %s" summary)))
+
+(defun org-gtd-reflect-missed-calendar-review--spec ()
+  "Return the missed-calendar-review walk spec template."
+  (list :name 'missed-calendar-review
+        :find #'org-gtd-reflect-missed-calendar-review--find-items
+        :render #'org-gtd-reflect-missed-calendar-review--render
+        :actions org-gtd-reflect-missed-calendar-review-mode-map
+        :on-finish #'org-gtd-reflect-missed-calendar-review--on-finish
+        :resumable nil
+        :resolve #'org-gtd-reflect-missed-calendar-review--resolve
+        :scope (org-agenda-files)))
+
+(org-gtd-walk-register 'missed-calendar-review
+                       (org-gtd-reflect-missed-calendar-review--spec))
+```
+
+Add a `;;;; Entry Point` section (place it after `;;;; Modes`):
+
+```elisp
+;;;; Entry Point
+
+;;;###autoload
+(defun org-gtd-reflect-missed-calendar-review ()
+  "Review overdue calendar items one at a time.
+The actionable counterpart of the read-only `org-gtd-reflect-missed-calendar'
+view: walks each open Calendar item whose date has passed and lets you
+decide -- with consent -- what it becomes now.  Opens nothing when your
+hard landscape is clean."
+  (interactive)
+  (let ((items (org-gtd-reflect-missed-calendar-review--find-items)))
+    (if (null items)
+        (message "No overdue calendar items -- your hard landscape is clean.")
+      (let ((spec (org-gtd-reflect-missed-calendar-review--spec)))
+        (setq spec (plist-put spec :find (lambda () items)))
+        (setq spec (plist-put spec :scope (org-agenda-files)))
+        (org-gtd-walk-start spec
+                            (org-gtd-reflect-missed-calendar-review--surface))))))
+```
+
+Add a `;;;; Commands` section (place it after `;;;; Entry Point`), starting with just the
+quit command (the disposition commands come in Tasks 4-8):
+
+```elisp
+;;;; Commands
+
+(defun org-gtd-reflect-missed-calendar-review-quit ()
+  "Abandon the review: report the tally, clean up, tear down the walk."
+  (interactive)
+  (let ((summary (org-gtd-reflect-missed-calendar-review--summary)))
+    (org-gtd-walk-quit)
+    (org-gtd-wip--cleanup-temp-file
+     org-gtd-reflect-missed-calendar-review--surface-key)
+    (message "Missed-calendar review complete. %s" summary)))
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run the /test skill on `test/unit/missed-calendar-review-test.el`.
+Expected: PASS (registration, entry, empty-state, quit tests green; earlier tests green).
+
+**Step 5: Commit**
+
+```bash
+git add org-gtd-reflect-missed-calendar-review.el test/unit/missed-calendar-review-test.el
+git commit -m "feat: register overdue-calendar-review walk + entry/quit/empty-state"
+```
+
+---
+
+## Task 4: `d` — done disposition
+
+**Files:**
+- Modify: `org-gtd-reflect-missed-calendar-review.el`
+- Test: `test/unit/missed-calendar-review-test.el`
+
+**Step 1: Write the failing test**
+
+Append to the test file:
+
+```elisp
+;;; Disposition: done
+
+(deftest mcr/done-archives-and-advances ()
+  "`d' marks the item done, archives it, and ends the walk on the last item."
+  (let ((id (mcr-test--make-calendar "It happened" "<2020-01-01>")))
+    (org-gtd-reflect-missed-calendar-review)
+    (with-current-buffer (car (org-gtd-wip--get-buffers))
+      (org-gtd-reflect-missed-calendar-review-done))
+    ;; Only item -> walk finished -> surface cleaned up.
+    (assert-equal 0 (length (org-gtd-wip--get-buffers)))
+    ;; The item is no longer detected as overdue (it was archived away).
+    (assert-equal 0 (length (org-gtd-reflect-missed-calendar-review--find-items)))
+    (ignore id)))
+```
+
+**Step 2: Run test to verify it fails**
+
+Run the /test skill on `test/unit/missed-calendar-review-test.el`.
+Expected: FAIL — `org-gtd-reflect-missed-calendar-review-done` is undefined.
+
+**Step 3: Implement the done command**
+
+In the `;;;; Commands` section, add:
+
+```elisp
+(defun org-gtd-reflect-missed-calendar-review-done ()
+  "Mark the current item done and archive it (it happened), then advance."
+  (interactive)
+  (org-gtd-walk-call-action
+   (lambda ()
+     (let* ((id (org-gtd-walk-model-current
+                 (plist-get org-gtd-walk--active :model)))
+            (marker (org-id-find id 'marker)))
+       (when marker
+         (org-with-point-at marker
+           (org-todo (org-gtd-keywords--done))
+           (org-gtd-archive-item-at-point)))
+       (org-gtd-reflect-missed-calendar-review--bump :reviewed)
+       (org-gtd-reflect-missed-calendar-review--bump :done)
+       (org-gtd-walk-advance)))))
+```
+
+**Step 4: Run test to verify it passes**
+
+Run the /test skill on `test/unit/missed-calendar-review-test.el`.
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add org-gtd-reflect-missed-calendar-review.el test/unit/missed-calendar-review-test.el
+git commit -m "feat: add done disposition to overdue-calendar-review"
+```
+
+---
+
+## Task 5: `m` — migrate to Next Action (with hook suppression)
+
+**Files:**
+- Modify: `org-gtd-reflect-missed-calendar-review.el`
+- Test: `test/unit/missed-calendar-review-test.el`
+
+**Step 1: Write the failing tests**
+
+Append to the test file:
+
+```elisp
+;;; Disposition: migrate
+
+(deftest mcr/migrate-retypes-to-next-action ()
+  "`m' migrates the item to a next action: ORG_GTD=Actions, NEXT state,
+ORG_GTD_TIMESTAMP dropped."
+  (let ((id (mcr-test--make-calendar "Still need to do this" "<2020-01-01>")))
+    (org-gtd-reflect-missed-calendar-review)
+    (with-current-buffer (car (org-gtd-wip--get-buffers))
+      (org-gtd-reflect-missed-calendar-review-migrate))
+    (let ((marker (org-id-find id 'marker)))
+      (assert-true marker)
+      (org-with-point-at marker
+        (assert-equal "Actions" (org-entry-get (point) "ORG_GTD"))
+        (assert-equal (org-gtd-keywords--next) (org-get-todo-state))
+        (assert-nil (org-entry-get (point) "ORG_GTD_TIMESTAMP"))))))
+
+(deftest mcr/migrate-suppresses-organize-hooks ()
+  "Migrate binds `org-gtd-organize-hooks' off, so decoration hooks never fire."
+  (mcr-test--make-calendar "No re-prompt" "<2020-01-01>")
+  (org-gtd-reflect-missed-calendar-review)
+  (let* ((fired nil)
+         (org-gtd-organize-hooks (list (lambda () (setq fired t)))))
+    (with-current-buffer (car (org-gtd-wip--get-buffers))
+      (org-gtd-reflect-missed-calendar-review-migrate))
+    (assert-nil fired)))
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run the /test skill on `test/unit/missed-calendar-review-test.el`.
+Expected: FAIL — `org-gtd-reflect-missed-calendar-review-migrate` is undefined.
+
+**Step 3: Implement the migrate command**
+
+In the `;;;; Commands` section, add:
+
+```elisp
+(defun org-gtd-reflect-missed-calendar-review-migrate ()
+  "Migrate the current item to a Next Action (it still needs doing), then advance.
+Runs the headless organize pipeline with the classic decoration hooks
+bound off -- the item is already clarified, so it must not be re-prompted
+for tags/effort/etc.  The pipeline auto-drops the Calendar-only
+ORG_GTD_TIMESTAMP because next-action declares no properties."
+  (interactive)
+  (org-gtd-walk-call-action
+   (lambda ()
+     (let* ((id (org-gtd-walk-model-current
+                 (plist-get org-gtd-walk--active :model)))
+            (marker (org-id-find id 'marker)))
+       (when marker
+         (let ((org-gtd-organize-hooks nil))
+           (org-gtd-process-heading marker 'next-action)))
+       (org-gtd-reflect-missed-calendar-review--bump :reviewed)
+       (org-gtd-reflect-missed-calendar-review--bump :migrated)
+       (org-gtd-walk-advance)))))
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run the /test skill on `test/unit/missed-calendar-review-test.el`.
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add org-gtd-reflect-missed-calendar-review.el test/unit/missed-calendar-review-test.el
+git commit -m "feat: add migrate-to-next-action disposition (hooks suppressed)"
+```
+
+---
+
+## Task 6: `r` — reschedule (with past-date re-prompt guard)
+
+**Files:**
+- Modify: `org-gtd-reflect-missed-calendar-review.el`
+- Test: `test/unit/missed-calendar-review-test.el`
+
+**Step 1: Write the failing tests**
+
+Append to the test file:
+
+```elisp
+;;; Disposition: reschedule
+
+(deftest mcr/read-future-date-rejects-past ()
+  "The date reader re-prompts until the chosen date is today-or-later."
+  (let ((answers (list "2000-01-01" "2999-01-01")))
+    (cl-letf (((symbol-function 'org-read-date)
+               (lambda (&rest _) (pop answers)))
+              ((symbol-function 'sit-for) (lambda (&rest _) t)))
+      (assert-equal "2999-01-01"
+                    (org-gtd-reflect-missed-calendar-review--read-future-date))
+      ;; both answers consumed => it looped past the in-the-past first answer.
+      (assert-nil answers))))
+
+(deftest mcr/reschedule-sets-new-future-timestamp ()
+  "`r' keeps the item a Calendar item and writes the new (bracketed) timestamp."
+  (let ((id (mcr-test--make-calendar "Needs new date" "<2020-01-01>")))
+    (org-gtd-reflect-missed-calendar-review)
+    (cl-letf (((symbol-function 'org-read-date)
+               (lambda (&rest _) "2999-01-01")))
+      (with-current-buffer (car (org-gtd-wip--get-buffers))
+        (org-gtd-reflect-missed-calendar-review-reschedule)))
+    (let ((marker (org-id-find id 'marker)))
+      (assert-true marker)
+      (org-with-point-at marker
+        (assert-equal "Calendar" (org-entry-get (point) "ORG_GTD"))
+        (assert-equal "<2999-01-01>"
+                      (org-entry-get (point) "ORG_GTD_TIMESTAMP"))))))
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run the /test skill on `test/unit/missed-calendar-review-test.el`.
+Expected: FAIL — `--read-future-date` and the reschedule command are undefined.
+
+**Step 3: Implement the date reader and the reschedule command**
+
+In the `;;;; Commands` section, add both:
+
+```elisp
+(defun org-gtd-reflect-missed-calendar-review--read-future-date ()
+  "Prompt for a date via `org-read-date', re-prompting until it is today or later.
+Returns the chosen date as a \"YYYY-MM-DD\" string.  A past reschedule
+is rejected, not silently accepted."
+  (let ((today (org-today))
+        date)
+    (while (progn
+             (setq date (org-read-date))
+             (< (time-to-days (org-time-string-to-time date)) today))
+      (message "That date is also in the past -- pick today or later.")
+      (sit-for 1))
+    date))
+
+(defun org-gtd-reflect-missed-calendar-review-reschedule ()
+  "Reschedule the current item to a new (today-or-later) date, then advance.
+Stays a Calendar item; reuses the headless organize pipeline with the
+decoration hooks bound off.  The :when config value is bracketed so it is
+written verbatim as a valid org timestamp."
+  (interactive)
+  (org-gtd-walk-call-action
+   (lambda ()
+     (let* ((id (org-gtd-walk-model-current
+                 (plist-get org-gtd-walk--active :model)))
+            (marker (org-id-find id 'marker))
+            (date (org-gtd-reflect-missed-calendar-review--read-future-date)))
+       (when marker
+         (let ((org-gtd-organize-hooks nil))
+           (org-gtd-process-heading marker 'calendar
+                                    (list (cons :when (format "<%s>" date))))))
+       (org-gtd-reflect-missed-calendar-review--bump :reviewed)
+       (org-gtd-reflect-missed-calendar-review--bump :rescheduled)
+       (org-gtd-walk-advance)))))
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run the /test skill on `test/unit/missed-calendar-review-test.el`.
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add org-gtd-reflect-missed-calendar-review.el test/unit/missed-calendar-review-test.el
+git commit -m "feat: add reschedule disposition with past-date re-prompt guard"
+```
+
+---
+
+## Task 7: `t` — trash disposition
+
+**Files:**
+- Modify: `org-gtd-reflect-missed-calendar-review.el`
+- Test: `test/unit/missed-calendar-review-test.el`
+
+**Step 1: Write the failing test**
+
+Append to the test file:
+
+```elisp
+;;; Disposition: trash
+
+(deftest mcr/trash-cancels-and-archives ()
+  "`t' cancels + archives the item (irrelevant now) and ends the walk."
+  (mcr-test--make-calendar "No longer relevant" "<2020-01-01>")
+  (org-gtd-reflect-missed-calendar-review)
+  (with-current-buffer (car (org-gtd-wip--get-buffers))
+    (org-gtd-reflect-missed-calendar-review-trash))
+  (assert-equal 0 (length (org-gtd-wip--get-buffers)))
+  (assert-equal 0 (length (org-gtd-reflect-missed-calendar-review--find-items))))
+```
+
+**Step 2: Run test to verify it fails**
+
+Run the /test skill on `test/unit/missed-calendar-review-test.el`.
+Expected: FAIL — `org-gtd-reflect-missed-calendar-review-trash` is undefined.
+
+**Step 3: Implement the trash command**
+
+In the `;;;; Commands` section, add:
+
+```elisp
+(defun org-gtd-reflect-missed-calendar-review-trash ()
+  "Trash the current item (irrelevant now: cancel + archive), then advance.
+Reuses the `trash' type's cancel-and-archive disposition through the
+headless pipeline, with decoration hooks bound off."
+  (interactive)
+  (org-gtd-walk-call-action
+   (lambda ()
+     (let* ((id (org-gtd-walk-model-current
+                 (plist-get org-gtd-walk--active :model)))
+            (marker (org-id-find id 'marker)))
+       (when marker
+         (let ((org-gtd-organize-hooks nil))
+           (org-gtd-process-heading marker 'trash)))
+       (org-gtd-reflect-missed-calendar-review--bump :reviewed)
+       (org-gtd-reflect-missed-calendar-review--bump :trashed)
+       (org-gtd-walk-advance)))))
+```
+
+**Step 4: Run test to verify it passes**
+
+Run the /test skill on `test/unit/missed-calendar-review-test.el`.
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add org-gtd-reflect-missed-calendar-review.el test/unit/missed-calendar-review-test.el
+git commit -m "feat: add trash disposition to overdue-calendar-review"
+```
+
+---
+
+## Task 8: `s` — skip and `c` — clarify
+
+**Files:**
+- Modify: `org-gtd-reflect-missed-calendar-review.el`
+- Test: `test/unit/missed-calendar-review-test.el`
+
+> **Product-decision caveat (surface to the maintainer, do not silently change).** The
+> design says `c` runs `org-gtd-clarify-item` on the item and that "the review continues."
+> Opening the full interactive clarify flow *while the walk's `:scope` lock is held over the
+> same agenda files* is genuinely messy (clarify + organize would contend with the walk).
+> This plan implements the least-messy version that satisfies the walk invariants: **advance
+> the walk first, then open clarify on the item** (so on the last item the walk finishes and
+> unlocks before clarify opens). If the maintainer wants clarify to instead *quit* the walk
+> entirely first, that is a one-line change — flag it in review.
+
+**Step 1: Write the failing tests**
+
+Append to the test file:
+
+```elisp
+;;; Disposition: skip
+
+(deftest mcr/skip-advances-without-changing-item ()
+  "`s' advances without mutating the item; the item is still overdue."
+  (let ((id (mcr-test--make-calendar "Decide later" "<2020-01-01>")))
+    (org-gtd-reflect-missed-calendar-review)
+    (with-current-buffer (car (org-gtd-wip--get-buffers))
+      (org-gtd-reflect-missed-calendar-review-skip))
+    ;; Only item -> walk finished -> surface cleaned up, but item unchanged.
+    (assert-equal 0 (length (org-gtd-wip--get-buffers)))
+    (let ((marker (org-id-find id 'marker)))
+      (org-with-point-at marker
+        (assert-equal "Calendar" (org-entry-get (point) "ORG_GTD"))
+        (assert-equal "<2020-01-01>"
+                      (org-entry-get (point) "ORG_GTD_TIMESTAMP"))))
+    ;; Still detected on a fresh run (skip is "not now", not "never").
+    (assert-equal 1 (length (org-gtd-reflect-missed-calendar-review--find-items)))))
+
+(deftest mcr/skip-counts-a-skip ()
+  "`s' increments the skipped counter (checked mid-walk, two items)."
+  (mcr-test--make-calendar "First" "<2020-01-01>")
+  (mcr-test--make-calendar "Second" "<2020-01-02>")
+  (org-gtd-reflect-missed-calendar-review)
+  (let ((surface (car (org-gtd-wip--get-buffers))))
+    (with-current-buffer surface
+      (org-gtd-reflect-missed-calendar-review-skip)
+      (assert-same 1 (plist-get org-gtd-reflect-missed-calendar-review--counters :skipped))
+      (org-gtd-reflect-missed-calendar-review-quit))))
+
+;;; Disposition: clarify
+
+(deftest mcr/clarify-invokes-clarify-item-and-advances ()
+  "`c' calls `org-gtd-clarify-item' on the item and advances the walk."
+  (let ((clarified nil))
+    (mcr-test--make-calendar "Rethink me" "<2020-01-01>")
+    (org-gtd-reflect-missed-calendar-review)
+    (cl-letf (((symbol-function 'org-gtd-clarify-item)
+               (lambda (&rest _) (setq clarified t))))
+      (with-current-buffer (car (org-gtd-wip--get-buffers))
+        (org-gtd-reflect-missed-calendar-review-clarify)))
+    (assert-true clarified)
+    ;; Only item -> walk advanced off the end -> surface cleaned up.
+    (assert-equal 0 (length (org-gtd-wip--get-buffers)))))
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run the /test skill on `test/unit/missed-calendar-review-test.el`.
+Expected: FAIL — the skip and clarify commands are undefined.
+
+**Step 3: Implement the skip and clarify commands**
+
+In the `;;;; Commands` section, add:
+
+```elisp
+(defun org-gtd-reflect-missed-calendar-review-skip ()
+  "Skip the current item (decide later -- not a change) and advance."
+  (interactive)
+  (org-gtd-walk-call-action
+   (lambda ()
+     (org-gtd-reflect-missed-calendar-review--bump :reviewed)
+     (org-gtd-reflect-missed-calendar-review--bump :skipped)
+     (org-gtd-walk-advance))))
+
+(defun org-gtd-reflect-missed-calendar-review-clarify ()
+  "Clarify the current item fully (the heavy escape hatch), then advance.
+Advances the walk first so that on the last item the walk finishes and
+releases its scope lock before the interactive clarify flow opens."
+  (interactive)
+  (org-gtd-walk-call-action
+   (lambda ()
+     (let* ((id (org-gtd-walk-model-current
+                 (plist-get org-gtd-walk--active :model)))
+            (marker (org-id-find id 'marker)))
+       (org-gtd-reflect-missed-calendar-review--bump :reviewed)
+       (org-gtd-walk-advance)
+       (when marker
+         (org-gtd-clarify-item marker))))))
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run the /test skill on `test/unit/missed-calendar-review-test.el`.
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add org-gtd-reflect-missed-calendar-review.el test/unit/missed-calendar-review-test.el
+git commit -m "feat: add skip and clarify dispositions to overdue-calendar-review"
+```
+
+---
+
+## Task 9: Counters tally end-to-end + on-finish cleanup
+
+**Files:**
+- Test: `test/unit/missed-calendar-review-test.el` (test-only task — no production change
+  expected; if a test fails, fix the production code)
+
+**Step 1: Write the failing test**
+
+Append to the test file:
+
+```elisp
+;;; Counters + finish
+
+(deftest mcr/counters-tally-across-dispositions ()
+  "Mixed dispositions across several items tally correctly on the surface."
+  (mcr-test--make-calendar "One"   "<2020-01-01>")
+  (mcr-test--make-calendar "Two"   "<2020-01-02>")
+  (mcr-test--make-calendar "Three" "<2020-01-03>")
+  (org-gtd-reflect-missed-calendar-review)
+  (let ((surface (car (org-gtd-wip--get-buffers))))
+    ;; item 1 -> skip, item 2 -> migrate, item 3 -> done (finishes the walk)
+    (with-current-buffer surface
+      (org-gtd-reflect-missed-calendar-review-skip))
+    (with-current-buffer surface
+      (org-gtd-reflect-missed-calendar-review-migrate))
+    ;; Read counters BEFORE the last disposition finishes+cleans up the surface.
+    (with-current-buffer surface
+      (assert-same 2 (plist-get org-gtd-reflect-missed-calendar-review--counters :reviewed))
+      (assert-same 1 (plist-get org-gtd-reflect-missed-calendar-review--counters :skipped))
+      (assert-same 1 (plist-get org-gtd-reflect-missed-calendar-review--counters :migrated))
+      (org-gtd-reflect-missed-calendar-review-done))
+    ;; Last disposition ran :on-finish, which cleaned up the surface buffer.
+    (assert-equal 0 (length (org-gtd-wip--get-buffers)))))
+```
+
+**Step 2: Run test to verify it fails (or passes immediately)**
+
+Run the /test skill on `test/unit/missed-calendar-review-test.el`.
+Expected: PASS if Tasks 3-8 are correct. If it fails, debug the counter/`on-finish`
+wiring (do **not** weaken the test to make it pass). Use superpowers:systematic-debugging
+if needed.
+
+**Step 3: Commit**
+
+```bash
+git add test/unit/missed-calendar-review-test.el
+git commit -m "test: cover counter tally + on-finish cleanup for overdue-calendar-review"
+```
+
+---
+
+## Task 10: Lint, byte-compile clean, and full suite
+
+**Files:**
+- Possibly modify: `org-gtd-reflect-missed-calendar-review.el` (fix any lint/compile warnings)
+
+**Step 1: Byte-compile the new module clean**
+
+Run:
+
+```bash
+~/bin/eldev clean && ~/bin/eldev compile --warnings-as-errors
+```
+
+Expected: no errors, no warnings for `org-gtd-reflect-missed-calendar-review.el`. Fix any
+undefined-function/unused-lexical warnings (e.g. add missing `declare-function` forms) until
+clean. The autoload cookie on the entry command and on the mode must be present — confirm
+`org-gtd-autoloads` regenerates without error.
+
+**Step 2: Run the full test suite via the /test skill**
+
+Run the /test skill on `test/unit/missed-calendar-review-test.el` one final time, then run
+the /test skill across the whole suite (no file argument) to confirm no regressions in
+sibling walk consumers (`someday-review-test.el`, `inbox-walk-test.el`) or the reflect view
+tests.
+
+Expected: all green.
+
+**Step 3: Commit any fixups**
+
+```bash
+git add -A
+git commit -m "chore: byte-compile-clean overdue-calendar-review module"
+```
+
+---
+
+## Definition of done
+
+- `M-x org-gtd-reflect-missed-calendar-review` opens a read-only console over overdue
+  Calendar items, or messages the clean-landscape line when there are none.
+- Keys `d m r t c s q` behave per the design's disposition table; mutating dispositions
+  suppress `org-gtd-organize-hooks`; reschedule rejects past dates.
+- Buffer-local counters tally `reviewed / done / migrated / rescheduled / trashed / skipped`
+  and `:on-finish` reports them and cleans up the surface.
+- The walk is registered under `'missed-calendar-review`, scoped to `(org-agenda-files)`
+  (mutually exclusive with the someday review), `:resumable nil`.
+- New module is `require`d from `org-gtd.el`; entry command and mode are autoloaded.
+- Byte-compiles clean; the full test suite is green.
+
+## Deferred (explicitly NOT in this plan — do not build)
+
+- Command-center row and Weekly-Review-step embedding (design §10).
+- Resume / back-with-undo (design §10 — the walk is `:resumable nil` by design).
+- A general `org-gtd-retype` abstraction (design §10 — YAGNI; migrate rides
+  `org-gtd-process-heading`).

--- a/docs/plans/2026-07-21-clarify-in-place-auto-advance-design.md
+++ b/docs/plans/2026-07-21-clarify-in-place-auto-advance-design.md
@@ -1,0 +1,158 @@
+# Clarify-in-place → auto-advance for the overdue-calendar review — Design
+
+**Status:** Designed 2026-07-21. Follow-up to PR #298 (overdue-calendar review).
+**Target:** v5 (`org-gtd-5`), on branch `feature/overdue-calendar-review`.
+
+## 1. Goal
+
+Make the `c` (clarify) disposition of `org-gtd-reflect-missed-calendar-review`
+behave like the inbox loop: pressing `c` drops the current overdue item into the
+full clarify → organize flow, and **when the user finishes organizing it, the
+review automatically advances to the next overdue item.** No premature advance
+(the current shipped behavior parks the walk and makes the user press `s`); no
+separate orphan clarify buffer.
+
+## 2. Why it isn't free today
+
+`org-gtd-clarify-item` always opens a *separate* WIP buffer keyed by the item's
+own clarify-id. In that buffer `org-gtd-walk--active` is nil (it is buffer-local +
+permanent-local to the review's *surface* buffer). So when the user organizes
+there, `org-gtd-organize--call` (org-gtd-organize-core.el) takes its one-off
+branch — it never sees an active walk, so it never calls `org-gtd-walk-advance`.
+
+The inbox walk gets auto-advance precisely because its **surface buffer *is* the
+clarify buffer**: `org-gtd-inbox-walk--render-marker` renders each item as an
+editable clarify buffer *in the walk surface*, so `org-gtd-walk--active`
+(permanent-local, survives the `org-gtd-clarify-mode` switch) is still present
+when organize runs, and `org-gtd-organize--call`'s `walk-active` branch fires
+`org-gtd-walk-advance`.
+
+## 3. Approach — reuse the inbox in-place-clarify pattern
+
+The review walk becomes a **hybrid**: each item normally renders as the read-only
+disposition console; the `c` disposition transforms that *same surface buffer*
+into an in-place editable clarify buffer for the current item. Organize then
+advances the walk via the existing engine seam, and the next item renders back as
+the console.
+
+### 3.1 `--clarify-in-place (marker)` (new)
+
+Mirrors `org-gtd-inbox-walk--render-marker` (deliberately *not* DRY-extracted yet
+— see §7). In the surface buffer:
+
+1. capture `old-id` = current `org-gtd-clarify--clarify-id` or the surface key;
+2. `new-id` = `org-gtd-id-get-create marker` (lazy id stamp on the source);
+3. `inhibit-read-only` t; `erase-buffer`;
+4. `org-gtd--without-kill-merge` around
+   `org-gtd-clarify--initialize-buffer-contents marker surface` (copies the
+   subtree in, strips org-gtd state props);
+5. `org-gtd-wip--rekey old-id new-id` (so the WIP registry + org-id resolution
+   track the surface as this item's clarify buffer — same rationale as the inbox
+   twin's long comment: do *not* suppress `org-id-track-globally` here);
+6. `(unless (derived-mode-p 'org-gtd-clarify-mode) (org-gtd-clarify-mode))`
+   (`org-gtd-walk--active` survives — permanent-local);
+7. set buffer-locals: `org-gtd-clarify--clarify-id` = new-id,
+   `--source-heading-marker` = marker, `--skip-refile` = nil,
+   `--window-config` = the window config captured **before** `c` reconfigured
+   windows (so organize's post-advance and cancel can behave sanely);
+8. `set-buffer-modified-p nil`;
+9. install a **buffer-local `C-c C-k` override** (see §3.3);
+10. `org-gtd-clarify-setup-windows surface` (same clarify UX as normal, incl. the
+    horizons reference window).
+
+`c` (`org-gtd-reflect-missed-calendar-review-clarify`) resolves the current
+item's marker and calls `--clarify-in-place`; it does **not** advance or bump.
+
+### 3.2 Console `--render`: undo the clarify staging before drawing
+
+`--render` runs on every settle/advance. After a `c` + organize, the surface
+arrives still keyed under the item's clarify-id and (mode already about to switch)
+carrying clarify state + a horizons window. So at the **top** of `--render`,
+before drawing the console:
+
+- if `org-gtd-clarify--clarify-id` is set, `org-gtd-wip--rekey` the surface back
+  to `--surface-key` (so `:on-finish`/`-quit` cleanup by the surface key still
+  finds it — no leak);
+- `org-gtd-clarify--cleanup-horizons-view` (tear down the reference window the
+  clarify staging opened; the console is not a clarify view);
+
+then draw the console as today (switch to console mode — which clears the
+non-permanent clarify buffer-locals via `kill-all-local-variables` — set
+read-only, header-line, `pop-to-buffer`). This path is a no-op for items that
+were never clarified (clarify-id nil, no horizons window).
+
+### 3.3 Cancel (`C-c C-k`) semantics — **decision: return to the console**
+
+Default `org-gtd-clarify-stop` dispatches (on `org-gtd-walk--active`) to the
+inbox-flavored `org-gtd-clarify--stop-walk`, which *abandons the whole walk*
+(`org-gtd-walk-quit`) plus inbox-specific queue/horizons teardown. That is wrong
+for a per-item escape hatch: cancelling one clarify should **not** end the whole
+review.
+
+So the in-place clarify installs a buffer-local keymap (parent =
+`org-gtd-clarify-mode-map`) that rebinds `C-c C-k` to
+`--cancel-clarify`, which re-renders the **console for the current item** (rekey
+back, cleanup horizons, redraw read-only via the walk's own render) without
+advancing or quitting. The review continues; the item stays overdue until
+disposed. (Alternative considered — inbox-consistent "cancel = quit the review" —
+rejected: surprising, and its inbox cleanup path assumes a duplicate queue /
+horizons state this walk doesn't own.)
+
+### 3.4 Organize completion — already handled
+
+No new code: `org-gtd-organize--call`'s `walk-active` branch does the source cut,
+`org-gtd-walk-advance`, and `org-gtd-save-buffers` for us; an `org-gtd-error`
+stays on the current item; an unexpected `:render` error releases the scope lock
+and re-signals.
+
+## 4. End-to-end flow
+
+1. Console shows overdue item N (read-only).
+2. `c` → `--clarify-in-place` → surface becomes the editable clarify buffer for N,
+   walk still active.
+3. User organizes N (picks a type in the `org-gtd-organize` transient).
+4. `org-gtd-organize--call` (walk-active) cuts the source, `org-gtd-walk-advance`.
+5. Advance → settle → `--render` for item N+1 → rekey-back + horizons-cleanup +
+   console redraw. Review continues at N+1.
+6. On the last item, advance finishes the walk (`:on-finish` cleans up the
+   surface + reports the tally).
+7. If instead the user cancels (`C-c C-k`) at step 3 → `--cancel-clarify` redraws
+   the console for N; review continues.
+
+## 5. Counters
+
+Clarify still bumps no counter on entry (it is not a resolution). When organize
+completes it is a genuine disposition, but the engine advance path doesn't know
+our counter keys. Keep it simple for v1: clarify does not increment `:reviewed`
+or any action counter (the item's disposition was recorded by the organize flow
+itself, outside our tally). Documented as a known limitation; revisit if a
+"clarified N" counter is wanted.
+
+## 6. Testing
+
+- **Happy path**: overdue item → start review → `c` → assert surface is now
+  `org-gtd-clarify-mode`, editable, holds the item, `org-gtd-walk--active` still
+  set. Then drive organize-to-completion the way the inbox/organize tests do
+  (invoke the organize path for a concrete type, e.g. single-action) and assert
+  the walk **advanced**: for a 2-item walk the console now shows item 2; for a
+  1-item walk the walk finished (surface cleaned up) and the item is now the
+  organized type (no longer overdue calendar).
+- **Cancel path**: `c` → `--cancel-clarify` → assert surface is back in console
+  mode (read-only, disposition header-line) for the *same* item, walk still
+  active, cursor unchanged.
+- **Rekey/cleanup**: after `c` + organize + finish, no leaked WIP surface buffer
+  (cleanup by surface key still works); no leftover horizons window.
+- **Regression**: full suite stays green (esp. inbox-walk + someday-review +
+  the existing 29 missed-calendar tests, including the park/guard tests, which
+  must be updated to the new advance-on-organize behavior where they assert the
+  old park semantics).
+
+## 7. Deferred
+
+- **DRY**: extract the shared in-place-clarify render (`inbox-walk--render-marker`
+  and this module's `--clarify-in-place`) into one helper (likely in
+  `org-gtd-clarify.el`). Not now — refactoring the inbox render risks the inbox
+  test suite; do it once this second consumer is proven.
+- A first-class "clarified" counter.
+- Generalizing `org-gtd-clarify-stop` to be walk-spec-aware instead of the
+  buffer-local `C-c C-k` override (cleaner, but engine/clarify surgery).

--- a/org-gtd-reflect-missed-calendar-review.el
+++ b/org-gtd-reflect-missed-calendar-review.el
@@ -34,6 +34,7 @@
 (require 'org)
 (require 'org-id)
 (require 'org-gtd-core)
+(require 'org-gtd-id)
 (require 'org-gtd-wip)
 (require 'org-gtd-skip)
 (require 'org-gtd-types)
@@ -160,7 +161,42 @@ TS-STRING cannot be parsed."
 Resolves ID to a marker, refills SURFACE read-only with the teaching
 framing, the humanized lapse, an optional area-of-focus line, and the
 subtree body, then sets review mode, the header-line action bar, and
-displays the buffer."
+displays the buffer.
+
+Before drawing -- indeed before even resolving ID to a marker -- undoes
+any in-place clarify staging left on SURFACE by `--clarify-in-place'
+\(the `c' disposition): when `org-gtd-clarify--clarify-id' is set, the
+surface is still keyed under that item's own clarify id and may still
+have a horizons reference window open.  `--clarify-in-place' deliberately
+leaves `org-id-track-globally' on during its copy (see that function's
+docstring), so `org-paste-subtree' there re-registers the item's real
+org-id against SURFACE in the global `org-id-locations' table -- so if
+this render is about to resolve that SAME id again (the cancel path:
+ID is unchanged, the source was never cut), `org-id-find' below would
+otherwise resolve into SURFACE, which this function is about to erase,
+rather than back to the untouched source heading.  Fixing the id's
+registered location back to the source file (`org-id-add-location',
+using the still-live `org-gtd-clarify--source-heading-marker') MUST
+happen before that `org-id-find', hence this runs first.  Then rekey
+the WIP registry back to `--surface-key' (matching
+`org-gtd-wip--rekey''s use in `--clarify-in-place') and tear the
+horizons view down.  All of this is a no-op for items that were never
+clarified (clarify-id nil) -- e.g. the normal skip/done/migrate/etc.
+path, which never rekeys the surface or touches org-id-locations at
+all.  This runs on every settle/advance, so it fires both right after
+an organize completes (advancing to the next item -- a different id,
+so the id-location fixup is moot there, but harmless) and via
+`--cancel-clarify' (redrawing the current item -- the case that needs
+it)."
+  (with-current-buffer surface
+    (when (bound-and-true-p org-gtd-clarify--clarify-id)
+      (when (markerp org-gtd-clarify--source-heading-marker)
+        (org-id-add-location
+         org-gtd-clarify--clarify-id
+         (buffer-file-name (marker-buffer org-gtd-clarify--source-heading-marker))))
+      (org-gtd-wip--rekey org-gtd-clarify--clarify-id
+                          org-gtd-reflect-missed-calendar-review--surface-key)
+      (org-gtd-clarify--cleanup-horizons-view)))
   (let ((marker (org-id-find id 'marker)))
     (when marker
       (let ((ts (org-with-point-at marker
@@ -240,10 +276,26 @@ counters survive the whole walk (mirrors `org-gtd-someday-review--surface')."
 Runs in the surface buffer after the engine has cleared its session.
 Mutating dispositions (done/migrate/reschedule/trash) modify org-gtd
 buffers directly; `org-gtd-save-buffers' persists them, honoring
-`org-gtd-save-after-organize' (mirrors `org-gtd-inbox-walk--on-finish')."
+`org-gtd-save-after-organize' (mirrors `org-gtd-inbox-walk--on-finish').
+
+Cleans up whichever WIP key the surface is CURRENTLY registered under.
+Ordinarily that is the fixed `--surface-key' (the console never rekeys,
+and `--render' rekeys any in-place clarify staging back to it before
+drawing the next item or the same item on cancel).  But when the walk
+finishes immediately after an in-place clarify + organize on the LAST
+item, there is no next item to trigger that rekey-back -- the surface
+is still keyed under that item's own clarify id, and any horizons
+window the clarify staging opened is still up.  Reading
+`org-gtd-clarify--clarify-id' (falling back to `--surface-key' when
+unset -- the ordinary case) and tearing down the horizons view
+unconditionally (a no-op when none is showing) covers both cases
+without needing to know which one happened, mirroring
+`org-gtd-inbox-walk--on-finish'."
   (let ((summary (org-gtd-reflect-missed-calendar-review--summary)))
+    (org-gtd-clarify--cleanup-horizons-view)
     (org-gtd-wip--cleanup-temp-file
-     org-gtd-reflect-missed-calendar-review--surface-key)
+     (or (bound-and-true-p org-gtd-clarify--clarify-id)
+         org-gtd-reflect-missed-calendar-review--surface-key))
     (message "Missed-calendar review complete. %s" summary)
     (org-gtd-save-buffers)))
 
@@ -405,28 +457,128 @@ a doomed disposition never wastes the user's input."
      (org-gtd-reflect-missed-calendar-review--bump :skipped)
      (org-gtd-walk-advance))))
 
-(defun org-gtd-reflect-missed-calendar-review-clarify ()
-  "Clarify the current item fully (the heavy escape hatch).
-Unlike the other dispositions, this does NOT advance the walk or bump
-`:reviewed': `org-gtd-clarify-item' is an async, interactive hand-off --
-it opens a separate clarify buffer the user works in later, and the
-item's disposition is not resolved when this command returns.  Treating
-that hand-off as a completed review step would be premature, so the
-walk stays parked on the current item (the review surface stays open,
-cursor unchanged) until the user comes back and presses another
-disposition key, typically `s' (skip) once the item has been dealt with
-via clarify.  (Contrast `org-gtd-someday-review-clarify', which advances
-after its own clarify -- `org-gtd-reactivate' -- because that one is
-synchronous.)  Not wrapped in `org-gtd-walk-call-action': that helper
-exists for actions that transition/advance and tears the walk down on
-error; clarify does neither, so a plain `interactive' command is
-correct here."
+(defun org-gtd-reflect-missed-calendar-review--install-cancel-override ()
+  "Install a buffer-local `C-c C-k' override that cancels only THIS clarify.
+The default `org-gtd-clarify-stop' (bound in the shared
+`org-gtd-clarify-mode-map') dispatches, when a walk is active, to
+`org-gtd-clarify--stop-walk', which abandons the WHOLE walk -- correct
+for the inbox walk it was written for, wrong here: canceling one item's
+in-place clarify must not end the whole missed-calendar review.
+
+Installs a fresh sparse keymap parented on the shared
+`org-gtd-clarify-mode-map' as the CURRENT buffer's local map, with only
+`C-c C-k' rebound to `--cancel-clarify'.  Never mutates the shared map
+itself, so other clarify buffers (including inbox-walk ones) are
+unaffected."
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map org-gtd-clarify-mode-map)
+    (define-key map (kbd "C-c C-k")
+                #'org-gtd-reflect-missed-calendar-review--cancel-clarify)
+    (use-local-map map)))
+
+(defun org-gtd-reflect-missed-calendar-review--clarify-in-place (marker window-config)
+  "Transform the current surface into an editable clarify buffer for MARKER.
+Mirrors `org-gtd-inbox-walk--render-marker': copies the subtree at
+MARKER into the surface (the CURRENT buffer), rekeys the WIP registry
+from the surface's current key to the item's own (lazily-assigned)
+clarify id, switches to `org-gtd-clarify-mode', and installs the
+buffer-local `C-c C-k' cancel override (see
+`--install-cancel-override') so canceling returns to the console
+instead of abandoning the whole review.
+
+`org-gtd-walk--active' is buffer-local and permanent-local, so it
+survives the mode switch: when the user finishes organizing here,
+`org-gtd-organize--call''s walk-active branch calls
+`org-gtd-walk-advance' for us -- the review auto-advances, exactly as
+the inbox walk does.
+
+WINDOW-CONFIG is the window configuration captured by the caller
+BEFORE `c' made any window changes; it is stored as the clarify
+buffer-local `org-gtd-clarify--window-config'.
+
+Deliberately does NOT bind `org-id-track-globally' around the copy --
+see the long comment on `org-gtd-inbox-walk--render-marker' for why:
+this surface is the live staging buffer the item is about to be
+organized from, not a disposable review copy.  (See `--render' for the
+other half of that tradeoff: it must fix the id's registered location
+back to the source before re-resolving it on the cancel path.)"
+  (let* ((surface (current-buffer))
+         (old-id (or (bound-and-true-p org-gtd-clarify--clarify-id)
+                     org-gtd-reflect-missed-calendar-review--surface-key))
+         (new-id (org-gtd-id-get-create marker)))
+    (let ((inhibit-read-only t))
+      ;; The surface arrives here read-only (the console just displayed
+      ;; it): the clarify buffer must be editable.  `inhibit-read-only'
+      ;; above only covers the erase/copy/paste below; this `setq'
+      ;; persists past this `let', which is what we want.
+      (setq buffer-read-only nil)
+      (erase-buffer)
+      (org-gtd--without-kill-merge
+        (org-gtd-clarify--initialize-buffer-contents marker surface))
+      (goto-char (point-min))
+      (org-gtd-wip--rekey old-id new-id)
+      (unless (derived-mode-p 'org-gtd-clarify-mode)
+        (org-gtd-clarify-mode))
+      (setq-local org-gtd-clarify--clarify-id new-id
+                  org-gtd-clarify--source-heading-marker marker
+                  org-gtd-clarify--skip-refile nil
+                  org-gtd-clarify--window-config window-config)
+      ;; Freshly rendered, untouched: mirrors `org-gtd-inbox-walk--render-marker'
+      ;; so a later save-on-quit safety net can tell an edited item from a
+      ;; merely glanced one.
+      (set-buffer-modified-p nil)
+      (org-gtd-reflect-missed-calendar-review--install-cancel-override)
+      (org-gtd-clarify-setup-windows surface))))
+
+(defun org-gtd-reflect-missed-calendar-review--cancel-clarify ()
+  "Cancel the in-place clarify on the current item; return to the console.
+Bound to `C-c C-k' by the buffer-local override installed in
+`--clarify-in-place' (see `--install-cancel-override'), shadowing the
+default `org-gtd-clarify-stop', which would abandon the whole review.
+
+Does not advance and does not quit: it simply redraws the console for
+the CURRENT item.  All the undo work -- rekeying the surface back to
+`--surface-key' and tearing down the horizons view -- lives in
+`--render' itself (it runs at the top of every render), so this just
+delegates to it."
   (interactive)
-  (let* ((id (org-gtd-walk-model-current
+  (let ((id (org-gtd-walk-model-current
+             (plist-get org-gtd-walk--active :model))))
+    (org-gtd-reflect-missed-calendar-review--render id (current-buffer))))
+
+(defun org-gtd-reflect-missed-calendar-review-clarify ()
+  "Clarify the current item in place; the review auto-advances on organize.
+Transforms the review surface itself into an editable clarify buffer
+for the current item (see `--clarify-in-place'), instead of opening a
+separate one-off clarify buffer via `org-gtd-clarify-item'.  Because
+`org-gtd-walk--active' is permanent-local and survives the switch to
+`org-gtd-clarify-mode', when the user finishes organizing here
+`org-gtd-organize--call''s walk-active branch calls
+`org-gtd-walk-advance' for us -- the review moves on to the next
+overdue item automatically; no separate `s' (skip) needed.
+
+Does not itself advance the walk or bump `:reviewed': clarifying is not
+a resolution by itself, only a hand-off into the organize flow -- the
+resolution (and the advance) happens when the user finishes organizing.
+Clarify therefore bumps no counter on entry; see the design's \"Counters\"
+section for the accepted v1 limitation (no dedicated \"clarified\"
+tally).
+
+Canceling out of the clarify (`C-c C-k') returns to the console for
+this same item rather than abandoning the whole review -- see
+`--cancel-clarify'.
+
+Not wrapped in `org-gtd-walk-call-action': that helper exists for
+actions that transition/advance and tears the walk down on error; this
+command does neither itself (the transition happens later, on
+organize), so a plain `interactive' command is correct here."
+  (interactive)
+  (let* ((window-config (current-window-configuration))
+         (id (org-gtd-walk-model-current
               (plist-get org-gtd-walk--active :model)))
-         (marker (org-id-find id 'marker)))
+         (marker (and id (org-id-find id 'marker))))
     (if marker
-        (org-gtd-clarify-item marker)
+        (org-gtd-reflect-missed-calendar-review--clarify-in-place marker window-config)
       (message "This item is no longer available."))))
 
 (defun org-gtd-reflect-missed-calendar-review-quit ()

--- a/org-gtd-reflect-missed-calendar-review.el
+++ b/org-gtd-reflect-missed-calendar-review.el
@@ -1,0 +1,96 @@
+;;; org-gtd-reflect-missed-calendar-review.el --- Actionable overdue-calendar review -*- lexical-binding: t; coding: utf-8 -*-
+;;
+;; Copyright © 2026 Aldric Giacomoni
+
+;; Author: Aldric Giacomoni <trevoke@gmail.com>
+;; This file is not part of GNU Emacs.
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; The actionable counterpart of the read-only `org-gtd-reflect-missed-calendar'
+;; view: a walk that shows each overdue Calendar item one at a time and lets the
+;; user decide -- with consent -- what each one becomes now (done, migrate to a
+;; next action, reschedule, trash, clarify, or skip).  A walk consumer,
+;; structurally identical to `org-gtd-someday-review'.  See
+;; docs/plans/2026-07-19-overdue-calendar-review-design.md.
+;;
+;;; Code:
+
+;;;; Requirements
+
+(require 'org)
+(require 'org-id)
+(require 'org-gtd-core)
+(require 'org-gtd-wip)
+(require 'org-gtd-skip)
+(require 'org-gtd-types)
+(require 'org-gtd-organize-core)
+(require 'org-gtd-archive)
+(require 'org-gtd-clarify)
+(require 'org-gtd-walk-model)
+(require 'org-gtd-walk)
+
+;;;; External Function Declarations
+
+;; Evil functions (only called inside with-eval-after-load 'evil)
+(declare-function evil-set-initial-state "evil-core")
+(declare-function evil-emacs-state "evil-states")
+
+;;;; Variables
+
+(defconst org-gtd-reflect-missed-calendar-review--surface-key "missed-calendar-review"
+  "Fixed WIP key for the single missed-calendar-review surface buffer.")
+
+;;;; Detection
+
+(defun org-gtd-reflect-missed-calendar-review--find-items ()
+  "Return the org-ids of every overdue Calendar item across `org-agenda-files'.
+
+Composes the SAME `org-gtd-skip.el' predicates the read-only
+`org-gtd-reflect-missed-calendar' view uses: ORG_GTD = Calendar, not
+done, ORG_GTD_TIMESTAMP strictly before today, and not an org-gtd habit.
+The predicate factories are captured once in the outer `let' and
+`funcall'ed per heading."
+  (let ((calendar-p (org-gtd-pred--property-equals
+                     "ORG_GTD" (org-gtd-type-org-gtd-value 'calendar)))
+        (not-done-p (org-gtd-pred--not-done))
+        (overdue-p (org-gtd-pred--property-ts<
+                    (org-gtd-type-property 'calendar :when) "today"))
+        (not-habit-p (org-gtd-pred--property-not-equals
+                      "ORG_GTD" (org-gtd-type-org-gtd-value 'habit)))
+        (items '()))
+    (dolist (file (org-agenda-files))
+      (when (file-exists-p file)
+        (with-current-buffer (find-file-noselect file)
+          (org-with-wide-buffer
+           (goto-char (point-min))
+           (while (re-search-forward "^\\*+ " nil t)
+             (when (and (funcall calendar-p)
+                        (funcall not-done-p)
+                        (funcall overdue-p)
+                        (funcall not-habit-p))
+               (push (org-id-get-create) items)))))))
+    (nreverse items)))
+
+(defun org-gtd-reflect-missed-calendar-review--resolve (id)
+  "Return non-nil when ID still resolves to a live heading marker."
+  (org-id-find id 'marker))
+
+;;;; Footer
+
+(provide 'org-gtd-reflect-missed-calendar-review)
+
+;;; org-gtd-reflect-missed-calendar-review.el ends here

--- a/org-gtd-reflect-missed-calendar-review.el
+++ b/org-gtd-reflect-missed-calendar-review.el
@@ -264,6 +264,22 @@ hard landscape is clean."
 
 ;;;; Commands
 
+(defun org-gtd-reflect-missed-calendar-review-done ()
+  "Mark the current item done and archive it (it happened), then advance."
+  (interactive)
+  (org-gtd-walk-call-action
+   (lambda ()
+     (let* ((id (org-gtd-walk-model-current
+                 (plist-get org-gtd-walk--active :model)))
+            (marker (org-id-find id 'marker)))
+       (when marker
+         (org-with-point-at marker
+           (org-todo (org-gtd-keywords--done))
+           (org-gtd-archive-item-at-point)))
+       (org-gtd-reflect-missed-calendar-review--bump :reviewed)
+       (org-gtd-reflect-missed-calendar-review--bump :done)
+       (org-gtd-walk-advance)))))
+
 (defun org-gtd-reflect-missed-calendar-review-quit ()
   "Abandon the review: report the tally, clean up, tear down the walk."
   (interactive)

--- a/org-gtd-reflect-missed-calendar-review.el
+++ b/org-gtd-reflect-missed-calendar-review.el
@@ -54,6 +54,21 @@
 (defconst org-gtd-reflect-missed-calendar-review--surface-key "missed-calendar-review"
   "Fixed WIP key for the single missed-calendar-review surface buffer.")
 
+;;;; Keymaps
+
+(defvar org-gtd-reflect-missed-calendar-review-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map org-mode-map)
+    (define-key map (kbd "d") #'org-gtd-reflect-missed-calendar-review-done)
+    (define-key map (kbd "m") #'org-gtd-reflect-missed-calendar-review-migrate)
+    (define-key map (kbd "r") #'org-gtd-reflect-missed-calendar-review-reschedule)
+    (define-key map (kbd "t") #'org-gtd-reflect-missed-calendar-review-trash)
+    (define-key map (kbd "c") #'org-gtd-reflect-missed-calendar-review-clarify)
+    (define-key map (kbd "s") #'org-gtd-reflect-missed-calendar-review-skip)
+    (define-key map (kbd "q") #'org-gtd-reflect-missed-calendar-review-quit)
+    map)
+  "Keymap for `org-gtd-reflect-missed-calendar-review-mode'.")
+
 ;;;; Detection
 
 (defun org-gtd-reflect-missed-calendar-review--find-items ()
@@ -89,6 +104,76 @@ captured once in the outer `let' and `funcall'ed per heading."
 (defun org-gtd-reflect-missed-calendar-review--resolve (id)
   "Return non-nil when ID still resolves to a live heading marker."
   (org-id-find id 'marker))
+
+;;;; Render
+
+(defun org-gtd-reflect-missed-calendar-review--humanize-lapse (ts-string)
+  "Return a humanized description of the lapsed date TS-STRING.
+E.g. \"was: 2026-06-12 (37 days ago)\".  Returns \"date unknown\" when
+TS-STRING cannot be parsed."
+  (let ((ts (org-gtd--parse-timestamp ts-string)))
+    (if (null ts)
+        "date unknown"
+      (let ((days (- (org-today) (time-to-days ts))))
+        (format "was: %s (%d day%s ago)"
+                (format-time-string "%F" ts)
+                days
+                (if (= days 1) "" "s"))))))
+
+(defun org-gtd-reflect-missed-calendar-review--render (id surface)
+  "Render the overdue Calendar item ID into SURFACE (the walk :render contract).
+Resolves ID to a marker, refills SURFACE read-only with the teaching
+framing, the humanized lapse, an optional area-of-focus line, and the
+subtree body, then sets review mode, the header-line action bar, and
+displays the buffer."
+  (let ((marker (org-id-find id 'marker)))
+    (when marker
+      (let ((ts (org-with-point-at marker
+                  (org-entry-get (point) (org-gtd-type-property 'calendar :when))))
+            (aof (org-with-point-at marker
+                   (org-entry-get (point) org-gtd-prop-area-of-focus))))
+        (with-current-buffer surface
+          (let ((inhibit-read-only t)
+                (org-id-track-globally nil))
+            (erase-buffer)
+            (insert "# This date has passed -- decide what it is now.\n")
+            (insert (format "# %s\n"
+                            (org-gtd-reflect-missed-calendar-review--humanize-lapse ts)))
+            (when (and aof (not (string-empty-p aof)))
+              (insert (format "# Area of focus: %s\n" aof)))
+            (insert "\n")
+            (org-gtd--without-kill-merge
+              (org-with-point-at marker (org-copy-subtree)))
+            (org-paste-subtree)
+            (goto-char (point-min)))
+          (unless (eq major-mode 'org-gtd-reflect-missed-calendar-review-mode)
+            (org-gtd-reflect-missed-calendar-review-mode))
+          (setq buffer-read-only t)
+          (let* ((model (plist-get org-gtd-walk--active :model))
+                 (pos (1+ (plist-get model :cursor)))
+                 (total (length (plist-get model :entries))))
+            (setq header-line-format
+                  (format (concat "[d] Done  [m] Migrate  [r] Reschedule  "
+                                  "[t] Trash  [c] Clarify  [s] Skip  [q] Quit  (%d/%d)")
+                          pos total)))
+          (pop-to-buffer surface))))))
+
+;;;; Modes
+
+;;;###autoload
+(define-derived-mode org-gtd-reflect-missed-calendar-review-mode org-mode "GTD-MissedCal"
+  "Major mode for reviewing overdue calendar items one at a time.
+Derived from `org-mode'; the buffer is read-only (set in the render
+function) and offers disposition keys.
+
+\\{org-gtd-reflect-missed-calendar-review-mode-map}"
+  :group 'org-gtd)
+
+;;;; Evil-mode Integration
+
+(with-eval-after-load 'evil
+  (evil-set-initial-state 'org-gtd-reflect-missed-calendar-review-mode 'emacs)
+  (add-hook 'org-gtd-reflect-missed-calendar-review-mode-hook #'evil-emacs-state))
 
 ;;;; Footer
 

--- a/org-gtd-reflect-missed-calendar-review.el
+++ b/org-gtd-reflect-missed-calendar-review.el
@@ -54,6 +54,10 @@
 (defconst org-gtd-reflect-missed-calendar-review--surface-key "missed-calendar-review"
   "Fixed WIP key for the single missed-calendar-review surface buffer.")
 
+(defvar-local org-gtd-reflect-missed-calendar-review--counters nil
+  "Buffer-local plist of tallies for the active surface:
+\(:reviewed N :done N :migrated N :rescheduled N :trashed N :skipped N).")
+
 ;;;; Keymaps
 
 (defvar org-gtd-reflect-missed-calendar-review-mode-map
@@ -163,6 +167,66 @@ displays the buffer."
                           pos total)))
           (pop-to-buffer surface))))))
 
+;;;; Walk Surface
+
+(defun org-gtd-reflect-missed-calendar-review--surface ()
+  "Return the fresh WIP surface buffer for a missed-calendar-review walk.
+Activates `org-gtd-reflect-missed-calendar-review-mode' before setting the
+buffer-local counters: (re-)running a major mode calls
+`kill-all-local-variables', which would silently wipe them.  Doing this
+here means the mode is already active by the time `org-gtd-walk-start'
+calls :render, so :render's own mode-activation guard never fires and the
+counters survive the whole walk (mirrors `org-gtd-someday-review--surface')."
+  (let ((buf (org-gtd-wip--get-buffer
+              org-gtd-reflect-missed-calendar-review--surface-key)))
+    (with-current-buffer buf
+      (org-gtd-reflect-missed-calendar-review-mode)
+      (setq-local org-gtd-reflect-missed-calendar-review--counters
+                  (list :reviewed 0 :done 0 :migrated 0
+                        :rescheduled 0 :trashed 0 :skipped 0)))
+    buf))
+
+(defun org-gtd-reflect-missed-calendar-review--bump (key)
+  "Increment counter KEY on the surface buffer's counters plist."
+  (setq org-gtd-reflect-missed-calendar-review--counters
+        (plist-put org-gtd-reflect-missed-calendar-review--counters key
+                   (1+ (plist-get
+                        org-gtd-reflect-missed-calendar-review--counters key)))))
+
+(defun org-gtd-reflect-missed-calendar-review--summary ()
+  "Return the human-readable tally string for the active surface."
+  (let ((c org-gtd-reflect-missed-calendar-review--counters))
+    (format "reviewed %d - done %d - migrated %d - rescheduled %d - trashed %d - skipped %d"
+            (or (plist-get c :reviewed) 0)
+            (or (plist-get c :done) 0)
+            (or (plist-get c :migrated) 0)
+            (or (plist-get c :rescheduled) 0)
+            (or (plist-get c :trashed) 0)
+            (or (plist-get c :skipped) 0))))
+
+(defun org-gtd-reflect-missed-calendar-review--on-finish ()
+  "End-of-walk: report the tally and clean up the surface buffer.
+Runs in the surface buffer after the engine has cleared its session."
+  (let ((summary (org-gtd-reflect-missed-calendar-review--summary)))
+    (org-gtd-wip--cleanup-temp-file
+     org-gtd-reflect-missed-calendar-review--surface-key)
+    (message "Missed-calendar review complete. %s" summary)))
+
+(defun org-gtd-reflect-missed-calendar-review--spec ()
+  "Return the missed-calendar-review walk spec template (default :find = all
+overdue calendar items)."
+  (list :name 'missed-calendar-review
+        :find #'org-gtd-reflect-missed-calendar-review--find-items
+        :render #'org-gtd-reflect-missed-calendar-review--render
+        :actions org-gtd-reflect-missed-calendar-review-mode-map
+        :on-finish #'org-gtd-reflect-missed-calendar-review--on-finish
+        :resumable nil
+        :resolve #'org-gtd-reflect-missed-calendar-review--resolve
+        :scope (org-agenda-files)))
+
+(org-gtd-walk-register 'missed-calendar-review
+                       (org-gtd-reflect-missed-calendar-review--spec))
+
 ;;;; Modes
 
 ;;;###autoload
@@ -179,6 +243,35 @@ function) and offers disposition keys.
 (with-eval-after-load 'evil
   (evil-set-initial-state 'org-gtd-reflect-missed-calendar-review-mode 'emacs)
   (add-hook 'org-gtd-reflect-missed-calendar-review-mode-hook #'evil-emacs-state))
+
+;;;; Entry Point
+
+;;;###autoload
+(defun org-gtd-reflect-missed-calendar-review ()
+  "Review overdue calendar items one at a time.
+The actionable counterpart of the read-only `org-gtd-reflect-missed-calendar'
+view: walks each open Calendar item whose date has passed and lets you
+decide -- with consent -- what it becomes now.  Opens nothing when your
+hard landscape is clean."
+  (interactive)
+  (let ((items (org-gtd-reflect-missed-calendar-review--find-items)))
+    (if (null items)
+        (message "No overdue calendar items -- your hard landscape is clean.")
+      (let ((spec (org-gtd-reflect-missed-calendar-review--spec)))
+        (setq spec (plist-put spec :find (lambda () items)))
+        (setq spec (plist-put spec :scope (org-agenda-files)))
+        (org-gtd-walk-start spec (org-gtd-reflect-missed-calendar-review--surface))))))
+
+;;;; Commands
+
+(defun org-gtd-reflect-missed-calendar-review-quit ()
+  "Abandon the review: report the tally, clean up, tear down the walk."
+  (interactive)
+  (let ((summary (org-gtd-reflect-missed-calendar-review--summary)))
+    (org-gtd-walk-quit)
+    (org-gtd-wip--cleanup-temp-file
+     org-gtd-reflect-missed-calendar-review--surface-key)
+    (message "Missed-calendar review complete. %s" summary)))
 
 ;;;; Footer
 

--- a/org-gtd-reflect-missed-calendar-review.el
+++ b/org-gtd-reflect-missed-calendar-review.el
@@ -284,6 +284,25 @@ hard landscape is clean."
        (org-gtd-reflect-missed-calendar-review--bump :done)
        (org-gtd-walk-advance)))))
 
+(defun org-gtd-reflect-missed-calendar-review-migrate ()
+  "Migrate the current item to a Next Action (it still needs doing), then advance.
+Runs the headless organize pipeline with the classic decoration hooks
+bound off -- the item is already clarified, so it must not be re-prompted
+for tags/effort/etc.  The pipeline auto-drops the Calendar-only
+ORG_GTD_TIMESTAMP because next-action declares no properties."
+  (interactive)
+  (org-gtd-walk-call-action
+   (lambda ()
+     (let* ((id (org-gtd-walk-model-current
+                 (plist-get org-gtd-walk--active :model)))
+            (marker (org-id-find id 'marker)))
+       (when marker
+         (let ((org-gtd-organize-hooks nil))
+           (org-gtd-process-heading marker 'next-action)))
+       (org-gtd-reflect-missed-calendar-review--bump :reviewed)
+       (org-gtd-reflect-missed-calendar-review--bump :migrated)
+       (org-gtd-walk-advance)))))
+
 (defun org-gtd-reflect-missed-calendar-review-quit ()
   "Abandon the review: report the tally, clean up, tear down the walk."
   (interactive)

--- a/org-gtd-reflect-missed-calendar-review.el
+++ b/org-gtd-reflect-missed-calendar-review.el
@@ -177,20 +177,30 @@ otherwise resolve into SURFACE, which this function is about to erase,
 rather than back to the untouched source heading.  Fixing the id's
 registered location back to the source file (`org-id-add-location',
 using the still-live `org-gtd-clarify--source-heading-marker') MUST
-happen before that `org-id-find', hence this runs first.  Then rekey
-the WIP registry back to `--surface-key' (matching
+happen before that `org-id-find', hence this runs first -- but ONLY on
+that same-item cancel path: this function also runs right after an
+organize completes and the walk advances to the NEXT item, where ID is
+that next item's id while the buffer-locals still hold the
+JUST-organized item's clarify id/marker.  Calling `org-id-add-location'
+unconditionally there would re-point the just-organized item's id back
+at its own now-emptied source file (its subtree was already cut by
+`org-gtd-organize--call' once the refile completed elsewhere),
+clobbering the correct location `org-refile' just wrote and leaving
+that item unresolvable.  So the id-location fixup is gated on `(equal
+id org-gtd-clarify--clarify-id)' -- true only on the cancel path.  Then
+rekey the WIP registry back to `--surface-key' (matching
 `org-gtd-wip--rekey''s use in `--clarify-in-place') and tear the
-horizons view down.  All of this is a no-op for items that were never
+horizons view down -- both UNCONDITIONALLY, on either path: they are
+internal org-gtd bookkeeping (WIP registry key, horizons window),
+never global org-id state, and are correct to run regardless of which
+item ID names.  All of this is a no-op for items that were never
 clarified (clarify-id nil) -- e.g. the normal skip/done/migrate/etc.
 path, which never rekeys the surface or touches org-id-locations at
-all.  This runs on every settle/advance, so it fires both right after
-an organize completes (advancing to the next item -- a different id,
-so the id-location fixup is moot there, but harmless) and via
-`--cancel-clarify' (redrawing the current item -- the case that needs
-it)."
+all."
   (with-current-buffer surface
     (when (bound-and-true-p org-gtd-clarify--clarify-id)
-      (when (markerp org-gtd-clarify--source-heading-marker)
+      (when (and (equal id org-gtd-clarify--clarify-id)
+                 (markerp org-gtd-clarify--source-heading-marker))
         (org-id-add-location
          org-gtd-clarify--clarify-id
          (buffer-file-name (marker-buffer org-gtd-clarify--source-heading-marker))))
@@ -457,23 +467,42 @@ a doomed disposition never wastes the user's input."
      (org-gtd-reflect-missed-calendar-review--bump :skipped)
      (org-gtd-walk-advance))))
 
+(defun org-gtd-reflect-missed-calendar-review--duplicate-unavailable ()
+  "Message that duplicate-clarify is not available in this review walk.
+The shared `org-gtd-clarify-mode-map' binds `C-c d'/`C-c D' to
+`org-gtd-clarify-duplicate'/`-exact', which enqueue a synthetic
+duplicate token onto `org-gtd-clarify--duplicate-queue'.  This walk's
+model has no representation for that token: `:resolve'
+\(`--resolve', a plain `org-id-find') simply fails to resolve it and
+`org-gtd-walk--settle' silently skips it -- the user's requested
+duplicate would vanish with no feedback.  Bound over both keys in
+`--install-cancel-override' instead of leaving them reachable."
+  (interactive)
+  (message "Duplicates are not available in the calendar review; use `c' only to clarify."))
+
 (defun org-gtd-reflect-missed-calendar-review--install-cancel-override ()
-  "Install a buffer-local `C-c C-k' override that cancels only THIS clarify.
+  "Install a buffer-local override for keys unsafe in this in-place clarify.
 The default `org-gtd-clarify-stop' (bound in the shared
 `org-gtd-clarify-mode-map') dispatches, when a walk is active, to
 `org-gtd-clarify--stop-walk', which abandons the WHOLE walk -- correct
 for the inbox walk it was written for, wrong here: canceling one item's
-in-place clarify must not end the whole missed-calendar review.
+in-place clarify must not end the whole missed-calendar review.  And
+`C-c d'/`C-c D' (duplicate-clarify) would silently vanish an item the
+walk model cannot represent -- see `--duplicate-unavailable'.
 
 Installs a fresh sparse keymap parented on the shared
-`org-gtd-clarify-mode-map' as the CURRENT buffer's local map, with only
-`C-c C-k' rebound to `--cancel-clarify'.  Never mutates the shared map
-itself, so other clarify buffers (including inbox-walk ones) are
-unaffected."
+`org-gtd-clarify-mode-map' as the CURRENT buffer's local map, with
+`C-c C-k' rebound to `--cancel-clarify' and `C-c d'/`C-c D' rebound to
+`--duplicate-unavailable'.  Never mutates the shared map itself, so
+other clarify buffers (including inbox-walk ones) are unaffected."
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map org-gtd-clarify-mode-map)
     (define-key map (kbd "C-c C-k")
                 #'org-gtd-reflect-missed-calendar-review--cancel-clarify)
+    (define-key map (kbd "C-c d")
+                #'org-gtd-reflect-missed-calendar-review--duplicate-unavailable)
+    (define-key map (kbd "C-c D")
+                #'org-gtd-reflect-missed-calendar-review--duplicate-unavailable)
     (use-local-map map)))
 
 (defun org-gtd-reflect-missed-calendar-review--clarify-in-place (marker window-config)
@@ -494,7 +523,11 @@ the inbox walk does.
 
 WINDOW-CONFIG is the window configuration captured by the caller
 BEFORE `c' made any window changes; it is stored as the clarify
-buffer-local `org-gtd-clarify--window-config'.
+buffer-local `org-gtd-clarify--window-config' and consumed only by
+`--cancel-clarify', which restores it after redrawing the console --
+canceling therefore returns to exactly the window layout `c' was
+pressed from.  It is not consumed on the organize/advance path: the
+walk's own render takes care of that surface's display.
 
 Deliberately does NOT bind `org-id-track-globally' around the copy --
 see the long comment on `org-gtd-inbox-walk--render-marker' for why:
@@ -540,11 +573,21 @@ Does not advance and does not quit: it simply redraws the console for
 the CURRENT item.  All the undo work -- rekeying the surface back to
 `--surface-key' and tearing down the horizons view -- lives in
 `--render' itself (it runs at the top of every render), so this just
-delegates to it."
+delegates to it.
+
+Reads `org-gtd-clarify--window-config' (saved by `--clarify-in-place')
+BEFORE delegating to `--render': `--render''s console mode switch calls
+`kill-all-local-variables' on SURFACE, which would otherwise wipe the
+buffer-local before we could read it.  Once the console is redrawn,
+restores that window configuration, so canceling returns to exactly the
+layout `c' was pressed from."
   (interactive)
   (let ((id (org-gtd-walk-model-current
-             (plist-get org-gtd-walk--active :model))))
-    (org-gtd-reflect-missed-calendar-review--render id (current-buffer))))
+             (plist-get org-gtd-walk--active :model)))
+        (window-config (bound-and-true-p org-gtd-clarify--window-config)))
+    (org-gtd-reflect-missed-calendar-review--render id (current-buffer))
+    (when window-config
+      (set-window-configuration window-config))))
 
 (defun org-gtd-reflect-missed-calendar-review-clarify ()
   "Clarify the current item in place; the review auto-advances on organize.

--- a/org-gtd-reflect-missed-calendar-review.el
+++ b/org-gtd-reflect-missed-calendar-review.el
@@ -303,6 +303,39 @@ ORG_GTD_TIMESTAMP because next-action declares no properties."
        (org-gtd-reflect-missed-calendar-review--bump :migrated)
        (org-gtd-walk-advance)))))
 
+(defun org-gtd-reflect-missed-calendar-review--read-future-date ()
+  "Prompt for a date via `org-read-date', re-prompting until it is today or later.
+Returns the chosen date as a \"YYYY-MM-DD\" string.  A past reschedule
+is rejected, not silently accepted."
+  (let ((today (org-today))
+        date)
+    (while (progn
+             (setq date (org-read-date))
+             (< (time-to-days (org-time-string-to-time date)) today))
+      (message "That date is also in the past -- pick today or later.")
+      (sit-for 1))
+    date))
+
+(defun org-gtd-reflect-missed-calendar-review-reschedule ()
+  "Reschedule the current item to a new (today-or-later) date, then advance.
+Stays a Calendar item; reuses the headless organize pipeline with the
+decoration hooks bound off.  The :when config value is bracketed so it is
+written verbatim as a valid org timestamp."
+  (interactive)
+  (org-gtd-walk-call-action
+   (lambda ()
+     (let* ((id (org-gtd-walk-model-current
+                 (plist-get org-gtd-walk--active :model)))
+            (marker (org-id-find id 'marker))
+            (date (org-gtd-reflect-missed-calendar-review--read-future-date)))
+       (when marker
+         (let ((org-gtd-organize-hooks nil))
+           (org-gtd-process-heading marker 'calendar
+                                    (list (cons :when (format "<%s>" date))))))
+       (org-gtd-reflect-missed-calendar-review--bump :reviewed)
+       (org-gtd-reflect-missed-calendar-review--bump :rescheduled)
+       (org-gtd-walk-advance)))))
+
 (defun org-gtd-reflect-missed-calendar-review-quit ()
   "Abandon the review: report the tally, clean up, tear down the walk."
   (interactive)

--- a/org-gtd-reflect-missed-calendar-review.el
+++ b/org-gtd-reflect-missed-calendar-review.el
@@ -75,38 +75,51 @@
 
 ;;;; Detection
 
-(defun org-gtd-reflect-missed-calendar-review--overdue-calendar-p (marker-or-point)
-  "Return non-nil when MARKER-OR-POINT is still an overdue Calendar item.
+(defun org-gtd-reflect-missed-calendar-review--make-overdue-calendar-p ()
+  "Return a closure answering whether a heading is still an overdue Calendar item.
+The returned predicate takes one MARKER-OR-POINT argument and returns
+non-nil at an overdue Calendar heading.
 
-The single definition of \"overdue calendar\" shared by `--find-items'
-\(scanning) and `--current-overdue-marker' (the mutating-disposition
-guard), so the two can never drift apart.  Composes `org-gtd-skip.el'
-predicates matching the design's definition of overdue calendar: ORG_GTD
-= Calendar, not done, ORG_GTD_TIMESTAMP strictly before today, and not an
-org-gtd habit.  The not-habit clause is redundant given the
-Calendar/Habit type invariant (an entry cannot be both) but is kept for
-parity with that stated definition."
-  (org-with-point-at marker-or-point
-    (and (funcall (org-gtd-pred--property-equals
-                   "ORG_GTD" (org-gtd-type-org-gtd-value 'calendar)))
-         (funcall (org-gtd-pred--not-done))
-         (funcall (org-gtd-pred--property-ts<
-                   (org-gtd-type-property 'calendar :when) "today"))
-         (funcall (org-gtd-pred--property-not-equals
-                   "ORG_GTD" (org-gtd-type-org-gtd-value 'habit))))))
+This is the single definition of \"overdue calendar\" shared by
+`--find-items' (scanning) and `--current-overdue-marker' (the
+mutating-disposition guard), so the two can never drift apart.  It
+composes `org-gtd-skip.el' predicates matching the design's definition of
+overdue calendar: ORG_GTD = Calendar, not done, ORG_GTD_TIMESTAMP
+strictly before today, and not an org-gtd habit.  The not-habit clause is
+redundant given the Calendar/Habit type invariant (an entry cannot be
+both) but is kept for parity with that stated definition.
+
+The four predicate factory closures are captured ONCE here (the codebase
+factory-closure convention); the returned closure only `funcall's them
+per heading, so callers build the predicate once and reuse it across a
+whole scan rather than rebuilding it per heading."
+  (let ((calendar-p (org-gtd-pred--property-equals
+                     "ORG_GTD" (org-gtd-type-org-gtd-value 'calendar)))
+        (not-done-p (org-gtd-pred--not-done))
+        (overdue-p (org-gtd-pred--property-ts<
+                    (org-gtd-type-property 'calendar :when) "today"))
+        (not-habit-p (org-gtd-pred--property-not-equals
+                      "ORG_GTD" (org-gtd-type-org-gtd-value 'habit))))
+    (lambda (marker-or-point)
+      (org-with-point-at marker-or-point
+        (and (funcall calendar-p)
+             (funcall not-done-p)
+             (funcall overdue-p)
+             (funcall not-habit-p))))))
 
 (defun org-gtd-reflect-missed-calendar-review--find-items ()
   "Return the org-ids of every overdue Calendar item across `org-agenda-files'.
-Applies `--overdue-calendar-p' at every heading."
-  (let (items)
+Builds the overdue-calendar predicate once (see
+`--make-overdue-calendar-p') and applies it at every heading."
+  (let ((overdue-p (org-gtd-reflect-missed-calendar-review--make-overdue-calendar-p))
+        items)
     (dolist (file (org-agenda-files))
       (when (file-exists-p file)
         (with-current-buffer (find-file-noselect file)
           (org-with-wide-buffer
            (goto-char (point-min))
            (while (re-search-forward "^\\*+ " nil t)
-             (when (org-gtd-reflect-missed-calendar-review--overdue-calendar-p
-                    (point))
+             (when (funcall overdue-p (point))
                (push (org-id-get-create) items)))))))
     (nreverse items)))
 
@@ -118,10 +131,9 @@ Used by the mutating dispositions to refuse to act on an item the user has
 already handled another way (e.g. via `c' clarify)."
   (let* ((id (org-gtd-walk-model-current
               (plist-get org-gtd-walk--active :model)))
-         (marker (and id (org-id-find id 'marker))))
-    (when (and marker
-               (org-gtd-reflect-missed-calendar-review--overdue-calendar-p
-                marker))
+         (marker (and id (org-id-find id 'marker)))
+         (overdue-p (org-gtd-reflect-missed-calendar-review--make-overdue-calendar-p)))
+    (when (and marker (funcall overdue-p marker))
       marker)))
 
 (defun org-gtd-reflect-missed-calendar-review--resolve (id)
@@ -413,8 +425,9 @@ correct here."
   (let* ((id (org-gtd-walk-model-current
               (plist-get org-gtd-walk--active :model)))
          (marker (org-id-find id 'marker)))
-    (when marker
-      (org-gtd-clarify-item marker))))
+    (if marker
+        (org-gtd-clarify-item marker)
+      (message "This item is no longer available."))))
 
 (defun org-gtd-reflect-missed-calendar-review-quit ()
   "Abandon the review: report the tally, clean up, tear down the walk, and save.

--- a/org-gtd-reflect-missed-calendar-review.el
+++ b/org-gtd-reflect-missed-calendar-review.el
@@ -59,11 +59,12 @@
 (defun org-gtd-reflect-missed-calendar-review--find-items ()
   "Return the org-ids of every overdue Calendar item across `org-agenda-files'.
 
-Composes the SAME `org-gtd-skip.el' predicates the read-only
-`org-gtd-reflect-missed-calendar' view uses: ORG_GTD = Calendar, not
-done, ORG_GTD_TIMESTAMP strictly before today, and not an org-gtd habit.
-The predicate factories are captured once in the outer `let' and
-`funcall'ed per heading."
+Composes `org-gtd-skip.el' predicates matching the design's definition of
+overdue calendar: ORG_GTD = Calendar, not done, ORG_GTD_TIMESTAMP strictly
+before today, and not an org-gtd habit.  The not-habit clause is redundant
+given the Calendar/Habit type invariant (an entry cannot be both) but is
+kept for parity with that stated definition.  The predicate factories are
+captured once in the outer `let' and `funcall'ed per heading."
   (let ((calendar-p (org-gtd-pred--property-equals
                      "ORG_GTD" (org-gtd-type-org-gtd-value 'calendar)))
         (not-done-p (org-gtd-pred--not-done))

--- a/org-gtd-reflect-missed-calendar-review.el
+++ b/org-gtd-reflect-missed-calendar-review.el
@@ -75,35 +75,54 @@
 
 ;;;; Detection
 
+(defun org-gtd-reflect-missed-calendar-review--overdue-calendar-p (marker-or-point)
+  "Return non-nil when MARKER-OR-POINT is still an overdue Calendar item.
+
+The single definition of \"overdue calendar\" shared by `--find-items'
+\(scanning) and `--current-overdue-marker' (the mutating-disposition
+guard), so the two can never drift apart.  Composes `org-gtd-skip.el'
+predicates matching the design's definition of overdue calendar: ORG_GTD
+= Calendar, not done, ORG_GTD_TIMESTAMP strictly before today, and not an
+org-gtd habit.  The not-habit clause is redundant given the
+Calendar/Habit type invariant (an entry cannot be both) but is kept for
+parity with that stated definition."
+  (org-with-point-at marker-or-point
+    (and (funcall (org-gtd-pred--property-equals
+                   "ORG_GTD" (org-gtd-type-org-gtd-value 'calendar)))
+         (funcall (org-gtd-pred--not-done))
+         (funcall (org-gtd-pred--property-ts<
+                   (org-gtd-type-property 'calendar :when) "today"))
+         (funcall (org-gtd-pred--property-not-equals
+                   "ORG_GTD" (org-gtd-type-org-gtd-value 'habit))))))
+
 (defun org-gtd-reflect-missed-calendar-review--find-items ()
   "Return the org-ids of every overdue Calendar item across `org-agenda-files'.
-
-Composes `org-gtd-skip.el' predicates matching the design's definition of
-overdue calendar: ORG_GTD = Calendar, not done, ORG_GTD_TIMESTAMP strictly
-before today, and not an org-gtd habit.  The not-habit clause is redundant
-given the Calendar/Habit type invariant (an entry cannot be both) but is
-kept for parity with that stated definition.  The predicate factories are
-captured once in the outer `let' and `funcall'ed per heading."
-  (let ((calendar-p (org-gtd-pred--property-equals
-                     "ORG_GTD" (org-gtd-type-org-gtd-value 'calendar)))
-        (not-done-p (org-gtd-pred--not-done))
-        (overdue-p (org-gtd-pred--property-ts<
-                    (org-gtd-type-property 'calendar :when) "today"))
-        (not-habit-p (org-gtd-pred--property-not-equals
-                      "ORG_GTD" (org-gtd-type-org-gtd-value 'habit)))
-        (items '()))
+Applies `--overdue-calendar-p' at every heading."
+  (let (items)
     (dolist (file (org-agenda-files))
       (when (file-exists-p file)
         (with-current-buffer (find-file-noselect file)
           (org-with-wide-buffer
            (goto-char (point-min))
            (while (re-search-forward "^\\*+ " nil t)
-             (when (and (funcall calendar-p)
-                        (funcall not-done-p)
-                        (funcall overdue-p)
-                        (funcall not-habit-p))
+             (when (org-gtd-reflect-missed-calendar-review--overdue-calendar-p
+                    (point))
                (push (org-id-get-create) items)))))))
     (nreverse items)))
+
+(defun org-gtd-reflect-missed-calendar-review--current-overdue-marker ()
+  "Return the current walk item's marker iff it is STILL an overdue Calendar item.
+Returns nil when the item no longer qualifies (e.g. it was clarified into
+another type, rescheduled, or completed out of band) or cannot be resolved.
+Used by the mutating dispositions to refuse to act on an item the user has
+already handled another way (e.g. via `c' clarify)."
+  (let* ((id (org-gtd-walk-model-current
+              (plist-get org-gtd-walk--active :model)))
+         (marker (and id (org-id-find id 'marker))))
+    (when (and marker
+               (org-gtd-reflect-missed-calendar-review--overdue-calendar-p
+                marker))
+      marker)))
 
 (defun org-gtd-reflect-missed-calendar-review--resolve (id)
   "Return non-nil when ID still resolves to a live heading marker."
@@ -269,23 +288,27 @@ hard landscape is clean."
 ;;;; Commands
 
 (defun org-gtd-reflect-missed-calendar-review-done ()
-  "Mark the current item done and archive it (it happened), then advance."
+  "Mark the current item done and archive it (it happened), then advance.
+Refuses to mutate when the current item is no longer an overdue Calendar
+item (e.g. it was clarified away via `c' into some other type): the walk
+still advances -- the review step still counts toward `:reviewed' since
+the user is moving on, but not toward `:done', since nothing was
+actually marked done."
   (interactive)
   (org-gtd-walk-call-action
    (lambda ()
-     (let* ((id (org-gtd-walk-model-current
-                 (plist-get org-gtd-walk--active :model)))
-            (marker (org-id-find id 'marker)))
-       (when marker
+     (let ((marker (org-gtd-reflect-missed-calendar-review--current-overdue-marker)))
+       (if (null marker)
+           (message "No longer an overdue calendar item -- advancing.")
          (org-with-point-at marker
            ;; Suppress the state-change note prompt: this is a programmatic
            ;; "it already happened" mark, and an unfinished note buffer would
            ;; leave the following archive yanking the subtree out from under it.
            (let ((org-inhibit-logging 'note))
              (org-todo (org-gtd-keywords--done)))
-           (org-gtd-archive-item-at-point)))
+           (org-gtd-archive-item-at-point))
+         (org-gtd-reflect-missed-calendar-review--bump :done))
        (org-gtd-reflect-missed-calendar-review--bump :reviewed)
-       (org-gtd-reflect-missed-calendar-review--bump :done)
        (org-gtd-walk-advance)))))
 
 (defun org-gtd-reflect-missed-calendar-review-migrate ()
@@ -293,35 +316,37 @@ hard landscape is clean."
 Runs the headless organize pipeline with the classic decoration hooks
 bound off -- the item is already clarified, so it must not be re-prompted
 for tags/effort/etc.  The pipeline auto-drops the Calendar-only
-ORG_GTD_TIMESTAMP because next-action declares no properties."
+ORG_GTD_TIMESTAMP because next-action declares no properties.  Refuses
+to mutate when the current item is no longer an overdue Calendar item
+\(see `-done' for the guard's counter semantics)."
   (interactive)
   (org-gtd-walk-call-action
    (lambda ()
-     (let* ((id (org-gtd-walk-model-current
-                 (plist-get org-gtd-walk--active :model)))
-            (marker (org-id-find id 'marker)))
-       (when marker
+     (let ((marker (org-gtd-reflect-missed-calendar-review--current-overdue-marker)))
+       (if (null marker)
+           (message "No longer an overdue calendar item -- advancing.")
          (let ((org-gtd-organize-hooks nil))
-           (org-gtd-process-heading marker 'next-action)))
+           (org-gtd-process-heading marker 'next-action))
+         (org-gtd-reflect-missed-calendar-review--bump :migrated))
        (org-gtd-reflect-missed-calendar-review--bump :reviewed)
-       (org-gtd-reflect-missed-calendar-review--bump :migrated)
        (org-gtd-walk-advance)))))
 
 (defun org-gtd-reflect-missed-calendar-review-trash ()
   "Trash the current item (irrelevant now: cancel + archive), then advance.
 Reuses the `trash' type's cancel-and-archive disposition through the
-headless pipeline, with decoration hooks bound off."
+headless pipeline, with decoration hooks bound off.  Refuses to mutate
+when the current item is no longer an overdue Calendar item (see `-done'
+for the guard's counter semantics)."
   (interactive)
   (org-gtd-walk-call-action
    (lambda ()
-     (let* ((id (org-gtd-walk-model-current
-                 (plist-get org-gtd-walk--active :model)))
-            (marker (org-id-find id 'marker)))
-       (when marker
+     (let ((marker (org-gtd-reflect-missed-calendar-review--current-overdue-marker)))
+       (if (null marker)
+           (message "No longer an overdue calendar item -- advancing.")
          (let ((org-gtd-organize-hooks nil))
-           (org-gtd-process-heading marker 'trash)))
+           (org-gtd-process-heading marker 'trash))
+         (org-gtd-reflect-missed-calendar-review--bump :trashed))
        (org-gtd-reflect-missed-calendar-review--bump :reviewed)
-       (org-gtd-reflect-missed-calendar-review--bump :trashed)
        (org-gtd-walk-advance)))))
 
 (defun org-gtd-reflect-missed-calendar-review--read-future-date ()
@@ -341,20 +366,22 @@ is rejected, not silently accepted."
   "Reschedule the current item to a new (today-or-later) date, then advance.
 Stays a Calendar item; reuses the headless organize pipeline with the
 decoration hooks bound off.  The :when config value is bracketed so it is
-written verbatim as a valid org timestamp."
+written verbatim as a valid org timestamp.  Refuses to mutate when the
+current item is no longer an overdue Calendar item (see `-done' for the
+guard's counter semantics); the guard runs BEFORE prompting for a date so
+a doomed disposition never wastes the user's input."
   (interactive)
   (org-gtd-walk-call-action
    (lambda ()
-     (let* ((id (org-gtd-walk-model-current
-                 (plist-get org-gtd-walk--active :model)))
-            (marker (org-id-find id 'marker))
-            (date (org-gtd-reflect-missed-calendar-review--read-future-date)))
-       (when marker
-         (let ((org-gtd-organize-hooks nil))
+     (let ((marker (org-gtd-reflect-missed-calendar-review--current-overdue-marker)))
+       (if (null marker)
+           (message "No longer an overdue calendar item -- advancing.")
+         (let ((date (org-gtd-reflect-missed-calendar-review--read-future-date))
+               (org-gtd-organize-hooks nil))
            (org-gtd-process-heading marker 'calendar
-                                    (list (cons :when (format "<%s>" date))))))
+                                    (list (cons :when (format "<%s>" date)))))
+         (org-gtd-reflect-missed-calendar-review--bump :rescheduled))
        (org-gtd-reflect-missed-calendar-review--bump :reviewed)
-       (org-gtd-reflect-missed-calendar-review--bump :rescheduled)
        (org-gtd-walk-advance)))))
 
 (defun org-gtd-reflect-missed-calendar-review-skip ()
@@ -367,19 +394,27 @@ written verbatim as a valid org timestamp."
      (org-gtd-walk-advance))))
 
 (defun org-gtd-reflect-missed-calendar-review-clarify ()
-  "Clarify the current item fully (the heavy escape hatch), then advance.
-Advances the walk first so that on the last item the walk finishes and
-releases its scope lock before the interactive clarify flow opens."
+  "Clarify the current item fully (the heavy escape hatch).
+Unlike the other dispositions, this does NOT advance the walk or bump
+`:reviewed': `org-gtd-clarify-item' is an async, interactive hand-off --
+it opens a separate clarify buffer the user works in later, and the
+item's disposition is not resolved when this command returns.  Treating
+that hand-off as a completed review step would be premature, so the
+walk stays parked on the current item (the review surface stays open,
+cursor unchanged) until the user comes back and presses another
+disposition key, typically `s' (skip) once the item has been dealt with
+via clarify.  (Contrast `org-gtd-someday-review-clarify', which advances
+after its own clarify -- `org-gtd-reactivate' -- because that one is
+synchronous.)  Not wrapped in `org-gtd-walk-call-action': that helper
+exists for actions that transition/advance and tears the walk down on
+error; clarify does neither, so a plain `interactive' command is
+correct here."
   (interactive)
-  (org-gtd-walk-call-action
-   (lambda ()
-     (let* ((id (org-gtd-walk-model-current
-                 (plist-get org-gtd-walk--active :model)))
-            (marker (org-id-find id 'marker)))
-       (org-gtd-reflect-missed-calendar-review--bump :reviewed)
-       (org-gtd-walk-advance)
-       (when marker
-         (org-gtd-clarify-item marker))))))
+  (let* ((id (org-gtd-walk-model-current
+              (plist-get org-gtd-walk--active :model)))
+         (marker (org-id-find id 'marker)))
+    (when marker
+      (org-gtd-clarify-item marker))))
 
 (defun org-gtd-reflect-missed-calendar-review-quit ()
   "Abandon the review: report the tally, clean up, tear down the walk, and save.

--- a/org-gtd-reflect-missed-calendar-review.el
+++ b/org-gtd-reflect-missed-calendar-review.el
@@ -205,12 +205,16 @@ counters survive the whole walk (mirrors `org-gtd-someday-review--surface')."
             (or (plist-get c :skipped) 0))))
 
 (defun org-gtd-reflect-missed-calendar-review--on-finish ()
-  "End-of-walk: report the tally and clean up the surface buffer.
-Runs in the surface buffer after the engine has cleared its session."
+  "End-of-walk: report the tally, clean up the surface buffer, and save.
+Runs in the surface buffer after the engine has cleared its session.
+Mutating dispositions (done/migrate/reschedule/trash) modify org-gtd
+buffers directly; `org-gtd-save-buffers' persists them, honoring
+`org-gtd-save-after-organize' (mirrors `org-gtd-inbox-walk--on-finish')."
   (let ((summary (org-gtd-reflect-missed-calendar-review--summary)))
     (org-gtd-wip--cleanup-temp-file
      org-gtd-reflect-missed-calendar-review--surface-key)
-    (message "Missed-calendar review complete. %s" summary)))
+    (message "Missed-calendar review complete. %s" summary)
+    (org-gtd-save-buffers)))
 
 (defun org-gtd-reflect-missed-calendar-review--spec ()
   "Return the missed-calendar-review walk spec template.
@@ -378,13 +382,16 @@ releases its scope lock before the interactive clarify flow opens."
          (org-gtd-clarify-item marker))))))
 
 (defun org-gtd-reflect-missed-calendar-review-quit ()
-  "Abandon the review: report the tally, clean up, tear down the walk."
+  "Abandon the review: report the tally, clean up, tear down the walk, and save.
+Whatever mutating dispositions ran before quitting must still be persisted;
+see `org-gtd-reflect-missed-calendar-review--on-finish'."
   (interactive)
   (let ((summary (org-gtd-reflect-missed-calendar-review--summary)))
     (org-gtd-walk-quit)
     (org-gtd-wip--cleanup-temp-file
      org-gtd-reflect-missed-calendar-review--surface-key)
-    (message "Missed-calendar review complete. %s" summary)))
+    (message "Missed-calendar review complete. %s" summary)
+    (org-gtd-save-buffers)))
 
 ;;;; Footer
 

--- a/org-gtd-reflect-missed-calendar-review.el
+++ b/org-gtd-reflect-missed-calendar-review.el
@@ -353,6 +353,30 @@ written verbatim as a valid org timestamp."
        (org-gtd-reflect-missed-calendar-review--bump :rescheduled)
        (org-gtd-walk-advance)))))
 
+(defun org-gtd-reflect-missed-calendar-review-skip ()
+  "Skip the current item (decide later -- not a change) and advance."
+  (interactive)
+  (org-gtd-walk-call-action
+   (lambda ()
+     (org-gtd-reflect-missed-calendar-review--bump :reviewed)
+     (org-gtd-reflect-missed-calendar-review--bump :skipped)
+     (org-gtd-walk-advance))))
+
+(defun org-gtd-reflect-missed-calendar-review-clarify ()
+  "Clarify the current item fully (the heavy escape hatch), then advance.
+Advances the walk first so that on the last item the walk finishes and
+releases its scope lock before the interactive clarify flow opens."
+  (interactive)
+  (org-gtd-walk-call-action
+   (lambda ()
+     (let* ((id (org-gtd-walk-model-current
+                 (plist-get org-gtd-walk--active :model)))
+            (marker (org-id-find id 'marker)))
+       (org-gtd-reflect-missed-calendar-review--bump :reviewed)
+       (org-gtd-walk-advance)
+       (when marker
+         (org-gtd-clarify-item marker))))))
+
 (defun org-gtd-reflect-missed-calendar-review-quit ()
   "Abandon the review: report the tally, clean up, tear down the walk."
   (interactive)

--- a/org-gtd-reflect-missed-calendar-review.el
+++ b/org-gtd-reflect-missed-calendar-review.el
@@ -133,6 +133,11 @@ displays the buffer."
             (aof (org-with-point-at marker
                    (org-entry-get (point) org-gtd-prop-area-of-focus))))
         (with-current-buffer surface
+          ;; Bind `org-id-track-globally' to nil so `org-paste-subtree' does
+          ;; not re-register the pasted :ID: (via `org-id-paste-tracker') into
+          ;; this disposable surface's temp file, which would corrupt the
+          ;; global `org-id-locations' map.  This binding is load-bearing, not
+          ;; dead code -- see `org-gtd-someday-review--render'.
           (let ((inhibit-read-only t)
                 (org-id-track-globally nil))
             (erase-buffer)

--- a/org-gtd-reflect-missed-calendar-review.el
+++ b/org-gtd-reflect-missed-calendar-review.el
@@ -274,7 +274,11 @@ hard landscape is clean."
             (marker (org-id-find id 'marker)))
        (when marker
          (org-with-point-at marker
-           (org-todo (org-gtd-keywords--done))
+           ;; Suppress the state-change note prompt: this is a programmatic
+           ;; "it already happened" mark, and an unfinished note buffer would
+           ;; leave the following archive yanking the subtree out from under it.
+           (let ((org-inhibit-logging 'note))
+             (org-todo (org-gtd-keywords--done)))
            (org-gtd-archive-item-at-point)))
        (org-gtd-reflect-missed-calendar-review--bump :reviewed)
        (org-gtd-reflect-missed-calendar-review--bump :done)

--- a/org-gtd-reflect-missed-calendar-review.el
+++ b/org-gtd-reflect-missed-calendar-review.el
@@ -213,8 +213,8 @@ Runs in the surface buffer after the engine has cleared its session."
     (message "Missed-calendar review complete. %s" summary)))
 
 (defun org-gtd-reflect-missed-calendar-review--spec ()
-  "Return the missed-calendar-review walk spec template (default :find = all
-overdue calendar items)."
+  "Return the missed-calendar-review walk spec template.
+The default :find covers all overdue calendar items."
   (list :name 'missed-calendar-review
         :find #'org-gtd-reflect-missed-calendar-review--find-items
         :render #'org-gtd-reflect-missed-calendar-review--render

--- a/org-gtd-reflect-missed-calendar-review.el
+++ b/org-gtd-reflect-missed-calendar-review.el
@@ -303,6 +303,23 @@ ORG_GTD_TIMESTAMP because next-action declares no properties."
        (org-gtd-reflect-missed-calendar-review--bump :migrated)
        (org-gtd-walk-advance)))))
 
+(defun org-gtd-reflect-missed-calendar-review-trash ()
+  "Trash the current item (irrelevant now: cancel + archive), then advance.
+Reuses the `trash' type's cancel-and-archive disposition through the
+headless pipeline, with decoration hooks bound off."
+  (interactive)
+  (org-gtd-walk-call-action
+   (lambda ()
+     (let* ((id (org-gtd-walk-model-current
+                 (plist-get org-gtd-walk--active :model)))
+            (marker (org-id-find id 'marker)))
+       (when marker
+         (let ((org-gtd-organize-hooks nil))
+           (org-gtd-process-heading marker 'trash)))
+       (org-gtd-reflect-missed-calendar-review--bump :reviewed)
+       (org-gtd-reflect-missed-calendar-review--bump :trashed)
+       (org-gtd-walk-advance)))))
+
 (defun org-gtd-reflect-missed-calendar-review--read-future-date ()
   "Prompt for a date via `org-read-date', re-prompting until it is today or later.
 Returns the chosen date as a \"YYYY-MM-DD\" string.  A past reschedule

--- a/org-gtd.el
+++ b/org-gtd.el
@@ -82,6 +82,7 @@
 (require 'org-gtd-mode)
 (require 'org-gtd-reflect)
 (require 'org-gtd-someday-review)
+(require 'org-gtd-reflect-missed-calendar-review)
 (require 'org-gtd-review)
 (require 'org-gtd-walk-model)
 (require 'org-gtd-walk)

--- a/test/unit/missed-calendar-review-test.el
+++ b/test/unit/missed-calendar-review-test.el
@@ -175,6 +175,9 @@ lapse, and advertises the disposition keys."
     (assert-equal 0 (length (org-gtd-wip--get-buffers)))
     ;; The item is no longer detected as overdue (it was archived away).
     (assert-equal 0 (length (org-gtd-reflect-missed-calendar-review--find-items)))
+    ;; It was archived with the DONE keyword, not just removed from view.
+    (assert-match (format "\\* %s It happened" (org-gtd-keywords--done))
+                  (ogt--archive-string))
     (ignore id)))
 
 ;;; Disposition: migrate
@@ -201,6 +204,16 @@ ORG_GTD_TIMESTAMP dropped."
          (org-gtd-organize-hooks (list (lambda () (setq fired t)))))
     (with-current-buffer (car (org-gtd-wip--get-buffers))
       (org-gtd-reflect-missed-calendar-review-migrate))
+    (assert-nil fired)))
+
+(deftest mcr/trash-suppresses-organize-hooks ()
+  "Trash binds `org-gtd-organize-hooks' off, so decoration hooks never fire."
+  (mcr-test--make-calendar "No re-prompt on trash" "<2020-01-01>")
+  (org-gtd-reflect-missed-calendar-review)
+  (let* ((fired nil)
+         (org-gtd-organize-hooks (list (lambda () (setq fired t)))))
+    (with-current-buffer (car (org-gtd-wip--get-buffers))
+      (org-gtd-reflect-missed-calendar-review-trash))
     (assert-nil fired)))
 
 ;;; Disposition: reschedule
@@ -231,6 +244,18 @@ ORG_GTD_TIMESTAMP dropped."
         (assert-equal "<2999-01-01>"
                       (org-entry-get (point) "ORG_GTD_TIMESTAMP"))))))
 
+(deftest mcr/reschedule-suppresses-organize-hooks ()
+  "Reschedule binds `org-gtd-organize-hooks' off, so decoration hooks never fire."
+  (mcr-test--make-calendar "No re-prompt on reschedule" "<2020-01-01>")
+  (org-gtd-reflect-missed-calendar-review)
+  (let* ((fired nil)
+         (org-gtd-organize-hooks (list (lambda () (setq fired t)))))
+    (cl-letf (((symbol-function 'org-read-date)
+               (lambda (&rest _) "2999-01-01")))
+      (with-current-buffer (car (org-gtd-wip--get-buffers))
+        (org-gtd-reflect-missed-calendar-review-reschedule)))
+    (assert-nil fired)))
+
 ;;; Disposition: trash
 
 (deftest mcr/trash-cancels-and-archives ()
@@ -240,7 +265,11 @@ ORG_GTD_TIMESTAMP dropped."
   (with-current-buffer (car (org-gtd-wip--get-buffers))
     (org-gtd-reflect-missed-calendar-review-trash))
   (assert-equal 0 (length (org-gtd-wip--get-buffers)))
-  (assert-equal 0 (length (org-gtd-reflect-missed-calendar-review--find-items))))
+  (assert-equal 0 (length (org-gtd-reflect-missed-calendar-review--find-items)))
+  ;; It was archived with the CANCELED keyword, not the DONE keyword --
+  ;; distinguishes trash from done (a copy-paste keyword swap would fail this).
+  (assert-match (format "\\* %s No longer relevant" (org-gtd-keywords--canceled))
+                (ogt--archive-string)))
 
 ;;; Disposition: skip
 
@@ -308,6 +337,35 @@ ORG_GTD_TIMESTAMP dropped."
       (org-gtd-reflect-missed-calendar-review-done))
     ;; Last disposition ran :on-finish, which cleaned up the surface buffer.
     (assert-equal 0 (length (org-gtd-wip--get-buffers)))))
+
+;;; Persistence: on-finish / quit save buffers when opted in
+
+(deftest mcr/on-finish-saves-when-opted-in ()
+  "`--on-finish' saves org-gtd buffers via `org-gtd-save-buffers' when the
+user opted in via `org-gtd-save-after-organize'.  Migrating the only item
+finishes the walk (runs :on-finish) and modifies the default GTD file
+(refile-in-place); afterward that buffer must not be left modified."
+  (let ((org-gtd-save-after-organize t))
+    (mcr-test--make-calendar "Save me" "<2020-01-01>")
+    (org-gtd-reflect-missed-calendar-review)
+    (with-current-buffer (car (org-gtd-wip--get-buffers))
+      (org-gtd-reflect-missed-calendar-review-migrate))
+    (with-current-buffer (org-gtd--default-file)
+      (assert-nil (buffer-modified-p)))))
+
+(deftest mcr/quit-saves-when-opted-in ()
+  "`-quit' also saves org-gtd buffers via `org-gtd-save-buffers' when opted in.
+Migrates one item (mutating the default GTD file) while the walk is still
+active (a second item remains), then quits; the buffer must be saved."
+  (let ((org-gtd-save-after-organize t))
+    (mcr-test--make-calendar "First" "<2020-01-01>")
+    (mcr-test--make-calendar "Second" "<2020-01-02>")
+    (org-gtd-reflect-missed-calendar-review)
+    (with-current-buffer (car (org-gtd-wip--get-buffers))
+      (org-gtd-reflect-missed-calendar-review-migrate)
+      (org-gtd-reflect-missed-calendar-review-quit))
+    (with-current-buffer (org-gtd--default-file)
+      (assert-nil (buffer-modified-p)))))
 
 (provide 'missed-calendar-review-test)
 

--- a/test/unit/missed-calendar-review-test.el
+++ b/test/unit/missed-calendar-review-test.el
@@ -9,6 +9,7 @@
 ;;; Code:
 
 (require 'ogt-eunit-prelude "test/helpers/prelude.el")
+(require 'cl-lib)
 (require 'org-gtd-reflect-missed-calendar-review)
 (require 'org-gtd-walk)
 
@@ -201,6 +202,34 @@ ORG_GTD_TIMESTAMP dropped."
     (with-current-buffer (car (org-gtd-wip--get-buffers))
       (org-gtd-reflect-missed-calendar-review-migrate))
     (assert-nil fired)))
+
+;;; Disposition: reschedule
+
+(deftest mcr/read-future-date-rejects-past ()
+  "The date reader re-prompts until the chosen date is today-or-later."
+  (let ((answers (list "2000-01-01" "2999-01-01")))
+    (cl-letf (((symbol-function 'org-read-date)
+               (lambda (&rest _) (pop answers)))
+              ((symbol-function 'sit-for) (lambda (&rest _) t)))
+      (assert-equal "2999-01-01"
+                    (org-gtd-reflect-missed-calendar-review--read-future-date))
+      ;; both answers consumed => it looped past the in-the-past first answer.
+      (assert-nil answers))))
+
+(deftest mcr/reschedule-sets-new-future-timestamp ()
+  "`r' keeps the item a Calendar item and writes the new (bracketed) timestamp."
+  (let ((id (mcr-test--make-calendar "Needs new date" "<2020-01-01>")))
+    (org-gtd-reflect-missed-calendar-review)
+    (cl-letf (((symbol-function 'org-read-date)
+               (lambda (&rest _) "2999-01-01")))
+      (with-current-buffer (car (org-gtd-wip--get-buffers))
+        (org-gtd-reflect-missed-calendar-review-reschedule)))
+    (let ((marker (org-id-find id 'marker)))
+      (assert-true marker)
+      (org-with-point-at marker
+        (assert-equal "Calendar" (org-entry-get (point) "ORG_GTD"))
+        (assert-equal "<2999-01-01>"
+                      (org-entry-get (point) "ORG_GTD_TIMESTAMP"))))))
 
 (provide 'missed-calendar-review-test)
 

--- a/test/unit/missed-calendar-review-test.el
+++ b/test/unit/missed-calendar-review-test.el
@@ -231,6 +231,17 @@ ORG_GTD_TIMESTAMP dropped."
         (assert-equal "<2999-01-01>"
                       (org-entry-get (point) "ORG_GTD_TIMESTAMP"))))))
 
+;;; Disposition: trash
+
+(deftest mcr/trash-cancels-and-archives ()
+  "`t' cancels + archives the item (irrelevant now) and ends the walk."
+  (mcr-test--make-calendar "No longer relevant" "<2020-01-01>")
+  (org-gtd-reflect-missed-calendar-review)
+  (with-current-buffer (car (org-gtd-wip--get-buffers))
+    (org-gtd-reflect-missed-calendar-review-trash))
+  (assert-equal 0 (length (org-gtd-wip--get-buffers)))
+  (assert-equal 0 (length (org-gtd-reflect-missed-calendar-review--find-items))))
+
 (provide 'missed-calendar-review-test)
 
 ;;; missed-calendar-review-test.el ends here

--- a/test/unit/missed-calendar-review-test.el
+++ b/test/unit/missed-calendar-review-test.el
@@ -162,6 +162,20 @@ lapse, and advertises the disposition keys."
     (org-gtd-reflect-missed-calendar-review-quit))
   (assert-equal 0 (length (org-gtd-wip--get-buffers))))
 
+;;; Disposition: done
+
+(deftest mcr/done-archives-and-advances ()
+  "`d' marks the item done, archives it, and ends the walk on the last item."
+  (let ((id (mcr-test--make-calendar "It happened" "<2020-01-01>")))
+    (org-gtd-reflect-missed-calendar-review)
+    (with-current-buffer (car (org-gtd-wip--get-buffers))
+      (org-gtd-reflect-missed-calendar-review-done))
+    ;; Only item -> walk finished -> surface cleaned up.
+    (assert-equal 0 (length (org-gtd-wip--get-buffers)))
+    ;; The item is no longer detected as overdue (it was archived away).
+    (assert-equal 0 (length (org-gtd-reflect-missed-calendar-review--find-items)))
+    (ignore id)))
+
 (provide 'missed-calendar-review-test)
 
 ;;; missed-calendar-review-test.el ends here

--- a/test/unit/missed-calendar-review-test.el
+++ b/test/unit/missed-calendar-review-test.el
@@ -176,6 +176,32 @@ lapse, and advertises the disposition keys."
     (assert-equal 0 (length (org-gtd-reflect-missed-calendar-review--find-items)))
     (ignore id)))
 
+;;; Disposition: migrate
+
+(deftest mcr/migrate-retypes-to-next-action ()
+  "`m' migrates the item to a next action: ORG_GTD=Actions, NEXT state,
+ORG_GTD_TIMESTAMP dropped."
+  (let ((id (mcr-test--make-calendar "Still need to do this" "<2020-01-01>")))
+    (org-gtd-reflect-missed-calendar-review)
+    (with-current-buffer (car (org-gtd-wip--get-buffers))
+      (org-gtd-reflect-missed-calendar-review-migrate))
+    (let ((marker (org-id-find id 'marker)))
+      (assert-true marker)
+      (org-with-point-at marker
+        (assert-equal "Actions" (org-entry-get (point) "ORG_GTD"))
+        (assert-equal (org-gtd-keywords--next) (org-get-todo-state))
+        (assert-nil (org-entry-get (point) "ORG_GTD_TIMESTAMP"))))))
+
+(deftest mcr/migrate-suppresses-organize-hooks ()
+  "Migrate binds `org-gtd-organize-hooks' off, so decoration hooks never fire."
+  (mcr-test--make-calendar "No re-prompt" "<2020-01-01>")
+  (org-gtd-reflect-missed-calendar-review)
+  (let* ((fired nil)
+         (org-gtd-organize-hooks (list (lambda () (setq fired t)))))
+    (with-current-buffer (car (org-gtd-wip--get-buffers))
+      (org-gtd-reflect-missed-calendar-review-migrate))
+    (assert-nil fired)))
+
 (provide 'missed-calendar-review-test)
 
 ;;; missed-calendar-review-test.el ends here

--- a/test/unit/missed-calendar-review-test.el
+++ b/test/unit/missed-calendar-review-test.el
@@ -126,6 +126,42 @@ lapse, and advertises the disposition keys."
     (org-gtd-wip--cleanup-temp-file
      org-gtd-reflect-missed-calendar-review--surface-key)))
 
+;;; Spec registration + entry + empty state
+
+(deftest mcr/registers-a-walk-consumer ()
+  "Loading the module registers a `missed-calendar-review' walk."
+  (let ((spec (org-gtd-walk-get 'missed-calendar-review)))
+    (assert-true spec)
+    (assert-same 'missed-calendar-review (plist-get spec :name))
+    (assert-true (org-gtd-walk--callable-p (plist-get spec :render)))
+    (assert-true (org-gtd-walk--callable-p (plist-get spec :find)))))
+
+(deftest mcr/entry-opens-console-when-items-exist ()
+  "The entry command opens a read-only review surface for the item."
+  (mcr-test--make-calendar "Review me" "<2020-01-01>")
+  (org-gtd-reflect-missed-calendar-review)
+  (let ((bufs (org-gtd-wip--get-buffers)))
+    (assert-true (> (length bufs) 0))
+    (with-current-buffer (car bufs)
+      (assert-true (eq major-mode 'org-gtd-reflect-missed-calendar-review-mode))
+      (assert-true buffer-read-only)
+      (assert-match "Review me" (buffer-string))
+      (org-gtd-reflect-missed-calendar-review-quit))))
+
+(deftest mcr/entry-empty-state-opens-no-console ()
+  "With no overdue calendar items, the console never opens."
+  (org-gtd-reflect-missed-calendar-review)
+  (assert-equal 0 (length (org-gtd-wip--get-buffers))))
+
+(deftest mcr/quit-cleans-up-surface ()
+  "Quit tears down the walk and cleans up the surface buffer."
+  (mcr-test--make-calendar "Item" "<2020-01-01>")
+  (org-gtd-reflect-missed-calendar-review)
+  (assert-true (> (length (org-gtd-wip--get-buffers)) 0))
+  (with-current-buffer (car (org-gtd-wip--get-buffers))
+    (org-gtd-reflect-missed-calendar-review-quit))
+  (assert-equal 0 (length (org-gtd-wip--get-buffers))))
+
 (provide 'missed-calendar-review-test)
 
 ;;; missed-calendar-review-test.el ends here

--- a/test/unit/missed-calendar-review-test.el
+++ b/test/unit/missed-calendar-review-test.el
@@ -302,21 +302,95 @@ ORG_GTD_TIMESTAMP dropped."
 
 ;;; Disposition: clarify
 
-(deftest mcr/clarify-invokes-clarify-item-without-advancing ()
-  "`c' opens clarify on the current item but leaves the walk parked (no advance)."
-  (let ((clarified nil))
-    (mcr-test--make-calendar "Rethink me" "<2020-01-01>")
-    (org-gtd-reflect-missed-calendar-review)
-    (cl-letf (((symbol-function 'org-gtd-clarify-item)
-               (lambda (&rest _) (setq clarified t))))
-      (with-current-buffer (car (org-gtd-wip--get-buffers))
-        (org-gtd-reflect-missed-calendar-review-clarify)))
-    (assert-true clarified)
-    ;; Walk is STILL parked on the item: the walk session is still active
-    ;; and the cursor has not moved, proving `c' did not advance.
-    (with-current-buffer (car (org-gtd-wip--get-buffers))
+(deftest mcr/clarify-transforms-surface-in-place-without-advancing ()
+  "`c' turns the review surface itself into an editable clarify buffer for
+the current item -- it does not advance the walk (advancing happens later,
+when the user finishes organizing)."
+  (mcr-test--make-calendar "Rethink me" "<2020-01-01>")
+  (org-gtd-reflect-missed-calendar-review)
+  (let ((surface (car (org-gtd-wip--get-buffers))))
+    (with-current-buffer surface
+      (org-gtd-reflect-missed-calendar-review-clarify)
+      (assert-true (derived-mode-p 'org-gtd-clarify-mode))
+      (assert-nil buffer-read-only)
+      (assert-match "Rethink me" (buffer-string))
+      ;; Walk is STILL parked on the item: the walk session is still active
+      ;; and the cursor has not moved, proving `c' did not advance.
       (assert-true org-gtd-walk--active)
-      (assert-equal 0 (plist-get (plist-get org-gtd-walk--active :model) :cursor)))))
+      (assert-equal 0 (plist-get (plist-get org-gtd-walk--active :model) :cursor))
+      ;; Cancel back to the console, then quit cleanly (no leaked temp file).
+      (org-gtd-reflect-missed-calendar-review--cancel-clarify)
+      (org-gtd-reflect-missed-calendar-review-quit))))
+
+(deftest mcr/clarify-then-organize-advances-and-retypes-item ()
+  "Finishing organize on an in-place-clarified item advances the review to
+the next item, through the REAL organize -> walk-advance seam (not a
+direct call to `org-gtd-walk-advance').
+
+Drives `org-gtd-next-action', which is `org-gtd--dispatch' for the
+`next-action' type: because the surface's `org-gtd-clarify--clarify-id'
+is set (by `--clarify-in-place'), dispatch routes through
+`org-gtd-organize--call', whose `walk-active' branch is the exact code
+path `org-gtd-organize--call' uses for the inbox walk's auto-advance.
+`org-gtd-organize-hooks' is bound to nil to suppress the default
+tag-prompt hook, which would otherwise block on interactive input."
+  (mcr-test--make-calendar "First" "<2020-01-01>")
+  (mcr-test--make-calendar "Second" "<2020-01-02>")
+  (org-gtd-reflect-missed-calendar-review)
+  (let ((surface (car (org-gtd-wip--get-buffers)))
+        (org-gtd-organize-hooks nil))
+    (with-current-buffer surface
+      (org-gtd-reflect-missed-calendar-review-clarify)
+      (assert-true (derived-mode-p 'org-gtd-clarify-mode))
+      (org-gtd-next-action))
+    ;; The walk advanced: the surface is back to the console, on item 2.
+    (with-current-buffer surface
+      (assert-true (eq major-mode 'org-gtd-reflect-missed-calendar-review-mode))
+      (assert-true buffer-read-only)
+      (assert-match "Second" (buffer-string))
+      (refute-match "First" (buffer-string)))
+    ;; Item 1 is now a next action, no longer an overdue calendar item.
+    (assert-equal 1 (length (org-gtd-reflect-missed-calendar-review--find-items)))
+    (with-current-buffer surface
+      (org-gtd-reflect-missed-calendar-review-quit))))
+
+(deftest mcr/cancel-clarify-returns-to-console-for-same-item ()
+  "Canceling (`C-c C-k') an in-place clarify redraws the console for the
+SAME item, without advancing or quitting: the walk stays active, the
+cursor is unchanged."
+  (mcr-test--make-calendar "Item" "<2020-01-01>")
+  (org-gtd-reflect-missed-calendar-review)
+  (let ((surface (car (org-gtd-wip--get-buffers))))
+    (with-current-buffer surface
+      (org-gtd-reflect-missed-calendar-review-clarify)
+      ;; The buffer-local override shadows the default `org-gtd-clarify-stop'
+      ;; (which would abandon the whole review) with our per-item cancel.
+      (assert-equal 'org-gtd-reflect-missed-calendar-review--cancel-clarify
+                    (lookup-key (current-local-map) (kbd "C-c C-k")))
+      (call-interactively (lookup-key (current-local-map) (kbd "C-c C-k"))))
+    (with-current-buffer surface
+      (assert-true (eq major-mode 'org-gtd-reflect-missed-calendar-review-mode))
+      (assert-true buffer-read-only)
+      (assert-match "Item" (buffer-string))
+      (assert-true org-gtd-walk--active)
+      (assert-equal 0 (plist-get (plist-get org-gtd-walk--active :model) :cursor))
+      (org-gtd-reflect-missed-calendar-review-quit))))
+
+(deftest mcr/clarify-then-organize-finish-leaves-no-wip-surface ()
+  "After `c' + organize on the only overdue item, the walk finishes and no
+WIP surface buffer is left behind.  This is the tricky case: the walk
+finishes directly from the advance (no next item to render), so
+`--render' never runs to rekey the surface back to the fixed surface
+key -- `--on-finish' itself must clean up under whichever key the
+surface currently carries."
+  (mcr-test--make-calendar "Only item" "<2020-01-01>")
+  (org-gtd-reflect-missed-calendar-review)
+  (let ((surface (car (org-gtd-wip--get-buffers)))
+        (org-gtd-organize-hooks nil))
+    (with-current-buffer surface
+      (org-gtd-reflect-missed-calendar-review-clarify)
+      (org-gtd-next-action))
+    (assert-equal 0 (length (org-gtd-wip--get-buffers)))))
 
 ;;; Landmine guard: mutating dispositions after out-of-band changes
 

--- a/test/unit/missed-calendar-review-test.el
+++ b/test/unit/missed-calendar-review-test.el
@@ -30,6 +30,21 @@ Returns the id."
       (save-buffer)
       id)))
 
+(defun mcr-test--make-calendar-in-file (file title timestamp)
+  "Insert a Calendar item TITLE with ORG_GTD_TIMESTAMP TIMESTAMP into FILE.
+Like `mcr-test--make-calendar' but targets an arbitrary FILE instead of
+`org-gtd--default-file' -- used to build a multi-file topology where the
+item's SOURCE file differs from the organize destination (next-action
+always refiles to `org-gtd--default-file'; see org-gtd-refile.el).
+Returns the id."
+  (with-current-buffer (find-file-noselect file)
+    (goto-char (point-max))
+    (let ((id (org-id-uuid)))
+      (insert (format "* %s\n:PROPERTIES:\n:ID: %s\n:ORG_GTD: Calendar\n:ORG_GTD_TIMESTAMP: %s\n:END:\n"
+                      title id timestamp))
+      (save-buffer)
+      id)))
+
 ;;; Detection
 
 (deftest mcr/find-includes-overdue-calendar ()
@@ -376,6 +391,25 @@ cursor is unchanged."
       (assert-equal 0 (plist-get (plist-get org-gtd-walk--active :model) :cursor))
       (org-gtd-reflect-missed-calendar-review-quit))))
 
+(deftest mcr/duplicate-keys-are-guarded-in-clarify-in-place ()
+  "`C-c d'/`C-c D' are rebound in the in-place clarify's cancel-override map
+to a command that messages instead of silently enqueuing an unrenderable
+duplicate the walk would drop."
+  (mcr-test--make-calendar "No duplicates here" "<2020-01-01>")
+  (org-gtd-reflect-missed-calendar-review)
+  (let ((surface (car (org-gtd-wip--get-buffers))))
+    (with-current-buffer surface
+      (org-gtd-reflect-missed-calendar-review-clarify)
+      (assert-equal 'org-gtd-reflect-missed-calendar-review--duplicate-unavailable
+                    (lookup-key (current-local-map) (kbd "C-c d")))
+      (assert-equal 'org-gtd-reflect-missed-calendar-review--duplicate-unavailable
+                    (lookup-key (current-local-map) (kbd "C-c D")))
+      ;; Invoking it does not error and does not enqueue a duplicate.
+      (call-interactively (lookup-key (current-local-map) (kbd "C-c d")))
+      (assert-nil (bound-and-true-p org-gtd-clarify--duplicate-queue))
+      (org-gtd-reflect-missed-calendar-review--cancel-clarify)
+      (org-gtd-reflect-missed-calendar-review-quit))))
+
 (deftest mcr/clarify-then-organize-finish-leaves-no-wip-surface ()
   "After `c' + organize on the only overdue item, the walk finishes and no
 WIP surface buffer is left behind.  This is the tricky case: the walk
@@ -391,6 +425,71 @@ surface currently carries."
       (org-gtd-reflect-missed-calendar-review-clarify)
       (org-gtd-next-action))
     (assert-equal 0 (length (org-gtd-wip--get-buffers)))))
+
+(deftest mcr/clarify-organize-preserves-id-resolution-across-files ()
+  "Regression: in-place clarify + organize must not corrupt the JUST-organized
+item's global `org-id-locations' entry when the walk advances to render the
+NEXT item.
+
+Multi-file setup: `org-agenda-files' is bound to `org-gtd-directory' (see
+`ogt-eunit--configure-emacs'), and org-mode expands a directory entry to
+every `*.org' file inside it -- including `org-gtd-calendar.org', already
+present (empty) in the mock-fs spec (`ogt-eunit--mock-fs-spec').  Both
+overdue items below are written into THAT file, in file order, so
+`--find-items' (a linear scan per file) deterministically finds \"First\"
+before \"Second\" regardless of which order `org-agenda-files' lists the
+files in -- no dependency on cross-file scan order, only on in-file
+heading order.
+
+\"First\" is the one clarified + organized as a next-action.  Next-action
+always refiles to `org-gtd--default-file' (org-gtd-tasks.org; see
+org-gtd-refile.el) -- a DIFFERENT file from `org-gtd-calendar.org', where
+it started.  This is deliberately NOT a single-item walk: with only one
+overdue item, `org-gtd-walk-advance' finds the model done and calls
+`org-gtd-walk-finish' directly without ever calling `--render' (see
+`org-gtd-walk--settle'), so the buggy fixup would never even run and the
+bug would not reproduce.  \"Second\" stays overdue so the advance has a
+next item to render, forcing `--render' to run with ID = \"Second\"'s id
+while the surface's buffer-locals (`org-gtd-clarify--clarify-id',
+`org-gtd-clarify--source-heading-marker') still hold \"First\"'s values
+from the just-finished clarify.
+
+Pre-fix, `--render''s unconditional `org-id-add-location' call re-points
+\"First\"'s id back at `org-gtd-calendar.org' -- its now-emptied source
+file (the subtree was cut by `org-gtd-organize--call' once the refile to
+org-gtd-tasks.org completed) -- clobbering the correct location
+`org-refile' just wrote.  `org-id-find' on \"First\"'s id then returns
+nil.  Post-fix (gated on `(equal id org-gtd-clarify--clarify-id)', false
+here since ID is \"Second\"'s, not \"First\"'s), the fixup does not run
+for \"First\" and its org-gtd-tasks.org location survives untouched."
+  (let* ((calendar-file (org-gtd--path "org-gtd-calendar"))
+         (first-id (mcr-test--make-calendar-in-file
+                    calendar-file "First" "<2020-01-01>"))
+         (second-id (mcr-test--make-calendar-in-file
+                     calendar-file "Second" "<2020-01-02>")))
+    (org-gtd-reflect-missed-calendar-review)
+    (let ((surface (car (org-gtd-wip--get-buffers)))
+          (org-gtd-organize-hooks nil))
+      (with-current-buffer surface
+        (org-gtd-reflect-missed-calendar-review-clarify)
+        (assert-true (derived-mode-p 'org-gtd-clarify-mode))
+        (assert-match "First" (buffer-string))
+        (org-gtd-next-action))
+      ;; The walk advanced onto "Second": the surface is back to the
+      ;; console, on the remaining item.
+      (with-current-buffer surface
+        (assert-true (eq major-mode 'org-gtd-reflect-missed-calendar-review-mode))
+        (assert-match "Second" (buffer-string))
+        (org-gtd-reflect-missed-calendar-review-quit)))
+    ;; The regression: "First"'s id must still resolve, at its correct
+    ;; post-organize location, not be clobbered back onto the (emptied)
+    ;; calendar file.
+    (let ((marker (org-id-find first-id 'marker)))
+      (assert-true marker)
+      (org-with-point-at marker
+        (assert-equal "Actions" (org-entry-get (point) "ORG_GTD"))
+        (assert-equal (org-gtd-keywords--next) (org-get-todo-state))))
+    (ignore second-id)))
 
 ;;; Landmine guard: mutating dispositions after out-of-band changes
 

--- a/test/unit/missed-calendar-review-test.el
+++ b/test/unit/missed-calendar-review-test.el
@@ -78,6 +78,54 @@ Returns the id."
     (assert-true (org-gtd-reflect-missed-calendar-review--resolve id))
     (assert-nil (org-gtd-reflect-missed-calendar-review--resolve "no-such-id-xyz"))))
 
+;;; Mode + keymap
+
+(deftest mcr/mode-is-derived-from-org-mode ()
+  "Review mode is derived from org-mode."
+  (with-temp-buffer
+    (org-gtd-reflect-missed-calendar-review-mode)
+    (assert-true (derived-mode-p 'org-mode))))
+
+(deftest mcr/mode-has-disposition-keybindings ()
+  "The mode keymap binds every disposition key to its command."
+  (let ((map org-gtd-reflect-missed-calendar-review-mode-map))
+    (assert-equal 'org-gtd-reflect-missed-calendar-review-done
+                  (lookup-key map (kbd "d")))
+    (assert-equal 'org-gtd-reflect-missed-calendar-review-migrate
+                  (lookup-key map (kbd "m")))
+    (assert-equal 'org-gtd-reflect-missed-calendar-review-reschedule
+                  (lookup-key map (kbd "r")))
+    (assert-equal 'org-gtd-reflect-missed-calendar-review-trash
+                  (lookup-key map (kbd "t")))
+    (assert-equal 'org-gtd-reflect-missed-calendar-review-clarify
+                  (lookup-key map (kbd "c")))
+    (assert-equal 'org-gtd-reflect-missed-calendar-review-skip
+                  (lookup-key map (kbd "s")))
+    (assert-equal 'org-gtd-reflect-missed-calendar-review-quit
+                  (lookup-key map (kbd "q")))))
+
+;;; Render
+
+(deftest mcr/render-fills-surface-read-only ()
+  "Render draws the item, activates review mode read-only, humanizes the
+lapse, and advertises the disposition keys."
+  (let* ((id (mcr-test--make-calendar "Overdue thing" "<2020-01-01>"))
+         (surface (org-gtd-wip--get-buffer
+                   org-gtd-reflect-missed-calendar-review--surface-key)))
+    (with-current-buffer surface
+      (setq-local org-gtd-walk--active
+                  (list :model (org-gtd-walk-model-create (list id))))
+      (org-gtd-reflect-missed-calendar-review--render id surface)
+      (assert-true (eq major-mode 'org-gtd-reflect-missed-calendar-review-mode))
+      (assert-true buffer-read-only)
+      (assert-match "Overdue thing" (buffer-string))
+      (assert-match "days ago" (buffer-string))
+      (assert-match "\\[d\\] Done" header-line-format)
+      (assert-match "\\[r\\] Reschedule" header-line-format)
+      (assert-match "(1/1)" header-line-format))
+    (org-gtd-wip--cleanup-temp-file
+     org-gtd-reflect-missed-calendar-review--surface-key)))
+
 (provide 'missed-calendar-review-test)
 
 ;;; missed-calendar-review-test.el ends here

--- a/test/unit/missed-calendar-review-test.el
+++ b/test/unit/missed-calendar-review-test.el
@@ -286,6 +286,29 @@ ORG_GTD_TIMESTAMP dropped."
     ;; Only item -> walk advanced off the end -> surface cleaned up.
     (assert-equal 0 (length (org-gtd-wip--get-buffers)))))
 
+;;; Counters + finish
+
+(deftest mcr/counters-tally-across-dispositions ()
+  "Mixed dispositions across several items tally correctly on the surface."
+  (mcr-test--make-calendar "One"   "<2020-01-01>")
+  (mcr-test--make-calendar "Two"   "<2020-01-02>")
+  (mcr-test--make-calendar "Three" "<2020-01-03>")
+  (org-gtd-reflect-missed-calendar-review)
+  (let ((surface (car (org-gtd-wip--get-buffers))))
+    ;; item 1 -> skip, item 2 -> migrate, item 3 -> done (finishes the walk)
+    (with-current-buffer surface
+      (org-gtd-reflect-missed-calendar-review-skip))
+    (with-current-buffer surface
+      (org-gtd-reflect-missed-calendar-review-migrate))
+    ;; Read counters BEFORE the last disposition finishes+cleans up the surface.
+    (with-current-buffer surface
+      (assert-same 2 (plist-get org-gtd-reflect-missed-calendar-review--counters :reviewed))
+      (assert-same 1 (plist-get org-gtd-reflect-missed-calendar-review--counters :skipped))
+      (assert-same 1 (plist-get org-gtd-reflect-missed-calendar-review--counters :migrated))
+      (org-gtd-reflect-missed-calendar-review-done))
+    ;; Last disposition ran :on-finish, which cleaned up the surface buffer.
+    (assert-equal 0 (length (org-gtd-wip--get-buffers)))))
+
 (provide 'missed-calendar-review-test)
 
 ;;; missed-calendar-review-test.el ends here

--- a/test/unit/missed-calendar-review-test.el
+++ b/test/unit/missed-calendar-review-test.el
@@ -242,6 +242,50 @@ ORG_GTD_TIMESTAMP dropped."
   (assert-equal 0 (length (org-gtd-wip--get-buffers)))
   (assert-equal 0 (length (org-gtd-reflect-missed-calendar-review--find-items))))
 
+;;; Disposition: skip
+
+(deftest mcr/skip-advances-without-changing-item ()
+  "`s' advances without mutating the item; the item is still overdue."
+  (let ((id (mcr-test--make-calendar "Decide later" "<2020-01-01>")))
+    (org-gtd-reflect-missed-calendar-review)
+    (with-current-buffer (car (org-gtd-wip--get-buffers))
+      (org-gtd-reflect-missed-calendar-review-skip))
+    ;; Only item -> walk finished -> surface cleaned up, but item unchanged.
+    (assert-equal 0 (length (org-gtd-wip--get-buffers)))
+    (let ((marker (org-id-find id 'marker)))
+      (org-with-point-at marker
+        (assert-equal "Calendar" (org-entry-get (point) "ORG_GTD"))
+        (assert-equal "<2020-01-01>"
+                      (org-entry-get (point) "ORG_GTD_TIMESTAMP"))))
+    ;; Still detected on a fresh run (skip is "not now", not "never").
+    (assert-equal 1 (length (org-gtd-reflect-missed-calendar-review--find-items)))))
+
+(deftest mcr/skip-counts-a-skip ()
+  "`s' increments the skipped counter (checked mid-walk, two items)."
+  (mcr-test--make-calendar "First" "<2020-01-01>")
+  (mcr-test--make-calendar "Second" "<2020-01-02>")
+  (org-gtd-reflect-missed-calendar-review)
+  (let ((surface (car (org-gtd-wip--get-buffers))))
+    (with-current-buffer surface
+      (org-gtd-reflect-missed-calendar-review-skip)
+      (assert-same 1 (plist-get org-gtd-reflect-missed-calendar-review--counters :skipped))
+      (org-gtd-reflect-missed-calendar-review-quit))))
+
+;;; Disposition: clarify
+
+(deftest mcr/clarify-invokes-clarify-item-and-advances ()
+  "`c' calls `org-gtd-clarify-item' on the item and advances the walk."
+  (let ((clarified nil))
+    (mcr-test--make-calendar "Rethink me" "<2020-01-01>")
+    (org-gtd-reflect-missed-calendar-review)
+    (cl-letf (((symbol-function 'org-gtd-clarify-item)
+               (lambda (&rest _) (setq clarified t))))
+      (with-current-buffer (car (org-gtd-wip--get-buffers))
+        (org-gtd-reflect-missed-calendar-review-clarify)))
+    (assert-true clarified)
+    ;; Only item -> walk advanced off the end -> surface cleaned up.
+    (assert-equal 0 (length (org-gtd-wip--get-buffers)))))
+
 (provide 'missed-calendar-review-test)
 
 ;;; missed-calendar-review-test.el ends here

--- a/test/unit/missed-calendar-review-test.el
+++ b/test/unit/missed-calendar-review-test.el
@@ -1,0 +1,83 @@
+;;; missed-calendar-review-test.el --- Tests for overdue calendar review -*- lexical-binding: t; coding: utf-8 -*-
+
+;; Copyright (C) 2026 Aldric Giacomoni
+
+;;; Commentary:
+;;
+;; Tests for the actionable overdue-calendar review walk (REC-UI-04).
+
+;;; Code:
+
+(require 'ogt-eunit-prelude "test/helpers/prelude.el")
+(require 'org-gtd-reflect-missed-calendar-review)
+(require 'org-gtd-walk)
+
+(e-unit-initialize)
+
+(around-each (proceed context)
+  (ogt-eunit-with-mock-gtd
+    (funcall proceed context)))
+
+(defun mcr-test--make-calendar (title timestamp)
+  "Insert a Calendar item TITLE with ORG_GTD_TIMESTAMP TIMESTAMP into the GTD file.
+Returns the id."
+  (with-current-buffer (org-gtd--default-file)
+    (goto-char (point-max))
+    (let ((id (org-id-uuid)))
+      (insert (format "* %s\n:PROPERTIES:\n:ID: %s\n:ORG_GTD: Calendar\n:ORG_GTD_TIMESTAMP: %s\n:END:\n"
+                      title id timestamp))
+      (save-buffer)
+      id)))
+
+;;; Detection
+
+(deftest mcr/find-includes-overdue-calendar ()
+  "An open Calendar item dated before today is detected."
+  (mcr-test--make-calendar "Dentist" "<2020-01-01>")
+  (assert-equal 1 (length (org-gtd-reflect-missed-calendar-review--find-items))))
+
+(deftest mcr/find-excludes-today-and-future ()
+  "A Calendar item dated today or in the future is not overdue."
+  (mcr-test--make-calendar "Today thing" (format-time-string "<%Y-%m-%d>"))
+  (mcr-test--make-calendar "Future thing" "<2099-01-01>")
+  (assert-equal 0 (length (org-gtd-reflect-missed-calendar-review--find-items))))
+
+(deftest mcr/find-excludes-done ()
+  "A done Calendar item is not detected."
+  (let ((id (mcr-test--make-calendar "Happened" "<2020-01-01>")))
+    (let ((m (org-id-find id 'marker)))
+      (org-with-point-at m
+        (let ((org-inhibit-logging t)) (org-todo (org-gtd-keywords--done)))
+        (save-buffer))))
+  (assert-equal 0 (length (org-gtd-reflect-missed-calendar-review--find-items))))
+
+(deftest mcr/find-excludes-non-calendar ()
+  "A non-Calendar heading with a past timestamp is not detected."
+  (with-current-buffer (org-gtd--default-file)
+    (goto-char (point-max))
+    (insert "* A next action\n:PROPERTIES:\n:ID: mcr-na-1\n:ORG_GTD: Actions\n:ORG_GTD_TIMESTAMP: <2020-01-01>\n:END:\n")
+    (save-buffer))
+  (assert-equal 0 (length (org-gtd-reflect-missed-calendar-review--find-items))))
+
+(deftest mcr/find-excludes-habit ()
+  "A Habit heading with a past timestamp is not detected."
+  (with-current-buffer (org-gtd--default-file)
+    (goto-char (point-max))
+    (insert "* A routine\n:PROPERTIES:\n:ID: mcr-hab-1\n:ORG_GTD: Habit\n:ORG_GTD_TIMESTAMP: <2020-01-01>\n:STYLE: habit\n:END:\n")
+    (save-buffer))
+  (assert-equal 0 (length (org-gtd-reflect-missed-calendar-review--find-items))))
+
+(deftest mcr/find-includes-repeating-calendar ()
+  "A repeating Calendar item with a past base date is included (view parity)."
+  (mcr-test--make-calendar "Weekly sync" "<2020-01-01 +1w>")
+  (assert-equal 1 (length (org-gtd-reflect-missed-calendar-review--find-items))))
+
+(deftest mcr/resolve-rejects-missing-id ()
+  "The :resolve predicate is nil for an unknown id, non-nil for a real one."
+  (let ((id (mcr-test--make-calendar "Real" "<2020-01-01>")))
+    (assert-true (org-gtd-reflect-missed-calendar-review--resolve id))
+    (assert-nil (org-gtd-reflect-missed-calendar-review--resolve "no-such-id-xyz"))))
+
+(provide 'missed-calendar-review-test)
+
+;;; missed-calendar-review-test.el ends here

--- a/test/unit/missed-calendar-review-test.el
+++ b/test/unit/missed-calendar-review-test.el
@@ -302,8 +302,8 @@ ORG_GTD_TIMESTAMP dropped."
 
 ;;; Disposition: clarify
 
-(deftest mcr/clarify-invokes-clarify-item-and-advances ()
-  "`c' calls `org-gtd-clarify-item' on the item and advances the walk."
+(deftest mcr/clarify-invokes-clarify-item-without-advancing ()
+  "`c' opens clarify on the current item but leaves the walk parked (no advance)."
   (let ((clarified nil))
     (mcr-test--make-calendar "Rethink me" "<2020-01-01>")
     (org-gtd-reflect-missed-calendar-review)
@@ -312,7 +312,35 @@ ORG_GTD_TIMESTAMP dropped."
       (with-current-buffer (car (org-gtd-wip--get-buffers))
         (org-gtd-reflect-missed-calendar-review-clarify)))
     (assert-true clarified)
-    ;; Only item -> walk advanced off the end -> surface cleaned up.
+    ;; Walk is STILL parked on the item: the walk session is still active
+    ;; and the cursor has not moved, proving `c' did not advance.
+    (with-current-buffer (car (org-gtd-wip--get-buffers))
+      (assert-true org-gtd-walk--active)
+      (assert-equal 0 (plist-get (plist-get org-gtd-walk--active :model) :cursor)))))
+
+;;; Landmine guard: mutating dispositions after out-of-band changes
+
+(deftest mcr/mutating-disposition-skips-item-clarified-away ()
+  "A mutating key refuses to act on the current item once it is no longer an
+overdue Calendar item (e.g. retyped away), advancing instead of corrupting it."
+  (let ((id (mcr-test--make-calendar "Was calendar" "<2020-01-01>")))
+    (org-gtd-reflect-missed-calendar-review)
+    ;; Simulate the item being handled out of band: retype it away from Calendar.
+    (let ((m (org-id-find id 'marker)))
+      (org-with-point-at m (org-entry-put (point) "ORG_GTD" "Actions")))
+    (with-current-buffer (car (org-gtd-wip--get-buffers))
+      (org-gtd-reflect-missed-calendar-review-done))
+    ;; `done' did NOT touch it: still in the default GTD file (not archived
+    ;; away) with no TODO state added (org-gtd-archive-item-at-point leaves
+    ;; ORG_GTD alone, so that property alone can't prove the guard fired --
+    ;; location + TODO state are the properties that actually distinguish
+    ;; "mutated" from "left alone").  The single-item walk still advanced.
+    (let ((m (org-id-find id 'marker)))
+      (assert-true m)
+      (assert-equal (org-gtd--default-file) (marker-buffer m))
+      (org-with-point-at m
+        (assert-equal "Actions" (org-entry-get (point) "ORG_GTD"))
+        (assert-nil (org-get-todo-state))))
     (assert-equal 0 (length (org-gtd-wip--get-buffers)))))
 
 ;;; Counters + finish


### PR DESCRIPTION
## Summary

Adds `org-gtd-reflect-missed-calendar-review` — the **actionable counterpart** of the read-only `org-gtd-reflect-missed-calendar` view (REC-UI-04). It walks each overdue Calendar item (ORG_GTD=Calendar, not done, ORG_GTD_TIMESTAMP before today, not a habit) one at a time in a read-only console and, with consent, lets the user decide what each one becomes now. The first net-new actionable consumer of the walk engine; structurally a clone of `org-gtd-someday-review`.

Design: `docs/plans/2026-07-19-overdue-calendar-review-design.md` · Plan: `docs/plans/2026-07-19-overdue-calendar-review-plan.md` · Clarify-in-place design: `docs/plans/2026-07-21-clarify-in-place-auto-advance-design.md`

### Dispositions (header-line action bar)

| key | disposition | mechanism |
|-----|-------------|-----------|
| `d` | done (it happened) | mark DONE + archive (note-prompt suppressed) |
| `m` | migrate → next action | `org-gtd-process-heading … 'next-action` (drops dead timestamp) |
| `r` | reschedule | `… 'calendar` with a new **today-or-later** date (past dates re-prompt) |
| `t` | trash (irrelevant now) | `… 'trash` (cancel + archive) |
| `c` | clarify (rethink fully) | clarifies **in place**; review auto-advances on organize (see below) |
| `s` | skip (decide later) | advance, no change |
| `q` | quit | tear down |

Mutating dispositions reuse the headless `org-gtd-process-heading` with `org-gtd-organize-hooks` bound off — the item is already clarified, so it is not re-decorated. They also **guard against acting on an item handled out of band**: if the current item is no longer an overdue Calendar entry (e.g. you clarified it into a project), the mutating keys refuse to corrupt it and advance with a message instead. Live counters (`reviewed / done / migrated / rescheduled / trashed / skipped`) are reported on finish; empty state opens no console. Changes persist on finish/quit via `org-gtd-save-buffers` (honors `org-gtd-save-after-organize`).

### `c` (clarify): in-place, auto-advancing

`c` transforms the review's own surface into an editable clarify buffer for the current item — reusing the inbox-processing pattern, so `org-gtd-walk--active` stays visible to the organize step. When you finish organizing (choose project/delegate/etc.), the review **auto-advances** to the next overdue item, which re-renders as the console. `C-c C-k` cancels back to the console for the same item (the review continues; it does not abandon the whole walk). This is the same clarify→organize→advance loop as inbox processing.

### Implementation

- New module `org-gtd-reflect-missed-calendar-review.el`, `require`d from `org-gtd.el`; entry command + mode autoloaded.
- Detection and the mutating-disposition guard share **one** extracted "overdue calendar" predicate factory (built once per scan).
- Built task-by-task via TDD (subagent-driven), spec- and quality-reviewed throughout. A final whole-feature review added disk-persistence; the clarify-in-place work was reviewed and a **critical `org-id-locations` corruption bug** (multi-file topology, advance path re-pointing the organized item's id at its emptied source) was caught and fixed + regression-tested before merge.

### Test plan

- [x] 34 module tests (detection incl. repeaters/habits, render, each disposition end-state, past-date guard, hook suppression, empty state, quit, counters, persistence, clarify-in-place, auto-advance-on-organize via the real seam, cancel-returns-to-console, no-leak, **multi-file id-resolution regression**, C-c d/D guard)
- [x] Full suite green: **1632 pass**
- [x] Byte-compiles clean with `--warnings-as-errors`; lint clean (modulo the project-wide `with-eval-after-load` pattern shared with `someday-review`)

### Follow-ups (deferred, not in this PR)

- DRY-extract the shared in-place-clarify render (`inbox-walk--render-marker` + this module's `--clarify-in-place`) once this second consumer is proven; generalize `org-gtd-clarify-stop` to be walk-spec-aware instead of the buffer-local `C-c C-k` override.
- Command-center row / Weekly-Review-step embedding.
- Guard `org-todo` in organize-core's shared `cancel-and-archive`/`done-and-archive` branches against note-buffer races (pre-existing; yak filed).
- Refresh load-time `:scope` on registered walk specs when hosted as a review step (shared with `someday-review`; yak filed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)