### PR TITLE
fix: nest new tasks under the project instead of hardcoding outline level 2

### DIFF
--- a/org-gtd-graph-transient.el
+++ b/org-gtd-graph-transient.el
@@ -258,11 +258,7 @@ ORG_GTD_FIRST_TASKS property."
         ;; Create new task
         (org-with-point-at org-gtd-graph-view--project-marker
           (let ((project-id (org-entry-get (point) "ID")))
-            (org-end-of-subtree t t)
-            (unless (bolp) (insert "\n"))
-            (insert "** " title "\n")
-            (forward-line -1)
-            (org-back-to-heading t)
+            (org-gtd-projects-insert-child-task title)
             (setq task-id (org-id-get-create))
             (org-todo "TODO")
             (org-entry-put (point) "ORG_GTD" "Actions")
@@ -1072,11 +1068,7 @@ Reads from transient scope and prefix object's edge-selection slot."
     ;; Create new task if needed
     (unless new-task-id
       (org-with-point-at project-marker
-        (org-end-of-subtree t t)
-        (unless (bolp) (insert "\n"))
-        (insert "** " task-title "\n")
-        (forward-line -1)
-        (org-back-to-heading t)
+        (org-gtd-projects-insert-child-task task-title)
         (setq new-task-id (org-id-get-create))
         (org-todo "TODO")
         (org-entry-put (point) "ORG_GTD" "Actions")
@@ -1199,11 +1191,7 @@ Reads from transient scope and prefix object's edge-selection slot."
     ;; Create new task if needed
     (unless new-task-id
       (org-with-point-at project-marker
-        (org-end-of-subtree t t)
-        (unless (bolp) (insert "\n"))
-        (insert "** " task-title "\n")
-        (forward-line -1)
-        (org-back-to-heading t)
+        (org-gtd-projects-insert-child-task task-title)
         (setq new-task-id (org-id-get-create))
         (org-todo "TODO")
         (org-entry-put (point) "ORG_GTD" "Actions")
@@ -1244,11 +1232,7 @@ Returns the ID of the newly created task."
         new-task-id)
     ;; Create new task
     (org-with-point-at project-marker
-      (org-end-of-subtree t t)
-      (unless (bolp) (insert "\n"))
-      (insert "** " task-title "\n")
-      (forward-line -1)
-      (org-back-to-heading t)
+      (org-gtd-projects-insert-child-task task-title)
       (setq new-task-id (org-id-get-create))
       (org-todo "TODO")
       (org-entry-put (point) "ORG_GTD" "Actions")
@@ -1277,11 +1261,7 @@ Returns the ID of the newly created task."
         new-task-id)
     ;; Create new task
     (org-with-point-at project-marker
-      (org-end-of-subtree t t)
-      (unless (bolp) (insert "\n"))
-      (insert "** " task-title "\n")
-      (forward-line -1)
-      (org-back-to-heading t)
+      (org-gtd-projects-insert-child-task task-title)
       (setq new-task-id (org-id-get-create))
       (org-todo "TODO")
       (org-entry-put (point) "ORG_GTD" "Actions")
@@ -1312,11 +1292,7 @@ Returns the ID of the newly created task."
         new-task-id)
     ;; Create new task
     (org-with-point-at project-marker
-      (org-end-of-subtree t t)
-      (unless (bolp) (insert "\n"))
-      (insert "** " task-title "\n")
-      (forward-line -1)
-      (org-back-to-heading t)
+      (org-gtd-projects-insert-child-task task-title)
       (setq new-task-id (org-id-get-create))
       (org-todo "TODO")
       (org-entry-put (point) "ORG_GTD" "Actions")

--- a/org-gtd-project-operations.el
+++ b/org-gtd-project-operations.el
@@ -74,11 +74,7 @@ Offers completion on existing tasks or allows creating new ones."
           (setq task-id existing-id)
         ;; Create new task using proper GTD configuration
         (org-with-point-at project-marker
-          (org-end-of-subtree t t)
-          (unless (bolp) (insert "\n"))
-          (insert "** " title "\n")
-          (forward-line -1)
-          (org-back-to-heading t)
+          (org-gtd-projects-insert-child-task title)
           (setq task-id (org-id-get-create))
           ;; Use existing type configuration
           (org-gtd-configure-as-type 'next-action)
@@ -124,11 +120,7 @@ Creates or selects task that blocks the task at point."
           (setq task-id existing-id)
         ;; Create new blocker using proper GTD configuration
         (org-with-point-at project-marker
-          (org-end-of-subtree t t)
-          (unless (bolp) (insert "\n"))
-          (insert "** " title "\n")
-          (forward-line -1)
-          (org-back-to-heading t)
+          (org-gtd-projects-insert-child-task title)
           (setq task-id (org-id-get-create))
           ;; Use existing type configuration
           (org-gtd-configure-as-type 'next-action)
@@ -179,11 +171,7 @@ Creates or selects task to add as root (no dependencies)."
           (setq task-id existing-id)
         ;; Create new root task using proper GTD configuration
         (org-with-point-at project-marker
-          (org-end-of-subtree t t)
-          (unless (bolp) (insert "\n"))
-          (insert "** " title "\n")
-          (forward-line -1)
-          (org-back-to-heading t)
+          (org-gtd-projects-insert-child-task title)
           (setq task-id (org-id-get-create))
           ;; Use existing type configuration
           (org-gtd-configure-as-type 'next-action)

--- a/org-gtd-projects.el
+++ b/org-gtd-projects.el
@@ -48,7 +48,6 @@
 ;; variables, ensuring `let' bindings work correctly with lexical-binding: t.
 (defvar org-gtd-graph-view--project-marker)
 (defvar org-gtd-graph-view--graph)
-
 ;; Defined in org-gtd-someday.el - forward declared to avoid circular dependency.
 (defvar org-gtd-someday-lists)
 
@@ -85,11 +84,29 @@
 ;; Functions from org-gtd-tickler.el (loaded lazily - cycle with org-gtd-projects)
 (declare-function org-gtd-tickler "org-gtd-tickler")
 
+;;;; Structural Helpers
+
+(defun org-gtd-projects-insert-child-task (title)
+  "Insert TITLE as a new task heading at the end of the current subtree.
+Point must be on a project heading; it is left on the newly created
+heading.
+
+The new heading is created one level deeper than the project, so tasks
+nest correctly no matter how deeply the project itself is nested.  Real
+org-gtd files keep projects at level 2 under a `* Projects' heading, so
+assuming a fixed depth here would make the new task a sibling of the
+project -- turning it into a new project rather than one of its tasks."
+  (let ((level (or (org-current-level) 1)))
+    (org-end-of-subtree t t)
+    (unless (bolp) (insert "\n"))
+    (insert (make-string (1+ level) ?*) " " title "\n")
+    (forward-line -1)
+    (org-back-to-heading t)))
+
 ;;;; Constants
 
 (defconst org-gtd-add-to-project-func #'org-gtd-project-extend--apply
   "Function called when organizing item at point as a new task in a project.")
-
 (defconst org-gtd-project-func #'org-gtd-project-new--apply
   "Function called when organizing item at point as a project.")
 

--- a/test/unit/project-operations-test.el
+++ b/test/unit/project-operations-test.el
@@ -209,5 +209,133 @@
         (assert-equal 'org (org-gtd-context-mode ctx))
         (assert-equal task-id (org-gtd-context-task-id ctx))))))
 
+;;;; Outline Level Regression Tests
+
+;; The helper above builds a level-1 project, which is the one depth at which a
+;; hardcoded "** " prefix happens to be correct. Real org-gtd files nest
+;; projects at level 2 under a "* Projects" heading (see
+;; test/fixtures/gtd-file.org), so these tests use that shape instead.
+
+(defun ogt-create-nested-project-with-task (project-name task-name)
+  "Create a level-2 PROJECT-NAME under `* Projects', with a level-3 TASK-NAME.
+Return (project-marker . task-id)."
+  (with-current-buffer (org-gtd--default-file)
+    (goto-char (point-max))
+    (insert "* Projects\n")
+    (forward-line -1)
+    (org-back-to-heading t)
+    (org-entry-put (point) "ORG_GTD" "Projects")
+    (org-end-of-subtree t t)
+    (insert (format "** %s\n" project-name))
+    (forward-line -1)
+    (org-back-to-heading t)
+    (let ((project-id (org-id-get-create))
+          (project-marker (point-marker)))
+      (org-entry-put (point) "ORG_GTD" "Projects")
+      (org-end-of-subtree t t)
+      (insert (format "*** NEXT %s\n" task-name))
+      (forward-line -1)
+      (org-back-to-heading t)
+      (let ((task-id (org-id-get-create)))
+        (org-entry-put (point) "ORG_GTD" "Actions")
+        (org-entry-put (point) "ORG_GTD_PROJECT_IDS" project-id)
+        (org-entry-add-to-multivalued-property project-marker "ORG_GTD_FIRST_TASKS" task-id)
+        (basic-save-buffer)
+        (cons project-marker task-id)))))
+
+(defun ogt-heading-level-and-parent (title)
+  "Return (LEVEL . PARENT-TITLE) for the heading containing TITLE."
+  (with-current-buffer (org-gtd--default-file)
+    (goto-char (point-min))
+    (search-forward title)
+    (org-back-to-heading t)
+    (cons (org-current-level)
+          (save-excursion
+            (when (org-up-heading-safe)
+              (org-get-heading t t t t))))))
+
+(deftest project-ops/add-root-nests-task-under-project ()
+  "Add-root creates the task as a child of a level-2 project.
+Regression: the heading level was hardcoded to two stars, so on a
+realistically nested file the new task landed as a sibling of the
+project -- appearing as a brand new project rather than a task."
+  (let* ((result (ogt-create-nested-project-with-task "AlphaProject" "AlphaExisting"))
+         (existing-task-id (cdr result)))
+
+    (org-with-point-at (org-id-find existing-task-id t)
+      (with-simulated-input "AlphaNewRoot RET"
+        (org-gtd-add-root--simple-with-context (org-gtd-context-at-point))))
+
+    (let ((level-and-parent (ogt-heading-level-and-parent "AlphaNewRoot")))
+      (assert-equal 3 (car level-and-parent))
+      (assert-equal "AlphaProject" (cdr level-and-parent)))))
+
+(deftest project-ops/add-successor-nests-task-under-project ()
+  "Add-successor creates the task as a child of a level-2 project."
+  (let* ((result (ogt-create-nested-project-with-task "BetaProject" "BetaExisting"))
+         (predecessor-id (cdr result)))
+
+    (org-with-point-at (org-id-find predecessor-id t)
+      (with-simulated-input "BetaNewSuccessor RET"
+        (org-gtd-add-successor--simple-with-context (org-gtd-context-at-point))))
+
+    (let ((level-and-parent (ogt-heading-level-and-parent "BetaNewSuccessor")))
+      (assert-equal 3 (car level-and-parent))
+      (assert-equal "BetaProject" (cdr level-and-parent)))))
+
+(deftest project-ops/add-blocker-nests-task-under-project ()
+  "Add-blocker creates the task as a child of a level-2 project."
+  (let* ((result (ogt-create-nested-project-with-task "GammaProject" "GammaExisting"))
+         (blocked-id (cdr result)))
+
+    (org-with-point-at (org-id-find blocked-id t)
+      (with-simulated-input "GammaNewBlocker RET"
+        (org-gtd-add-blocker--simple-with-context (org-gtd-context-at-point))))
+
+    (let ((level-and-parent (ogt-heading-level-and-parent "GammaNewBlocker")))
+      (assert-equal 3 (car level-and-parent))
+      (assert-equal "GammaProject" (cdr level-and-parent)))))
+
+;; The graph transient commands build tasks through their own insertion code,
+;; so they carried the same hardcoded level.  The `--internal' functions take
+;; the project marker directly, which makes them testable without the UI.
+
+(deftest project-ops/graph-add-root-nests-task-under-project ()
+  "The graph add-root path creates the task as a child of a level-2 project."
+  (let* ((result (ogt-create-nested-project-with-task "DeltaProject" "DeltaExisting"))
+         (project-marker (car result)))
+
+    (org-gtd-graph--add-root-internal "DeltaNewRoot" project-marker)
+
+    (let ((level-and-parent (ogt-heading-level-and-parent "DeltaNewRoot")))
+      (assert-equal 3 (car level-and-parent))
+      (assert-equal "DeltaProject" (cdr level-and-parent)))))
+
+(deftest project-ops/graph-add-successor-nests-task-under-project ()
+  "The graph add-successor path creates the task as a child of a level-2 project."
+  (let* ((result (ogt-create-nested-project-with-task "EpsilonProject" "EpsilonExisting"))
+         (project-marker (car result))
+         (predecessor-id (cdr result)))
+
+    (org-gtd-graph--add-successor-internal
+     "EpsilonNewSuccessor" (list predecessor-id) project-marker)
+
+    (let ((level-and-parent (ogt-heading-level-and-parent "EpsilonNewSuccessor")))
+      (assert-equal 3 (car level-and-parent))
+      (assert-equal "EpsilonProject" (cdr level-and-parent)))))
+
+(deftest project-ops/graph-add-blocker-nests-task-under-project ()
+  "The graph add-blocker path creates the task as a child of a level-2 project."
+  (let* ((result (ogt-create-nested-project-with-task "ZetaProject" "ZetaExisting"))
+         (project-marker (car result))
+         (blocked-id (cdr result)))
+
+    (org-gtd-graph--add-blocker-internal
+     "ZetaNewBlocker" (list blocked-id) project-marker)
+
+    (let ((level-and-parent (ogt-heading-level-and-parent "ZetaNewBlocker")))
+      (assert-equal 3 (car level-and-parent))
+      (assert-equal "ZetaProject" (cdr level-and-parent)))))
+
 (provide 'project-operations-test)
 ;;; project-operations-test.el ends here


### PR DESCRIPTION
## Problem

`org-gtd-project-add-root-task`, `org-gtd-project-add-successor-task`, and `org-gtd-project-add-blocker-task` (plus the six equivalent paths in `org-gtd-graph-transient.el`) insert the new heading with a hardcoded `"** "`:

```elisp
(org-with-point-at project-marker
  (org-end-of-subtree t t)
  (unless (bolp) (insert "\n"))
  (insert "** " title "\n")   ; <- assumes the project is at level 1
  ...)
```

That is only correct when the project itself is at level 1. Real org-gtd files — including `test/fixtures/gtd-file.org` — nest projects at level 2 under a `* Projects` heading:

```org
* Projects
** My Project
*** NEXT A task
```

So on an actual GTD file the new task is created as a **sibling of the project**, not a child. It shows up as a brand new project, is never picked up as one of the project's tasks, and does not appear in the engage view under its parent. Adding the ID to `ORG_GTD_FIRST_TASKS` still succeeds, which makes the failure quiet — the project's property references a heading that is no longer inside it.

## Fix

Extract the insertion into a shared helper in `org-gtd-projects.el` that reads the project's level and inserts one level deeper:

```elisp
(defun org-gtd-projects-insert-child-task (title)
  (let ((level (or (org-current-level) 1)))
    (org-end-of-subtree t t)
    (unless (bolp) (insert "\n"))
    (insert (make-string (1+ level) ?*) " " title "\n")
    (forward-line -1)
    (org-back-to-heading t)))
```

All nine call sites already run inside `(org-with-point-at project-marker ...)`, so point is on the project heading and the level is available. `org-gtd-projects.el` is required by both `org-gtd-project-operations.el` and `org-gtd-graph-transient.el` and does not require either, so there is no cycle. Behaviour at level 1 is unchanged.

## Why the existing suite did not catch it

The nine test files covering these commands each roll their own setup, and every one builds a **level-1** project (e.g. `ogt-create-project-with-task` inserts `"* %s\n"`) — the one depth at which `"** "` is accidentally correct. The assertions then only `search-forward` for the title and check `ORG_GTD_FIRST_TASKS` membership; none check outline level or parentage, both of which stay green when the task escapes the subtree.

## Tests

Six regression tests in `test/unit/project-operations-test.el` build a realistically nested project (`* Projects` -> `** Project` -> `*** Task`) and assert the new task's level **and** its parent heading, covering both the prompt-based operations and the graph transient `--internal` functions.

- Without the fix: 6 failed (`Expected: 3, Actual: 2`), 1276 passed
- With the fix: **1282 passed, 0 failed, 0 errors**

No pre-existing test changed behaviour in either direction.

## Note for macOS contributors

Running the suite on macOS produced 510 errors before any code changes, all from mock-fs's `/mock:` handler. Two causes, both environmental:

1. Emacs 31 writes native-comp subr trampolines under the mocked `/tmp`.
2. `org-id` shells out to `uuidgen` with `default-directory` set to `/mock:/gtd/`, which does not exist on the real filesystem. Linux CI presumably has no `uuidgen`, so org-id silently uses its elisp fallback.

This gives a clean run:

```sh
eldev -p -S '(progn (setq native-comp-enable-subr-trampolines nil) (setq org-id-method (quote org)))' -dtT gtd-etest
```

Happy to fold that into `Eldev` or CONTRIBUTING in a separate PR if useful.

## Possibly related, not addressed here

Tasks created by these commands do not get `TRIGGER: self org-gtd-update-project-after-task-done!` or `ORG_GTD_PROJECT`, unlike tasks created through clarify. Without the TRIGGER, completing one will not recalculate project state or unblock successors. That looks like a separate bug — let me know if you would like it in scope.
