### PR TITLE
fix: respect active keymaps in clarify header

### DIFF
--- a/org-gtd-clarify.el
+++ b/org-gtd-clarify.el
@@ -215,8 +215,9 @@ clarifying GTD items before organizing them.
   (setq-local org-gtd--loading-p t)
   (setq-local
    header-line-format
-   (substitute-command-keys
-    "\\<org-gtd-clarify-mode-map>Clarify item.  \\[org-gtd-organize] to file, \\[org-gtd-clarify-duplicate] to duplicate, \\[org-gtd-clarify-stop] to cancel."))
+   '(:eval
+     (substitute-command-keys
+      "Clarify item.  \\[org-gtd-organize] to file, \\[org-gtd-clarify-duplicate] to duplicate, \\[org-gtd-clarify-stop] to cancel.")))
   ;; Enable auto-save for crash protection (absorbed from wip-mode)
   (auto-save-mode 1)
   ;; Kill buffer hooks for cleanup

--- a/test/unit/clarify-test.el
+++ b/test/unit/clarify-test.el
@@ -295,6 +295,26 @@
   (assert-equal 'org-gtd-clarify-duplicate-exact
                 (lookup-key org-gtd-clarify-mode-map (kbd "C-c D"))))
 
+(deftest clarify/header-resolves-active-emulation-map-binding ()
+  "Clarify header displays bindings from active emulation maps."
+  (let* ((org-gtd-clarify-mode-map
+          (copy-keymap org-gtd-clarify-mode-map))
+         (modal-map (make-sparse-keymap))
+         (emulation-mode-map-alists
+          `(((org-gtd-test--modal-state . ,modal-map)))))
+    (define-key org-gtd-clarify-mode-map (kbd "C-c c") nil)
+    (define-key modal-map (kbd "C-c x") #'org-gtd-organize)
+    (with-temp-buffer
+      (org-gtd-clarify-mode)
+      ;; Activate the modal map after mode setup to ensure that the header
+      ;; resolves bindings when it is rendered, not only during setup.
+      (setq-local org-gtd-test--modal-state t)
+      (assert-equal #'org-gtd-organize (key-binding (kbd "C-c x")))
+      (assert-equal :eval (car-safe header-line-format))
+      (let ((header (eval (cadr header-line-format) t)))
+        (assert-match "C-c x" header)
+        (refute-match "M-x org-gtd-organize" header)))))
+
 ;;; Duplicate Command Tests
 
 (deftest clarify/duplicate-exact-adds-to-queue ()

--- a/test/unit/horizons-test.el
+++ b/test/unit/horizons-test.el
@@ -206,9 +206,10 @@
         (org-next-visible-heading 1)
         (org-gtd-clarify-item))
       (with-current-buffer (car (org-gtd-wip--get-buffers))
-        (assert-match "C-c c" header-line-format)
-        (assert-match "C-c C-k" header-line-format)
-        (assert-match "cancel" header-line-format)))))
+        (let ((header (eval (cadr header-line-format) t)))
+          (assert-match "C-c c" header)
+          (assert-match "C-c C-k" header)
+          (assert-match "cancel" header))))))
 
 (provide 'horizons-test)
 


### PR DESCRIPTION
## Summary

- resolve Clarify header key hints through the current buffer’s active keymaps
- evaluate the header dynamically so modal/emulation maps activated after mode setup are reflected
- add a regression test for an `emulation-mode-map-alists` binding and adapt the existing header test

This leaves Transient suffix keys unchanged; it only fixes the Clarify header’s command hints.